### PR TITLE
Fix bug with simulating the same file twice

### DIFF
--- a/asreview/review/simulate.py
+++ b/asreview/review/simulate.py
@@ -32,6 +32,9 @@ class ReviewSimulate(BaseReview):
                  prior_idx=None,
                  init_seed=None,
                  **kwargs):
+
+        self.n_prior_included = n_prior_included
+        self.n_prior_excluded = n_prior_excluded
         if prior_idx is not None and len(prior_idx) != 0:
             start_idx = prior_idx
         else:


### PR DESCRIPTION
Resolves #288 

Only fixes it for new simulation files. Old files will still give the same error.