### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/asreview/data.py
+++ b/asreview/data.py
@@ -32,7 +32,7 @@ from asreview.utils import is_url
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore")
-    from fuzzywuzzy import fuzz
+    from rapidfuzz import fuzz
 
 
 def get_fuzzy_scores(keywords, str_list):
@@ -280,7 +280,7 @@ class ASReviewData():
         """Find a record using keywords.
 
         It looks for keywords in the title/authors/keywords
-        (for as much is available). Using the fuzzywuzzy package it creates
+        (for as much is available). Using the rapidfuzz package it creates
         a ranking based on token set matching.
 
         Arguments

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,7 @@ autodoc_mock_imports = [
     "sklearn.exceptions",
     "scipy",
     "h5py",
-    "fuzzywuzzy",
+    "rapidfuzz",
     "dill",
     "PyInquirer"
 ]

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,9 @@ DEPS = {
     "tensorflow": ['tensorflow'],
     "dev": ['check-manifest'],
     'test': ['coverage', 'pytest'],
-    'performance': ['python-Levenshtein'],
 }
 DEPS['all'] = DEPS['sbert'] + DEPS['doc2vec'] + DEPS['dev']
-DEPS['all'] += DEPS['performance'] + DEPS['tensorflow']
+DEPS['all'] += DEPS['tensorflow']
 
 setup(
     name='asreview',
@@ -76,7 +75,7 @@ setup(
         'RISparser',
         'dill',
         'questionary',
-        'fuzzywuzzy',
+        'rapidfuzz',
         'h5py',
         'xlrd>=1.0.0',
         'setuptools',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.