### PR TITLE
Update help text for prior_idx in simulate.py

### DIFF
--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -75,7 +75,7 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         default=[],
         nargs="*",
         type=int,
-        help="Prior indices by id."
+        help="Prior indices by rownumber (0 is first rownumber)."
     )
     parser.add_argument(
         "--included_dataset",


### PR DESCRIPTION
Change help text for prior_idx, since it was confusing whether it referred to the column of id numbers, or rownumbers in the file.