### PR TITLE
Show a warning instead of failing on bad labels

### DIFF
--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -51,8 +51,10 @@ def read_ris(fp):
                 mapping = _tag_key_mapping(reverse=False)
                 entries = list(readris(bibliography_file, mapping=mapping))
                 break
-        except (UnicodeDecodeError, IOError):
+        except UnicodeDecodeError:
             pass
+        except IOError as e:
+            logging.warning(e)
 
     if entries is None:
         raise ValueError("Cannot find proper encoding for data file.")

--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -104,6 +104,10 @@ def standardize_dataframe(df, column_spec={}):
             df[col] = pd.to_numeric(df[col])
         except KeyError:
             pass
+        except ValueError:
+            logging.warning("Failed to parse label column name, no labels will"
+                            " be present.")
+            df.rename(columns={"label": "final_included"})
 
     # If the we have a record_id (for example from an ASReview export) use it.
     if "record_id" in list(df):

--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -108,6 +108,7 @@ def standardize_dataframe(df, column_spec={}):
             logging.warning("Failed to parse label column name, no labels will"
                             " be present.")
             df.rename(columns={"label": "final_included"})
+            all_column_spec.pop("final_included")
 
     # If the we have a record_id (for example from an ASReview export) use it.
     if "record_id" in list(df):


### PR DESCRIPTION
Resolves #332 

Problem is that the RIS 'LB' tag can be used for things other than inclusion/exclusion labels. This pull request should instead of failing immediately give a warning that the labels could not be read.