### PR TITLE
Update config.py

### DIFF
--- a/asreview/config.py
+++ b/asreview/config.py
@@ -37,7 +37,7 @@ LOGGER_EXTENSIONS = STATE_EXTENSIONS
 COLUMN_DEFINITIONS = [
     ["final_included", "label", "label_included", "included_label",
      "included_final", "included", "included_flag", "include"],
-    ["abstract_included", "included_abstract", "included_after_abstract"],
+    ["abstract_included", "included_abstract", "included_after_abstract", "label_abstract_screening"],
     ['title', 'primary_title'],
     ['authors', 'author names', 'first_authors'],
     ['abstract', 'abstract note'],

--- a/asreview/config.py
+++ b/asreview/config.py
@@ -35,9 +35,9 @@ STATE_EXTENSIONS = ['.h5', '.hdf5', '.he5', '.json']
 LOGGER_EXTENSIONS = STATE_EXTENSIONS
 
 COLUMN_DEFINITIONS = [
-    ["final_included", "label", "label_included", "included_label",
+    ["label_included", "final_included", "label", "included_label",
      "included_final", "included", "included_flag", "include"],
-    ["abstract_included", "included_abstract", "included_after_abstract", "label_abstract_screening"],
+    ["label_abstract_screening", "abstract_included", "included_abstract", "included_after_abstract"],
     ['title', 'primary_title'],
     ['authors', 'author names', 'first_authors'],
     ['abstract', 'abstract note'],


### PR DESCRIPTION
Add `label_abstract_screening`as a possible label for abstract inclusions.

This name makes more sense in combination with `label_included`, which is used mainly in the systematic-review-datasets-repository @terrymyc 