### PR TITLE
Fix papers in red for testing algorithms

### DIFF
--- a/asreview/webapp/src/Components/ArticlePanel.js
+++ b/asreview/webapp/src/Components/ArticlePanel.js
@@ -47,6 +47,10 @@ const useStyles = makeStyles({
 const ArticlePanel = (props) => {
   const classes = useStyles();
 
+  const isDebugInclusion =  ()  => {
+    return (props.record._debug_label === 1)
+  }
+
   return (
       <Container
         maxWidth="md"
@@ -57,7 +61,7 @@ const ArticlePanel = (props) => {
         <Typography
           className={classes.title}
           variant="h5"
-          color={props.record._debug_label === 1 ? "error" : "textSecondary"}
+          color={isDebugInclusion() ? "error" : "textSecondary"}
           component="div"
           paragraph>
 
@@ -85,7 +89,7 @@ const ArticlePanel = (props) => {
         {!(props.record.publish_time === undefined || props.record.publish_time === null)  &&
           <Typography
               className={classes.publish_time + " textSize" + props.textSize}
-              color={props.record._debug_label === 1 ? "error" : "textSecondary"}
+              color={isDebugInclusion() ? "error" : "textSecondary"}
               component="p"
               fontStyle="italic"
               paragraph>
@@ -97,7 +101,7 @@ const ArticlePanel = (props) => {
         {!(props.record.doi === undefined || props.record.doi === null)  &&
           <Typography
               className={classes.doi + " textSize" + props.textSize}
-              color={props.record._debug_label === 1 ? "error" : "textSecondary"}
+              color={isDebugInclusion() ? "error" : "textSecondary"}
               component="p"
               fontStyle="italic"
               paragraph>
@@ -117,7 +121,7 @@ const ArticlePanel = (props) => {
         <Typography
             className={classes.abstract + " textSize" + props.textSize}
             variant="body2"
-            color={props.record._debug_label === 1 ? "error" : "textSecondary"}
+            color={isDebugInclusion() ? "error" : "textSecondary"}
             component="div"
             paragraph>
 

--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -175,7 +175,7 @@ def get_paper_data(project_id,
 
     # return the debug label
     debug_label = record.extra_fields.get("debug_label", None)
-    paper_data['debug_label'] = \
+    paper_data['_debug_label'] = \
         int(debug_label) if pd.notnull(debug_label) else None
 
     return paper_data


### PR DESCRIPTION
This PR resolves the issue with inclusions not being displayed in red for the test datasets. 

Closes #270 