### PR TITLE
Replace RISParser by rispy

### DIFF
--- a/asreview/config.py
+++ b/asreview/config.py
@@ -40,6 +40,6 @@ COLUMN_DEFINITIONS = [
     ["abstract_included", "included_abstract", "included_after_abstract", "label_abstract_screening"],
     ['title', 'primary_title'],
     ['authors', 'author names', 'first_authors'],
-    ['abstract', 'abstract note'],
+    ['abstract', 'abstract note', 'notes_abstract'],
     ['keywords'],
 ]

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -1,9 +1,9 @@
 import logging
 
 import pandas as pd
-from RISparser import readris
-from RISparser import TAG_KEY_MAPPING
-from RISparser.config import LIST_TYPE_TAGS
+import rispy
+from rispy import TAG_KEY_MAPPING
+from rispy.config import LIST_TYPE_TAGS
 
 from asreview.config import COLUMN_DEFINITIONS
 from asreview.io.utils import standardize_dataframe
@@ -38,8 +38,8 @@ def read_ris(fp):
 
     Returns
     -------
-    list:
-        List with entries.
+    pandas.DataFrame:
+        Dataframe with entries.
 
     """
 
@@ -49,7 +49,7 @@ def read_ris(fp):
         try:
             with open(fp, 'r', encoding=encoding) as bibliography_file:
                 mapping = _tag_key_mapping(reverse=False)
-                entries = list(readris(bibliography_file, mapping=mapping))
+                entries = list(rispy.load(bibliography_file, mapping=mapping))
                 break
         except UnicodeDecodeError:
             pass

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         'numpy',
         'sklearn',
         'pandas',
-        'RISparser',
+        'rispy',
         'dill',
         'h5py',
         'xlrd>=1.0.0',


### PR DESCRIPTION
This PR updates the deprecated RISParser library to rispy. This will resolve issues with Rayyan files when https://github.com/MrTango/rispy/pull/25 will be merged and released. 

This PR is part of issue https://github.com/asreview/asreview/issues/348. 