### PR TITLE
Remove PEP8 errors in tests

### DIFF
--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -7,7 +7,7 @@ from asreview.balance_strategies.utils import list_balance_strategies
 
 def generate_data(n_feature=20, n_sample=10):
     X = np.random.rand(n_sample, n_feature)
-    n_sample_zero = np.int(n_sample/2)
+    n_sample_zero = np.int(n_sample / 2)
     n_sample_one = n_sample - n_sample_zero
     y = np.append(np.zeros(n_sample_zero), np.ones(n_sample_one))
     np.random.shuffle(y)
@@ -18,9 +18,7 @@ def generate_data(n_feature=20, n_sample=10):
 def check_partition(X, y, X_partition, y_partition, train_idx):
     partition_idx = []
     for row in X_partition:
-        partition_idx.append(
-            np.where(np.all(X == row, axis=1))[0][0]
-        )
+        partition_idx.append(np.where(np.all(X == row, axis=1))[0][0])
 
     assert np.count_nonzero(y_partition == 0) > 0
     assert np.count_nonzero(y_partition == 1) > 0
@@ -30,15 +28,15 @@ def check_partition(X, y, X_partition, y_partition, train_idx):
     assert np.all(y[partition_idx] == y_partition)
 
 
-@mark.parametrize(
-    "balance_strategy",
-    [
-        "undersample",
-        "simple",
-        "double",
-        "triple",
-    ])
-def test_balance(balance_strategy, n_partition=100, n_feature=200,
+@mark.parametrize("balance_strategy", [
+    "undersample",
+    "simple",
+    "double",
+    "triple",
+])
+def test_balance(balance_strategy,
+                 n_partition=100,
+                 n_feature=200,
                  n_sample=100):
     model = get_balance_model(balance_strategy)
     assert isinstance(model.param, dict)
@@ -47,8 +45,9 @@ def test_balance(balance_strategy, n_partition=100, n_feature=200,
     for _ in range(n_partition):
         n_train = np.random.randint(10, n_sample)
         while True:
-            train_idx = np.random.choice(
-                np.arange(len(y)), n_train, replace=False)
+            train_idx = np.random.choice(np.arange(len(y)),
+                                         n_train,
+                                         replace=False)
             num_zero = np.count_nonzero(y[train_idx] == 0)
             num_one = np.count_nonzero(y[train_idx] == 1)
             if num_zero > 0 and num_one > 0:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,19 +11,17 @@ def exists(url):
     return urllib.request.urlopen(url).getcode() == 200
 
 
-@mark.parametrize(
-    "keywords,paper_id",
-    [
-        ("bronchogenic duplication cyst", 0),
-        ("diagnositc accuracy microscopy female priority", 1),
-        ("immunophenotiping", 4),
-        ("Foregut report embryoogenesis", 4),
-        ("Liu Adler", 0),
-        ("Khoury cysts", 4),
-        ("Isolated Edwards", 5),
-        ("Kwintanilla-djeck Neck", 3),
-        ("Cancer case computer contrast pancreatomy Yamada", 2),
-    ])
+@mark.parametrize("keywords,paper_id", [
+    ("bronchogenic duplication cyst", 0),
+    ("diagnositc accuracy microscopy female priority", 1),
+    ("immunophenotiping", 4),
+    ("Foregut report embryoogenesis", 4),
+    ("Liu Adler", 0),
+    ("Khoury cysts", 4),
+    ("Isolated Edwards", 5),
+    ("Kwintanilla-djeck Neck", 3),
+    ("Cancer case computer contrast pancreatomy Yamada", 2),
+])
 def test_fuzzy_finder(keywords, paper_id):
     fp = Path("tests", "demo_data", "embase.csv")
     as_data = ASReviewData.from_file(fp)
@@ -31,14 +29,11 @@ def test_fuzzy_finder(keywords, paper_id):
     assert as_data.fuzzy_find(keywords)[0] == paper_id
 
 
-@mark.parametrize(
-    "data_name",
-    [
-        "ptsd",
-        "ace",
-        "hall",
-    ]
-)
+@mark.parametrize("data_name", [
+    "ptsd",
+    "ace",
+    "hall",
+])
 def test_datasets(data_name):
     data = DatasetManager().find(data_name)
     assert exists(data.get())

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -54,8 +54,8 @@ def random_sample_embedding(words, n_samples=200):
 
     assert len(words) >= n_samples
     keys = random.sample(words, n_samples)
-    order = random.sample(range(1, n_samples+1), n_samples)
-    for i in range(1, n_samples+1):
+    order = random.sample(range(1, n_samples + 1), n_samples)
+    for i in range(1, n_samples + 1):
         assert i in order
     word_index = dict(zip(keys, order))
     assert len(keys) == n_samples
@@ -105,10 +105,10 @@ def write_random_embedding(full_embedding, tmpfile):
     with open(tmpfile, "w") as f:
         f.write(f"{n_words} {emb_vec_dim}\n")
         for word in list(full_embedding):
-            f.write(word+" ")
+            f.write(word + " ")
             new_rand_str = [str(x) for x in full_embedding[word]]
             # Add extra space at the end of the line for compatibility.
-            f.write(" ".join(new_rand_str)+" \n")
+            f.write(" ".join(new_rand_str) + " \n")
 
 
 def check_embedding(emb, full_embedding, n_samples, emb_vec_dim):
@@ -130,7 +130,7 @@ def check_embedding(emb, full_embedding, n_samples, emb_vec_dim):
         assert emb[key].size == emb_vec_dim
         for i in range(emb[key].size):
             assert abs(emb[key][i] - full_embedding[key][i]) < 1e-5
-    assert isinstance(emb, (dict,))
+    assert isinstance(emb, (dict, ))
 
 
 def test_load_embedding(tmpdir):
@@ -174,7 +174,7 @@ def test_sample_embedding():
     full_embedding = random_embedding(words, emb_vec_dim)
     emb_matrix = sample_embedding(full_embedding, word_index)
 
-    assert emb_matrix.shape == (n_samples+1, emb_vec_dim)
+    assert emb_matrix.shape == (n_samples + 1, emb_vec_dim)
     for key in word_index:
         i_row = word_index[key]
         if key in words:

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -6,9 +6,7 @@ from asreview import ASReviewData
 from asreview.feature_extraction.utils import get_feature_model
 from asreview.feature_extraction.utils import list_feature_extraction
 
-ADVANCED_DEPS = {
-    "tensorflow": False
-}
+ADVANCED_DEPS = {"tensorflow": False}
 
 REQUIRES_EXTRA_DEPS = ["doc2vec", "embedding-idf", "sbert"]
 
@@ -27,15 +25,14 @@ except ImportError:
         #  "sbert",
         "tfidf",
     ])
-@pytest.mark.parametrize(
-    "split_ta",
-    [
-        0,
-        1,
-    ])
+@pytest.mark.parametrize("split_ta", [
+    0,
+    1,
+])
 def test_features(feature_extraction, split_ta):
 
-    if feature_extraction in REQUIRES_EXTRA_DEPS and not ADVANCED_DEPS["tensorflow"]:
+    if feature_extraction in REQUIRES_EXTRA_DEPS and not ADVANCED_DEPS[
+            "tensorflow"]:
         pytest.skip()
 
     embedding_fp = os.path.join("tests", "demo_data", "generic.vec")
@@ -44,11 +41,13 @@ def test_features(feature_extraction, split_ta):
     as_data = ASReviewData.from_file(data_fp)
     texts = as_data.texts
     if feature_extraction.startswith("embedding-"):
-        model = get_feature_model(feature_extraction, split_ta=split_ta,
+        model = get_feature_model(feature_extraction,
+                                  split_ta=split_ta,
                                   embedding_fp=embedding_fp)
     else:
         model = get_feature_model(feature_extraction, split_ta=split_ta)
-    X = model.fit_transform(texts, titles=as_data.title,
+    X = model.fit_transform(texts,
+                            titles=as_data.title,
                             abstracts=as_data.abstract)
 
     assert X.shape[0] == len(as_data.title)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,9 +16,13 @@ def test_init_seed():
     for _ in range(n_test):
         all_start_idx = []
         for seed in seeds:
-            reviewer = get_reviewer(
-                data_fp, mode="simulate", model="nb", state_file=None,
-                init_seed=seed, n_prior_excluded=1, n_prior_included=1)
+            reviewer = get_reviewer(data_fp,
+                                    mode="simulate",
+                                    model="nb",
+                                    state_file=None,
+                                    init_seed=seed,
+                                    n_prior_excluded=1,
+                                    n_prior_included=1)
             assert len(reviewer.start_idx) == 2
             all_start_idx.append(reviewer.start_idx)
         if base_start_idx is None:
@@ -34,9 +38,13 @@ def test_no_seed():
     n_priored = np.zeros(len(as_data), dtype=int)
 
     for _ in range(n_test_max):
-        reviewer = get_reviewer(
-            data_fp, mode="simulate", model="nb", state_file=None,
-            init_seed=None, n_prior_excluded=1, n_prior_included=1)
+        reviewer = get_reviewer(data_fp,
+                                mode="simulate",
+                                model="nb",
+                                state_file=None,
+                                init_seed=None,
+                                n_prior_excluded=1,
+                                n_prior_included=1)
         assert len(reviewer.start_idx) == 2
         n_priored[reviewer.start_idx] += 1
         if np.all(n_priored > 0):
@@ -49,10 +57,15 @@ def test_model_seed():
     seed = 192874123
     last_train_idx = None
     for _ in range(n_test):
-        reviewer = get_reviewer(
-            data_fp, mode="simulate", model="rf", query_strategy="random",
-            state_file=None,
-            init_seed=seed, seed=seed, n_prior_excluded=1, n_prior_included=1)
+        reviewer = get_reviewer(data_fp,
+                                mode="simulate",
+                                model="rf",
+                                query_strategy="random",
+                                state_file=None,
+                                init_seed=seed,
+                                seed=seed,
+                                n_prior_excluded=1,
+                                n_prior_included=1)
         reviewer.review()
         if last_train_idx is None:
             last_train_idx = reviewer.train_idx

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,25 +6,27 @@ from asreview.query_strategies.utils import get_query_model
 from asreview.query_strategies.utils import list_query_strategies
 
 
-@mark.parametrize(
-    "query_strategy",
-    [
-        "max",
-        "random",
-        "random_max",
-        "max_random",
-        "uncertainty",
-        "max_uncertainty",
-        "cluster",
-    ])
-def test_query(query_strategy, n_features=50, n_sample=100,
-               n_instances_list=[0, 1, 5, 50], n_train_idx=[0, 1, 5, 50]):
+@mark.parametrize("query_strategy", [
+    "max",
+    "random",
+    "random_max",
+    "max_random",
+    "uncertainty",
+    "max_uncertainty",
+    "cluster",
+])
+def test_query(query_strategy,
+               n_features=50,
+               n_sample=100,
+               n_instances_list=[0, 1, 5, 50],
+               n_train_idx=[0, 1, 5, 50]):
     classifier = get_model("rf")
 
     query_model = get_query_model(query_strategy)
     X = np.random.rand(n_sample, n_features)
 
-    y = np.concatenate((np.zeros(n_sample//2), np.ones(n_sample//2)), axis=0)
+    y = np.concatenate((np.zeros(n_sample // 2), np.ones(n_sample // 2)),
+                       axis=0)
     print(X.shape, y.shape)
     order = np.random.permutation(n_sample)
     print(order.shape)
@@ -40,8 +42,9 @@ def test_query(query_strategy, n_features=50, n_sample=100,
     for n_instances in n_instances_list:
         for n_train in n_train_idx:
             shared = {"query_src": {}, "current_queries": {}}
-            train_idx = np.random.choice(
-                np.arange(n_sample), n_train, replace=False)
+            train_idx = np.random.choice(np.arange(n_sample),
+                                         n_train,
+                                         replace=False)
             pool_idx = np.delete(np.arange(n_sample), train_idx)
             query_idx, X_query = query_model.query(X, classifier, pool_idx,
                                                    n_instances, shared)
@@ -49,8 +52,8 @@ def test_query(query_strategy, n_features=50, n_sample=100,
                             n_instances, sources)
 
 
-def check_integrity(query_idx, X_query, X, pool_idx, shared,
-                    n_instances, sources):
+def check_integrity(query_idx, X_query, X, pool_idx, shared, n_instances,
+                    sources):
     # First check if the query_indices are valid
     assert len(query_idx) == n_instances
     assert len(query_idx) == len(np.unique(query_idx))

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 
 from pytest import mark
@@ -7,22 +6,20 @@ import numpy as np
 from asreview import ASReviewData
 
 
-@mark.parametrize(
-    "test_file,n_lines,labels,ignore_col",
-    [
-        ("embase.csv", 6, None, ["keywords"]),
-        ("embase.ris", 6, None, []),
-        ("generic.csv", 2, None, []),
-        ("generic_labels.csv", 6, [1, 0, 1, 0, 1, 0], []),
-        ("generic.ris", 2, None, []),
-        ("generic_labels.ris", 2, [1, 0], []),
-        ("pubmed_zotero.ris", 6, None, []),
-        ("pubmed_endnote.txt", 6, None, []),
-        ("scopus.ris", 6, None, []),
-        ("ovid_zotero.ris", 6, None, []),
-        ("proquest.ris", 6, None, []),
-        ("pubmed.xml", 10, None, []),
-    ])
+@mark.parametrize("test_file,n_lines,labels,ignore_col", [
+    ("embase.csv", 6, None, ["keywords"]),
+    ("embase.ris", 6, None, []),
+    ("generic.csv", 2, None, []),
+    ("generic_labels.csv", 6, [1, 0, 1, 0, 1, 0], []),
+    ("generic.ris", 2, None, []),
+    ("generic_labels.ris", 2, [1, 0], []),
+    ("pubmed_zotero.ris", 6, None, []),
+    ("pubmed_endnote.txt", 6, None, []),
+    ("scopus.ris", 6, None, []),
+    ("ovid_zotero.ris", 6, None, []),
+    ("proquest.ris", 6, None, []),
+    ("pubmed.xml", 10, None, []),
+])
 def test_reader(test_file, n_lines, labels, ignore_col):
     fp = Path("tests", "demo_data", test_file)
     as_data = ASReviewData.from_file(fp)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -4,14 +4,11 @@ from shutil import copyfile
 import numpy as np
 import pytest
 
-
 from asreview.models.utils import list_classifiers
 from asreview.state import open_state
 from asreview.review.factory import get_reviewer
 
-ADVANCED_DEPS = {
-    "tensorflow": False
-}
+ADVANCED_DEPS = {"tensorflow": False}
 
 try:
     import tensorflow  # noqa
@@ -19,10 +16,11 @@ try:
 except ImportError:
     pass
 
-
 data_fp = os.path.join("tests", "demo_data", "generic_labels.csv")
-data_fp_no_abs = os.path.join("tests", "demo_data", "generic_labels_no_abs.csv")
-data_fp_no_title = os.path.join("tests", "demo_data", "generic_labels_no_title.csv")
+data_fp_no_abs = os.path.join("tests", "demo_data",
+                              "generic_labels_no_abs.csv")
+data_fp_no_title = os.path.join("tests", "demo_data",
+                                "generic_labels_no_title.csv")
 embedding_fp = os.path.join("tests", "demo_data", "generic.vec")
 cfg_dir = os.path.join("tests", "cfg_files")
 state_dir = os.path.join("tests", "state_files")
@@ -33,35 +31,53 @@ json_state_file = os.path.join(state_dir, "test.json")
 def test_state_continue_json():
     inter_file = os.path.join(state_dir, "test_1_inst.json")
     if not os.path.isfile(inter_file):
-        reviewer = get_reviewer(
-            data_fp, mode="simulate", model="nb", embedding_fp=embedding_fp,
-            prior_idx=[1, 2, 3, 4], state_file=inter_file,
-            n_instances=1, n_queries=1)
+        reviewer = get_reviewer(data_fp,
+                                mode="simulate",
+                                model="nb",
+                                embedding_fp=embedding_fp,
+                                prior_idx=[1, 2, 3, 4],
+                                state_file=inter_file,
+                                n_instances=1,
+                                n_queries=1)
         reviewer.review()
 
     copyfile(inter_file, json_state_file)
-    check_model(mode="simulate", model="nb", state_file=json_state_file,
-                continue_from_state=True, n_instances=1, n_queries=2)
+    check_model(mode="simulate",
+                model="nb",
+                state_file=json_state_file,
+                continue_from_state=True,
+                n_instances=1,
+                n_queries=2)
 
 
 def test_state_continue_h5():
     inter_file = os.path.join(state_dir, "test_1_inst.h5")
     if not os.path.isfile(inter_file):
-        reviewer = get_reviewer(
-            data_fp, mode="simulate", model="nb", embedding_fp=embedding_fp,
-            prior_idx=[1, 2, 3, 4], state_file=inter_file,
-            n_instances=1, n_queries=1)
+        reviewer = get_reviewer(data_fp,
+                                mode="simulate",
+                                model="nb",
+                                embedding_fp=embedding_fp,
+                                prior_idx=[1, 2, 3, 4],
+                                state_file=inter_file,
+                                n_instances=1,
+                                n_queries=1)
         reviewer.review()
     copyfile(inter_file, h5_state_file)
-    check_model(mode="simulate", model="nb", state_file=h5_state_file,
-                continue_from_state=True, n_instances=1, n_queries=2)
+    check_model(mode="simulate",
+                model="nb",
+                state_file=h5_state_file,
+                continue_from_state=True,
+                n_instances=1,
+                n_queries=2)
+
 
 def test_nb():
     check_model(mode="simulate",
                 model="nb",
                 state_file=None,
                 use_granular=True,
-                n_instances=1, n_queries=1)
+                n_instances=1,
+                n_queries=1)
 
 
 def test_svm():
@@ -69,7 +85,8 @@ def test_svm():
                 model="svm",
                 state_file=json_state_file,
                 use_granular=False,
-                n_instances=1, n_queries=2,
+                n_instances=1,
+                n_queries=2,
                 data_fp=data_fp_no_abs)
 
 
@@ -78,19 +95,25 @@ def test_rf():
                 model="rf",
                 state_file=json_state_file,
                 use_granular=False,
-                n_instances=1, n_queries=2,
+                n_instances=1,
+                n_queries=2,
                 data_fp=data_fp_no_title)
 
 
-@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"], raises=ImportError, reason="requires tensorflow")
+@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
+                   raises=ImportError,
+                   reason="requires tensorflow")
 def test_nn_2_layer():
     check_model(mode="simulate",
                 model="nn-2-layer",
                 state_file=json_state_file,
-                n_instances=1, n_queries=2)
+                n_instances=1,
+                n_queries=2)
 
 
-@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"], raises=ImportError, reason="requires tensorflow")
+@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
+                   raises=ImportError,
+                   reason="requires tensorflow")
 def test_lstm_base():
 
     check_model(mode="simulate",
@@ -98,7 +121,9 @@ def test_lstm_base():
                 state_file=h5_state_file)
 
 
-@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"], raises=ImportError, reason="requires tensorflow")
+@pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
+                   raises=ImportError,
+                   reason="requires tensorflow")
 def test_lstm_pool():
     check_model(mode="simulate",
                 config_file=os.path.join(cfg_dir, "lstm_pool.ini"),
@@ -109,7 +134,8 @@ def test_logistic():
     check_model(mode="simulate",
                 model="logistic",
                 state_file=json_state_file,
-                n_instances=1, n_queries=2)
+                n_instances=1,
+                n_queries=2)
 
 
 def test_classifiers():
@@ -141,8 +167,12 @@ def check_state(state):
     assert len(state.get("labels")) == 6
 
 
-def check_model(monkeypatch=None, use_granular=False, state_file=h5_state_file,
-                continue_from_state=False, mode="oracle", data_fp=data_fp,
+def check_model(monkeypatch=None,
+                use_granular=False,
+                state_file=h5_state_file,
+                continue_from_state=False,
+                mode="oracle",
+                data_fp=data_fp,
                 **kwargs):
     if not continue_from_state:
         try:
@@ -154,7 +184,9 @@ def check_model(monkeypatch=None, use_granular=False, state_file=h5_state_file,
     if monkeypatch is not None:
         monkeypatch.setattr('builtins.input', lambda _: "0")
     # start the review process.
-    reviewer = get_reviewer(data_fp, mode=mode, embedding_fp=embedding_fp,
+    reviewer = get_reviewer(data_fp,
+                            mode=mode,
+                            embedding_fp=embedding_fp,
                             prior_idx=[1, 2, 3, 4],
                             state_file=state_file,
                             **kwargs)
@@ -179,7 +211,9 @@ def check_model(monkeypatch=None, use_granular=False, state_file=h5_state_file,
                 init_idx, init_labels = reviewer._prior_knowledge()
                 reviewer.query_i = 0
                 reviewer.train_idx = np.array([], dtype=np.int)
-                reviewer.classify(init_idx, init_labels, state,
+                reviewer.classify(init_idx,
+                                  init_labels,
+                                  state,
                                   method="initial")
 
             reviewer._do_review(state)


### PR DESCRIPTION
This PR removes the PEP8 errors in the tests module. Part of #347.