### PR TITLE
Revert asreview/asreview#323

### DIFF
--- a/asreview/config.py
+++ b/asreview/config.py
@@ -37,7 +37,7 @@ LOGGER_EXTENSIONS = STATE_EXTENSIONS
 COLUMN_DEFINITIONS = [
     ["final_included", "label", "label_included", "included_label",
      "included_final", "included", "included_flag", "include"],
-    ["abstract_included", "included_abstract", "included_after_abstract"],
+    ["abstract_included", "included_abstract", "included_after_abstract", "label_abstract_screening"],
     ['title', 'primary_title'],
     ['authors', 'author names', 'first_authors'],
     ['abstract', 'abstract note'],

--- a/asreview/config.py
+++ b/asreview/config.py
@@ -35,9 +35,9 @@ STATE_EXTENSIONS = ['.h5', '.hdf5', '.he5', '.json']
 LOGGER_EXTENSIONS = STATE_EXTENSIONS
 
 COLUMN_DEFINITIONS = [
-    ["label_included", "final_included", "label", "included_label",
+    ["final_included", "label", "label_included", "included_label",
      "included_final", "included", "included_flag", "include"],
-    ["label_abstract_screening", "abstract_included", "included_abstract", "included_after_abstract"],
+    ["abstract_included", "included_abstract", "included_after_abstract"],
     ['title', 'primary_title'],
     ['authors', 'author names', 'first_authors'],
     ['abstract', 'abstract note'],


### PR DESCRIPTION
Partially reverts asreview/asreview#323. Plenty of things turn out to depend on the order of the names in the list. I think this affects the tests only and should be changed in the future (more generic). 
