### PR TITLE
Improve performance of reading data

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -785,19 +785,35 @@ def export_results(project_id):
 
 @bp.route('/project/<project_id>/export_project', methods=["GET"])
 def export_project(project_id):
-    """Export a zipped project file"""
+    """Export the project file.
 
+    The ASReview project file is a file with .asreview extension.
+    The ASReview project file is a zipped file and contains
+    all information to continue working on the project as well
+    as the orginal dataset.
+    """
+
+    # create a temp folder to zip
     tmpdir = tempfile.TemporaryDirectory()
 
-    shutil.make_archive(
-        Path(tmpdir.name, f"export_{project_id}"),
-        "zip",
-        get_project_path(project_id)
+    # copy the source tree, but ignore pickle files
+    shutil.copytree(
+        f"/Users/jonathan/.asreview/{project_id}",
+        Path(tmpdir.name, project_id),
+        ignore=shutil.ignore_patterns('*.pickle')
     )
-    fp_tmp_export = Path(tmpdir.name, f"export_{project_id}.zip")
 
+    # create the archive
+    shutil.make_archive(
+        Path(tmpdir.name, project_id),
+        "zip",
+        root_dir=Path(tmpdir.name),
+        base_dir=project_id
+    )
+
+    # return the project file to the user
     return send_file(
-        fp_tmp_export,
+        str(Path(tmpdir.name, f"{project_id}.zip")),
         as_attachment=True,
         attachment_filename=f"{project_id}.asreview",
         cache_timeout=0

--- a/asreview/webapp/utils/io.py
+++ b/asreview/webapp/utils/io.py
@@ -50,7 +50,7 @@ def read_data(project_id, save_tmp=True):
 
     # save a pickle version
     if save_tmp:
-        print("Store copy of data in pickle file.")
+        logging.info("Store a copy of the data in a pickle file.")
         with open(fp_data_pickle, 'wb') as f_pickle:
             pickle.dump(data_obj, f_pickle)
 

--- a/asreview/webapp/utils/io.py
+++ b/asreview/webapp/utils/io.py
@@ -21,6 +21,8 @@ def read_data(project_id, save_tmp=True):
     ----------
     project_id: str, iterable
         The project identifier.
+    save_tmp: bool
+        Save the file to a pickle file if not available.
 
     Returns
     -------


### PR DESCRIPTION
This PR implements a temp pickle file for fast reading of the dataset. This is useful for large files and RIS files. Performance is 50x better for a RIS dataset with about 13k records.  

TODO:

- [x] Implement reader/writer
- [x] Remove pickle file when exporting project
- [x] Test on different platforms (Windows, MacOS).