### PR TITLE
Add an Alert for Exploration Mode

### DIFF
--- a/asreview/webapp/src/Components/ArticlePanel.js
+++ b/asreview/webapp/src/Components/ArticlePanel.js
@@ -25,10 +25,18 @@ const useStyles = makeStyles({
   title: {
     lineHeight: 1.2
   },
+  titleDebug: {
+    lineHeight: 1.2,
+    color: "#00C49F",
+  },
+  debug: {
+    color: "#00C49F",
+  },
   abstract: {
   },
   doi: {
-
+  },
+  publish_time: {
   },
   link: {
     marginLeft: "6px",
@@ -59,9 +67,9 @@ const ArticlePanel = (props) => {
 
         {/* Show the title */}
         <Typography
-          className={classes.title}
+          className={isDebugInclusion() ? classes.titleDebug : classes.title}
           variant="h5"
-          color={isDebugInclusion() ? "error" : "textSecondary"}
+          color="textSecondary"
           component="div"
           paragraph>
 
@@ -88,8 +96,8 @@ const ArticlePanel = (props) => {
         {/* Show the publication date if available */}
         {!(props.record.publish_time === undefined || props.record.publish_time === null)  &&
           <Typography
-              className={classes.publish_time + " textSize" + props.textSize}
-              color={isDebugInclusion() ? "error" : "textSecondary"}
+              className={(isDebugInclusion() ? classes.debug : classes.publish_time) + " textSize" + props.textSize}
+              color="textSecondary"
               component="p"
               fontStyle="italic"
               paragraph>
@@ -100,8 +108,8 @@ const ArticlePanel = (props) => {
         {/* Show the publication date if available */}
         {!(props.record.doi === undefined || props.record.doi === null)  &&
           <Typography
-              className={classes.doi + " textSize" + props.textSize}
-              color={isDebugInclusion() ? "error" : "textSecondary"}
+              className={(isDebugInclusion() ? classes.debug : classes.doi) + " textSize" + props.textSize}
+              color="textSecondary"
               component="p"
               fontStyle="italic"
               paragraph>
@@ -119,9 +127,9 @@ const ArticlePanel = (props) => {
 
         {/* Show the abstract */}
         <Typography
-            className={classes.abstract + " textSize" + props.textSize}
+            className={(isDebugInclusion() ? classes.debug : classes.abstract) + " textSize" + props.textSize}
             variant="body2"
-            color={isDebugInclusion() ? "error" : "textSecondary"}
+            color="textSecondary"
             component="div"
             paragraph>
 

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 
 import { makeStyles } from '@material-ui/core/styles'
-
 import {
   Box,
+  Link,
 } from '@material-ui/core'
+import { Alert, AlertTitle } from '@material-ui/lab'
 
 import ReviewDrawer from './ReviewDrawer'
 import ArticlePanel from './ArticlePanel'
@@ -15,7 +16,7 @@ import { useKeyPress } from '../hooks/useKeyPress'
 import { connect } from "react-redux";
 
 import axios from 'axios'
-import { api_url } from '../globals.js';
+import { api_url, reviewDrawerWidth } from '../globals.js';
 
 // redux config
 import { toggleReviewDrawer } from '../redux/actions'
@@ -25,6 +26,18 @@ const useStyles = makeStyles({
   box: {
     paddingBottom: 30,
     overflowY: 'auto',
+  },
+  alertFullWidth: {
+    width: '100%',
+    overflowY: 'auto',
+  },
+  alertWithDrawer: {
+    width: '100%',
+    overflowY: 'auto',
+    paddingRight: reviewDrawerWidth,
+  },
+  link: {
+    paddingLeft: "3px",
   },
 });
 
@@ -288,6 +301,25 @@ const ReviewZone = (props) => {
     <Box
       className={classes.box}
     >
+      
+      {/* Alert Exploration Mode */}
+      {recordState.record !== null && recordState.record._debug_label !== null  &&
+        <div className={props.reviewDrawerOpen ? classes.alertWithDrawer : classes.alertFullWidth}>
+          <Alert severity="warning">
+            <AlertTitle>You are screening through a manually pre-labeled dataset</AlertTitle>
+            <div>
+              Relevant documents are displayed in caribbean green. Read more about
+              <Link
+                className={classes.link}
+                href="https://asreview.readthedocs.io/en/latest/user_testing_algorithms.html#end-user-testing"
+                target="_blank"
+              >
+                <strong>Exploration Mode</strong>
+              </Link>.
+            </div>
+          </Alert>
+        </div>
+      }
 
       {/* Article panel */}
       {recordState['isloaded'] &&

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -311,7 +311,7 @@ const ReviewZone = (props) => {
               Relevant documents are displayed in green. Read more about
               <Link
                 className={classes.link}
-                href="https://asreview.readthedocs.io/en/latest/user_testing_algorithms.html#end-user-testing"
+                href="https://asreview.readthedocs.io/en/latest/user_testing_algorithms.html#exploration-mode"
                 target="_blank"
               >
                 <strong>Exploration Mode</strong>

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -308,7 +308,7 @@ const ReviewZone = (props) => {
           <Alert severity="warning">
             <AlertTitle>You are screening through a manually pre-labeled dataset</AlertTitle>
             <div>
-              Relevant documents are displayed in caribbean green. Read more about
+              Relevant documents are displayed in green. Read more about
               <Link
                 className={classes.link}
                 href="https://asreview.readthedocs.io/en/latest/user_testing_algorithms.html#end-user-testing"

--- a/docs/source/user_testing_algorithms.rst
+++ b/docs/source/user_testing_algorithms.rst
@@ -1,10 +1,10 @@
-End-user testing
+Exploration Mode
 ================
 
 This tutorial shows how the active learning software and algorithms can be
 tested. Because it is not possible to test the software by reading everything
 yourself. Therefore, ASReview implements a mode in which the relevant articles
-are displayed in red. This make decision making straightforward.
+are displayed in green. This make decision making straightforward.
 
 This tutorial assumes you have already installed Python and ASReview. If
 this is not the case, please check out the


### PR DESCRIPTION
While using the example datasets, users may see an alert during the reviewing process.
- End-user testing is renamed Exploration Mode.
- Relevant documents are displayed in green, the same color as the charts on the side statistics panel.

![exploration](https://user-images.githubusercontent.com/17449217/93610810-d4155080-f9cd-11ea-99c4-6b23f963de31.png)

