### PR TITLE
Move boot HTTP request from API to root of Flask app

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -64,32 +64,6 @@ bp = Blueprint('api', __name__, url_prefix='/api')
 CORS(bp, resources={r"*": {"origins": "*"}})
 
 
-@bp.route('/boot', methods=["GET"])
-def api_boot():  # noqa: F401
-    """Get the boot info"""
-
-    if os.environ.get("FLASK_ENV", None) == "development":
-        status = "development"
-    else:
-        status = "asreview"
-
-        try:
-            import asreviewcontrib.covid19  # noqa
-            status = "asreview-covid19"
-        except ImportError:
-            logging.debug("covid19 plugin not found")
-
-    # get the asreview version
-
-    response = jsonify({
-        "status": status,
-        "version": asreview_version,
-    })
-    response.headers.add('Access-Control-Allow-Origin', '*')
-
-    return response
-
-
 @bp.route('/projects', methods=["GET"])
 def api_get_projects():  # noqa: F401
     """Get info on the article"""

--- a/asreview/webapp/src/WelcomeScreen.js
+++ b/asreview/webapp/src/WelcomeScreen.js
@@ -8,7 +8,7 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 
 import './WelcomeScreen.css'
-import {api_url} from "./globals";
+import {base_url} from "./globals";
 import axios from "axios";
 
 import { connect } from "react-redux";
@@ -93,7 +93,7 @@ const WelcomeScreen = ({setASReviewVersion, setAppState}) => {
 
   useEffect(() => {
     const fetchData = async () => {
-      await axios.get(api_url + "boot")
+      await axios.get(base_url + "boot")
           .then(result => {
 
             // set the version of asreview

--- a/asreview/webapp/src/globals.js
+++ b/asreview/webapp/src/globals.js
@@ -2,7 +2,8 @@
 // When you're running the development server, the javascript code is always
 // pointing to localhost:5000. In all other configurations, the api url point to
 // the host domain.
-export const api_url = ((window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") && window.location.port === "3000") ? "http://localhost:5000/api/" : "/api/";
+export const base_url = ((window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") && window.location.port === "3000") ? "http://localhost:5000/" : "/";
+export const api_url = base_url + "api/";
 
 export const donateURL = "https://asreview.nl/donate";
 

--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -5,9 +5,11 @@ from threading import Timer
 
 from flask import Flask
 from flask import send_from_directory
+from flask.json import jsonify
 from flask.templating import render_template
 from flask_cors import CORS
 
+from asreview import __version__ as asreview_version
 from asreview.entry_points.gui import _oracle_parser
 from asreview.webapp import api
 
@@ -61,6 +63,31 @@ def create_app(**kwargs):
             'favicon.ico',
             mimetype='image/vnd.microsoft.icon'
         )
+
+    @app.route('/boot', methods=["GET"])
+    def api_boot():
+        """Get the boot info"""
+
+        if os.environ.get("FLASK_ENV", None) == "development":
+            status = "development"
+        else:
+            status = "asreview"
+
+            try:
+                import asreviewcontrib.covid19  # noqa
+                status = "asreview-covid19"
+            except ImportError:
+                logging.debug("covid19 plugin not found")
+
+        # get the asreview version
+
+        response = jsonify({
+            "status": status,
+            "version": asreview_version,
+        })
+        response.headers.add('Access-Control-Allow-Origin', '*')
+
+        return response
 
     return app
 


### PR DESCRIPTION
This PR makes the API more clean. Boot has no use in the API. We will work on a version and plugins request in the API in another PR. 