### PR TITLE
Add keyboard shortcut while reviewing

### DIFF
--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -27,7 +27,7 @@ import {
   useTextSize,
   useUndoEnabled,
   useKeyPressEnabled,
-} from './SettingsHooks'
+} from './hooks/SettingsHooks'
 
 import 'typeface-roboto'
 

--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -26,6 +26,7 @@ import {
   useDarkMode,
   useTextSize,
   useUndoEnabled,
+  useKeyPressEnabled,
 } from './SettingsHooks'
 
 import 'typeface-roboto'
@@ -62,6 +63,7 @@ const App = (props) => {
   const [authors, setAuthors] = React.useState(false);
   const [textSize, handleTextSizeChange] = useTextSize();
   const [undoEnabled, toggleUndoEnabled] = useUndoEnabled();
+  const [keyPressEnabled, toggleKeyPressEnabled] = useKeyPressEnabled();
 
   const toggleAuthors = () => {
     setAuthors(a => (!a));
@@ -133,6 +135,7 @@ const App = (props) => {
         showAuthors={authors}
         textSize={textSize}
         undoEnabled={undoEnabled}
+        keyPressEnabled={keyPressEnabled}
       />
       }
 
@@ -155,6 +158,8 @@ const App = (props) => {
         showAuthors={authors}
         toggleUndoEnabled={toggleUndoEnabled}
         undoEnabled={undoEnabled}
+        toggleKeyPressEnabled={toggleKeyPressEnabled}
+        keyPressEnabled={keyPressEnabled}
       />
       <ExitDialog
         toggleExit={toggleExit}

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -10,6 +10,7 @@ import ReviewDrawer from './ReviewDrawer'
 import ArticlePanel from './ArticlePanel'
 import DecisionBar from './DecisionBar'
 import DecisionUndoBar from './DecisionUndoBar'
+import { useKeyPress } from '../SettingsHooks'
 
 import { connect } from "react-redux";
 
@@ -74,6 +75,10 @@ const ReviewZone = (props) => {
   });
 
   const [history, setHistory] = useState([]);
+
+  const relevantPress = useKeyPress("r");
+  const irrelevantPress = useKeyPress("i");
+  const undoPress = useKeyPress("u");
 
   const storeRecordState = (label) => {
     setPreviousRecordState({
@@ -258,6 +263,26 @@ const ReviewZone = (props) => {
       getDocument();
     }
   },[props.project_id, recordState, props]);
+
+  useEffect(() => {
+
+    /**
+     * Use keyboard shortcut
+     */
+    if (props.keyPressEnabled) {
+
+      if (relevantPress && recordState.isloaded) {
+        makeDecision(1);
+      }
+      if (irrelevantPress && recordState.isloaded) {
+        makeDecision(0);
+      }
+      if (undoPress && undoState.open && props.undoEnabled) {
+        undoDecision();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [relevantPress, irrelevantPress, undoPress]);
 
   return (
     <Box

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -10,7 +10,7 @@ import ReviewDrawer from './ReviewDrawer'
 import ArticlePanel from './ArticlePanel'
 import DecisionBar from './DecisionBar'
 import DecisionUndoBar from './DecisionUndoBar'
-import { useKeyPress } from '../SettingsHooks'
+import { useKeyPress } from '../hooks/useKeyPress'
 
 import { connect } from "react-redux";
 

--- a/asreview/webapp/src/SettingsDialog.js
+++ b/asreview/webapp/src/SettingsDialog.js
@@ -92,7 +92,7 @@ export default function SettingsDialog(props) {
               </ListItemSecondaryAction>
             </ListItem>
             <ListItem>
-              <ListItemText id="switch-list-label-undo" primary="Undo Enabled" />
+              <ListItemText id="switch-list-label-undo" primary="Undo" />
               <ListItemSecondaryAction>
                 <Switch
                   edge="end"
@@ -103,7 +103,7 @@ export default function SettingsDialog(props) {
               </ListItemSecondaryAction>
             </ListItem>
             <ListItem>
-              <ListItemText id="switch-list-label-key" primary="Keyboard shortcut" />
+              <ListItemText id="switch-list-label-key" primary="Keyboard shortcuts" />
               <ListItemSecondaryAction>
                 <Switch
                   edge="end"

--- a/asreview/webapp/src/SettingsDialog.js
+++ b/asreview/webapp/src/SettingsDialog.js
@@ -102,6 +102,17 @@ export default function SettingsDialog(props) {
                 />
               </ListItemSecondaryAction>
             </ListItem>
+            <ListItem>
+              <ListItemText id="switch-list-label-key" primary="Keyboard shortcut" />
+              <ListItemSecondaryAction>
+                <Switch
+                  edge="end"
+                  onChange={props.toggleKeyPressEnabled}
+                  checked={props.keyPressEnabled}
+                  inputProps={{ 'aria-labelledby': 'switch-list-label-key' }}
+                />
+              </ListItemSecondaryAction>
+            </ListItem>
           </List>
 
         </DialogContent>

--- a/asreview/webapp/src/SettingsHooks.js
+++ b/asreview/webapp/src/SettingsHooks.js
@@ -84,13 +84,13 @@ const useKeyPress = (targetKey) => {
   useEffect(() => {
 
     const downHandler = ({ key }) => {
-      if (key === targetKey) {
+      if (key.toLowerCase() === targetKey) {
         setKeyPressed(true);
       }
     };
 
     const upHandler = ({ key }) => {
-      if (key === targetKey) {
+      if (key.toLowerCase() === targetKey) {
         setKeyPressed(false);
       }
     };

--- a/asreview/webapp/src/SettingsHooks.js
+++ b/asreview/webapp/src/SettingsHooks.js
@@ -77,4 +77,58 @@ const useUndoEnabled = () => {
 };
 
 
-export { useDarkMode, useTextSize, useUndoEnabled };
+const useKeyPress = (targetKey) => {
+
+  const [keyPressed, setKeyPressed] = useState(false);
+  
+  useEffect(() => {
+
+    const downHandler = ({ key }) => {
+      if (key === targetKey) {
+        setKeyPressed(true);
+      }
+    };
+
+    const upHandler = ({ key }) => {
+      if (key === targetKey) {
+        setKeyPressed(false);
+      }
+    };
+
+    // Add event listeners
+    window.addEventListener('keydown', downHandler);
+    window.addEventListener('keyup', upHandler);
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    };
+
+  }, [targetKey]);
+
+  return keyPressed;
+};
+
+
+const useKeyPressEnabled = () => {
+
+  const [keyPressEnabled, setKeyPressEnabled] = useState(false);
+
+  const toggleKeyPressEnabled = () => {
+    window.localStorage.setItem("keyPressEnabled", !keyPressEnabled);
+    setKeyPressEnabled(a => (!a));
+  };
+
+  useEffect(() => {
+    const localKeyPressEnabled = window.localStorage.getItem("keyPressEnabled");
+    const localKeyPressEnabledIsTrue = localKeyPressEnabled === "true";
+    if (keyPressEnabled !== localKeyPressEnabledIsTrue && localKeyPressEnabled !== null) {
+      setKeyPressEnabled(localKeyPressEnabledIsTrue);
+    };
+  }, [keyPressEnabled]);
+
+  return [keyPressEnabled, toggleKeyPressEnabled]
+}
+
+
+export { useDarkMode, useTextSize, useUndoEnabled, useKeyPress, useKeyPressEnabled };

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -77,39 +77,6 @@ const useUndoEnabled = () => {
 };
 
 
-const useKeyPress = (targetKey) => {
-
-  const [keyPressed, setKeyPressed] = useState(false);
-  
-  useEffect(() => {
-
-    const downHandler = ({ key }) => {
-      if (key.toLowerCase() === targetKey) {
-        setKeyPressed(true);
-      }
-    };
-
-    const upHandler = ({ key }) => {
-      if (key.toLowerCase() === targetKey) {
-        setKeyPressed(false);
-      }
-    };
-
-    // Add event listeners
-    window.addEventListener('keydown', downHandler);
-    window.addEventListener('keyup', upHandler);
-    // Remove event listeners on cleanup
-    return () => {
-      window.removeEventListener('keydown', downHandler);
-      window.removeEventListener('keyup', upHandler);
-    };
-
-  }, [targetKey]);
-
-  return keyPressed;
-};
-
-
 const useKeyPressEnabled = () => {
 
   const [keyPressEnabled, setKeyPressEnabled] = useState(false);
@@ -131,4 +98,4 @@ const useKeyPressEnabled = () => {
 }
 
 
-export { useDarkMode, useTextSize, useUndoEnabled, useKeyPress, useKeyPressEnabled };
+export { useDarkMode, useTextSize, useUndoEnabled, useKeyPressEnabled };

--- a/asreview/webapp/src/hooks/useKeyPress.js
+++ b/asreview/webapp/src/hooks/useKeyPress.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+
+const useKeyPress = (targetKey) => {
+
+  const [keyPressed, setKeyPressed] = useState(false);
+  
+  useEffect(() => {
+
+    const downHandler = ({ key }) => {
+      if (key.toLowerCase() === targetKey) {
+        setKeyPressed(true);
+      }
+    };
+
+    const upHandler = ({ key }) => {
+      if (key.toLowerCase() === targetKey) {
+        setKeyPressed(false);
+      }
+    };
+
+    // Add event listeners
+    window.addEventListener('keydown', downHandler);
+    window.addEventListener('keyup', upHandler);
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    };
+
+  }, [targetKey]);
+
+  return keyPressed;
+};
+
+export { useKeyPress };

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -1,0 +1,12 @@
+Features
+========
+
+Keyboard shortcuts
+------------------
+
+To improve the efficiency of the screening process, users can strike keyboard shortcuts to label the document as:
+
+- ``R`` or ``r``: Relevant
+- ``I`` or ``i``: Irrelevant
+
+Users can undo a decision by striking ``U`` or ``u`` if the undo feature has been toggled on.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -4,6 +4,8 @@ Features
 Keyboard shortcuts
 ------------------
 
+Enable keyboard shortcuts in the settings menu before you can make use of them. 
+
 To improve the efficiency of the screening process, users can strike keyboard shortcuts to label the document as:
 
 - ``R`` or ``r``: Relevant

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,8 @@ The source code is freely available at
 
    datasets
 
+   features
+
    extensions
 
    user_testing_algorithms


### PR DESCRIPTION
Three keyboard shortcuts are implemented. While reviewing, users can strike "r"/"R" to label "relevant", "i"/"I" to label "irrelevant", and "u"/"U" to undo labeling. This feature can be toggled on/off in the settings dialog.

![KeyboardShortcut](https://user-images.githubusercontent.com/17449217/90672359-4c191b00-e256-11ea-93b2-717d15e2174e.png)
