### PR TITLE
Add batch

### DIFF
--- a/asreview/batch.py
+++ b/asreview/batch.py
@@ -1,11 +1,12 @@
 from copy import deepcopy
-from pathlib import Path
-
-import queue
-import numpy as np
 from multiprocessing import Queue
 from multiprocessing import cpu_count
 from multiprocessing import Process
+from pathlib import Path
+import queue
+
+import numpy as np
+
 from asreview.review.factory import review_simulate
 
 

--- a/asreview/batch.py
+++ b/asreview/batch.py
@@ -1,0 +1,75 @@
+from copy import deepcopy
+from pathlib import Path
+
+import queue
+import numpy as np
+from multiprocessing import Queue
+from multiprocessing import cpu_count
+from multiprocessing import Process
+from asreview.review.factory import review_simulate
+
+
+def _sim_worker(job_queue):
+    while True:
+        try:
+            job = job_queue.get(block=False)
+        except queue.Empty:
+            return
+
+        args = job["args"]
+        kwargs = job["kwargs"]
+
+        review_simulate(*args, **kwargs)
+
+
+def batch_simulate(*args, n_jobs=-1, **kwargs):
+    if n_jobs is None:
+        n_jobs = 1
+    elif n_jobs == -1:
+        n_jobs = cpu_count()
+
+    new_jobs = create_jobs(*args, **kwargs)
+    job_queue = Queue()
+    for job in new_jobs:
+        job_queue.put(job)
+
+    worker_procs = [
+        Process(
+            target=_sim_worker,
+            args=(job_queue,),
+            daemon=True,
+        )
+        for _ in range(n_jobs)
+    ]
+
+    for proc in worker_procs:
+        proc.start()
+
+    for proc in worker_procs:
+        proc.join()
+
+
+def create_jobs(*args, **kwargs):
+    n_runs = kwargs.pop("n_run")
+    state_file = kwargs.pop("state_file", None)
+    if state_file is None:
+        state_file = kwargs.pop("log_file")
+    init_seed = kwargs.pop("init_seed", None)
+    r = np.random.RandomState(init_seed)
+
+    Path(state_file).parent.mkdir(exist_ok=True)
+    jobs = []
+    for i in range(n_runs):
+        suffix = Path(state_file).suffix
+        stem = Path(state_file).stem
+        state_dir = Path(state_file).parent
+        new_state_file = Path(state_dir, f"{stem}_{i}{suffix}")
+        new_kwargs = deepcopy(kwargs)
+        if init_seed is not None:
+            new_kwargs["init_seed"] = r.randint(0, 99999999)
+        new_kwargs["state_file"] = new_state_file
+        jobs.append({
+            "args": deepcopy(args),
+            "kwargs": new_kwargs,
+        })
+    return jobs

--- a/asreview/entry_points/__init__.py
+++ b/asreview/entry_points/__init__.py
@@ -2,3 +2,4 @@ from asreview.entry_points.base import BaseEntryPoint
 from asreview.entry_points.simulate import SimulateEntryPoint
 from asreview.entry_points.run_model import WebRunModelEntryPoint
 from asreview.entry_points.gui import GUIEntryPoint
+from asreview.entry_points.batch import BatchEntryPoint

--- a/asreview/entry_points/batch.py
+++ b/asreview/entry_points/batch.py
@@ -1,6 +1,6 @@
+from asreview.batch import batch_simulate
 from asreview.entry_points.base import BaseEntryPoint
 from asreview.entry_points.simulate import _simulate_parser
-from asreview.batch import batch_simulate
 
 
 class BatchEntryPoint(BaseEntryPoint):

--- a/asreview/entry_points/batch.py
+++ b/asreview/entry_points/batch.py
@@ -1,0 +1,31 @@
+from asreview.entry_points.base import BaseEntryPoint
+from asreview.entry_points.simulate import _simulate_parser
+from asreview.batch import batch_simulate
+
+
+class BatchEntryPoint(BaseEntryPoint):
+    description = "Parallel simulation for ASReview."
+
+    def execute(self, argv):
+        parser = _batch_parser()
+        kwargs = vars(parser.parse_args(argv))
+        batch_simulate(**kwargs)
+
+
+DESCRIPTION_BATCH = """
+Automated Systematic Review (ASReview) batch system for simulation runs.
+
+It has the same interface as the simulation modus, but adds an extra option
+(--n_runs) to run a batch of simulation runs with the same configuration.
+"""
+
+
+def _batch_parser():
+    parser = _simulate_parser(prog="batch", description=DESCRIPTION_BATCH)
+    parser.add_argument(
+        "-r", "--n_run",
+        default=10,
+        type=int,
+        help="Number of runs to perform."
+    )
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
             'simulate=asreview.entry_points:SimulateEntryPoint',
             'oracle=asreview.entry_points:GUIEntryPoint',
             'web_run_model = asreview.entry_points:WebRunModelEntryPoint',
+            'batch = asreview.entry_points:BatchEntryPoint',
         ],
         'asreview.readers': [
             '.csv = asreview.io.csv_reader:read_csv',

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             'simulate=asreview.entry_points:SimulateEntryPoint',
             'oracle=asreview.entry_points:GUIEntryPoint',
             'web_run_model = asreview.entry_points:WebRunModelEntryPoint',
-            'batch = asreview.entry_points:BatchEntryPoint',
+            'simulate-batch = asreview.entry_points:BatchEntryPoint',
         ],
         'asreview.readers': [
             '.csv = asreview.io.csv_reader:read_csv',


### PR DESCRIPTION
Add functionality from the asreview-simulation package.

For OS X users, you need to export the variable (also for the embedding_lstm feature extraction):

OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES

Usage is exactly the same as with `asreview simulate`, e.g.:

`asreview batch ptsd.csv --n_instances 200 --n_run 10`

with the exception of the additional `--n_run` optional argument, which gives the number of simulations to run.

The python API is similar to the one provided in the factory:

`batch_simulate('ptsd.csv', n_run=20, state_file='test/result.h5')