### PR TITLE
Add txt to import options for RIS

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -26,7 +26,7 @@ To carry out an automated systematic review on your own dataset, your data file 
 to adhere to a certain format. ASReview accepts the following formats:
 
  - `Research Information Systems (RIS) <https://en.wikipedia.org/wiki/RIS_(file_format)>`_.
-   Extension ``.ris``. RIS files are used by digital libraries, like IEEE Xplore, Scopus
+   Extension ``.ris`` or ``.txt``. RIS files are used by digital libraries, like IEEE Xplore, Scopus
    and ScienceDirect. Citation managers Mendeley, RefWorks, Zotero, and EndNote support
    the RIS format as well.
  - **Tabular datasets**. Extensions ``.csv``, ``.xlsx``, and ``.xls``. CSV files should


### PR DESCRIPTION
To clarify that `.txt` import is handled as RIS import. This wasn't documented. #332 