### PR TITLE
Replace oracle entry point by lab entry point

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ Build the project from source with the following code.
 
 ## Development workflow
 
-Install both [npm][1] and Python. 
+Install both [npm][1] and Python.
 
 Install the ASReview package (in a different terminal)
 
@@ -18,14 +18,14 @@ Install the ASReview package (in a different terminal)
 Start the Python API server
 
 	export FLASK_ENV=development
-	asreview oracle
+	asreview lab
 
 Navigate to `asreview/webapp` and install npm.
 
 	cd asreview/webapp
 	npm install
 
-The user interface is written in [React][2]. First, start a development server with npm. This serves is used for React development. 
+The user interface is written in [React][2]. First, start a development server with npm. This serves is used for React development.
 
 	npm start
 

--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -23,9 +23,10 @@ from asreview.utils import get_entry_points
 
 PROG_DESCRIPTION = "Automated Systematic Review (ASReview)."
 
-# Entry points for internal use. These entry points are not displayed in the
-# help page of the  user interface.
+# Internal or deprecated entry points. These entry points
+# are not displayed in the help page of the  user interface.
 INTERNAL_ENTRY_POINTS = ["web_run_model"]
+DEPRECATED_ENTRY_POINTS = ["oracle"]
 
 
 def _sort_entry_points(entry_points):
@@ -54,6 +55,10 @@ def _output_available_entry_points(entry_points):
         if name in INTERNAL_ENTRY_POINTS:
             continue
 
+        # don't display the deprecated entry points
+        if name in DEPRECATED_ENTRY_POINTS:
+            continue
+
         # try to load entry points, hide when failing on loading
         try:
             description_list.append(entry.load()().format(name))
@@ -68,18 +73,10 @@ def main():
     entry_points = get_entry_points("asreview.entry_points")
 
     # Try to load the entry point if available.
-    if len(sys.argv) > 1 and (sys.argv[1] in entry_points or sys.argv[1] == "oracle"):
-
-        # first argument is the subcommand
-        subcommand = sys.argv[1]
-
-        # replace 'oracle' by 'lab'
-        if subcommand == "oracle":
-            print("Warning: subcommmand 'oracle' is replaced by 'lab'.")
-            subcommand = "lab"
+    if len(sys.argv) > 1 and sys.argv[1] in entry_points:
 
         try:
-            entry = entry_points[subcommand]
+            entry = entry_points[sys.argv[1]]
             entry.load()().execute(sys.argv[2:])
         except ModuleNotFoundError:
             raise ValueError(

--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -28,10 +28,27 @@ PROG_DESCRIPTION = "Automated Systematic Review (ASReview)."
 INTERNAL_ENTRY_POINTS = ["web_run_model"]
 
 
+def _sort_entry_points(entry_points):
+
+    entry_points_copy = entry_points.copy()
+
+    entry_points_sorted = {
+        "lab": entry_points_copy.pop("lab"),
+        "simulate": entry_points_copy.pop("simulate"),
+        "simulate-batch": entry_points_copy.pop("simulate-batch"),
+    }
+
+    entry_points_sorted.update(entry_points_copy)
+
+    return entry_points_sorted
+
+
 def _output_available_entry_points(entry_points):
 
+    entry_points_sorted = _sort_entry_points(entry_points)
+
     description_list = []
-    for name, entry in entry_points.items():
+    for name, entry in entry_points_sorted.items():
 
         # don't display the internal entry points
         if name in INTERNAL_ENTRY_POINTS:
@@ -58,7 +75,7 @@ def main():
 
         # replace 'oracle' by 'lab'
         if subcommand == "oracle":
-            print("Warning: subcommmand 'oracle' is now 'lab'.")
+            print("Warning: subcommmand 'oracle' is replaced by 'lab'.")
             subcommand = "lab"
 
         try:

--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -15,10 +15,10 @@
 """Command Line Interface (CLI) for ASReview project."""
 import argparse
 import logging
-import pkg_resources
 import sys
 
 from asreview import __version__
+from asreview.utils import get_entry_points
 
 
 PROG_DESCRIPTION = "Automated Systematic Review (ASReview)."
@@ -47,16 +47,22 @@ def _output_available_entry_points(entry_points):
 
 
 def main():
-    # Find the available entry points.
-    entry_points = {
-        entry.name: entry
-        for entry in pkg_resources.iter_entry_points('asreview.entry_points')
-    }
+    # Get the available entry points.
+    entry_points = get_entry_points("asreview.entry_points")
 
     # Try to load the entry point if available.
-    if len(sys.argv) > 1 and sys.argv[1] in entry_points:
+    if len(sys.argv) > 1 and (sys.argv[1] in entry_points or sys.argv[1] == "oracle"):
+
+        # first argument is the subcommand
+        subcommand = sys.argv[1]
+
+        # replace 'oracle' by 'lab'
+        if subcommand == "oracle":
+            print("Warning: subcommmand 'oracle' is now 'lab'.")
+            subcommand = "lab"
+
         try:
-            entry = entry_points[sys.argv[1]]
+            entry = entry_points[subcommand]
             entry.load()().execute(sys.argv[2:])
         except ModuleNotFoundError:
             raise ValueError(

--- a/asreview/entry_points/__init__.py
+++ b/asreview/entry_points/__init__.py
@@ -1,5 +1,5 @@
 from asreview.entry_points.base import BaseEntryPoint
 from asreview.entry_points.simulate import SimulateEntryPoint
 from asreview.entry_points.run_model import WebRunModelEntryPoint
-from asreview.entry_points.gui import GUIEntryPoint
+from asreview.entry_points.gui import LABEntryPoint, OracleEntryPoint
 from asreview.entry_points.batch import BatchEntryPoint

--- a/asreview/entry_points/batch.py
+++ b/asreview/entry_points/batch.py
@@ -21,7 +21,7 @@ It has the same interface as the simulation modus, but adds an extra option
 
 
 def _batch_parser():
-    parser = _simulate_parser(prog="batch", description=DESCRIPTION_BATCH)
+    parser = _simulate_parser(prog="simulate-batch", description=DESCRIPTION_BATCH)
     parser.add_argument(
         "-r", "--n_run",
         default=10,

--- a/asreview/entry_points/gui.py
+++ b/asreview/entry_points/gui.py
@@ -13,14 +13,12 @@ PORT_NUMBER = 5000
 
 
 class LABEntryPoint(BaseEntryPoint):
-    description = "Graphical user interface for ASReview. (Formerly 'oracle')"
+    description = "Graphical user interface for ASReview."
 
     def _pre_execute(self):
         pass
 
     def execute(self, argv):
-
-        self._pre_execute()
 
         from asreview.webapp.start_flask import main
 
@@ -31,8 +29,11 @@ class LABEntryPoint(BaseEntryPoint):
 class OracleEntryPoint(LABEntryPoint):
     description = "Graphical user interface for ASReview. (Deprecated)"
 
-    def _pre_execute(self):
+    def execute(self, argv):
+
         logging.warning("Warning: subcommmand 'oracle' is replaced by 'lab'.")
+
+        super(OracleEntryPoint, self).execute(argv)
 
 
 def _lab_parser(prog="lab", description=DESCRIPTION_LAB):

--- a/asreview/entry_points/gui.py
+++ b/asreview/entry_points/gui.py
@@ -11,7 +11,7 @@ PORT_NUMBER = 5000
 
 
 class GUIEntryPoint(BaseEntryPoint):
-    description = "Graphical user interface for ASReview."
+    description = "Graphical user interface for ASReview. (Formerly 'oracle')"
 
     def execute(self, argv):
 

--- a/asreview/entry_points/gui.py
+++ b/asreview/entry_points/gui.py
@@ -4,7 +4,7 @@ from asreview.entry_points.base import BaseEntryPoint
 from asreview.entry_points.base import _base_parser
 
 
-DESCRIPTION_ORACLE = """
+DESCRIPTION_LAB = """
 ASReview LAB - Active learning for Systematic Reviews.
 """
 
@@ -35,7 +35,7 @@ class OracleEntryPoint(LABEntryPoint):
         logging.warning("Warning: subcommmand 'oracle' is replaced by 'lab'.")
 
 
-def _lab_parser(prog="lab", description=DESCRIPTION_ORACLE):
+def _lab_parser(prog="lab", description=DESCRIPTION_LAB):
     parser = _base_parser(prog=prog, description=description)
     # Active learning parameters
 

--- a/asreview/entry_points/gui.py
+++ b/asreview/entry_points/gui.py
@@ -15,9 +15,6 @@ PORT_NUMBER = 5000
 class LABEntryPoint(BaseEntryPoint):
     description = "Graphical user interface for ASReview."
 
-    def _pre_execute(self):
-        pass
-
     def execute(self, argv):
 
         from asreview.webapp.start_flask import main

--- a/asreview/entry_points/gui.py
+++ b/asreview/entry_points/gui.py
@@ -1,3 +1,5 @@
+import logging
+
 from asreview.entry_points.base import BaseEntryPoint
 from asreview.entry_points.base import _base_parser
 
@@ -10,17 +12,30 @@ HOST_NAME = "localhost"
 PORT_NUMBER = 5000
 
 
-class GUIEntryPoint(BaseEntryPoint):
+class LABEntryPoint(BaseEntryPoint):
     description = "Graphical user interface for ASReview. (Formerly 'oracle')"
 
+    def _pre_execute(self):
+        pass
+
     def execute(self, argv):
+
+        self._pre_execute()
 
         from asreview.webapp.start_flask import main
 
         main(argv)
 
 
-def _oracle_parser(prog="oracle", description=DESCRIPTION_ORACLE):
+# deprecated oracle class
+class OracleEntryPoint(LABEntryPoint):
+    description = "Graphical user interface for ASReview. (Deprecated)"
+
+    def _pre_execute(self):
+        logging.warning("Warning: subcommmand 'oracle' is replaced by 'lab'.")
+
+
+def _lab_parser(prog="lab", description=DESCRIPTION_ORACLE):
     parser = _base_parser(prog=prog, description=description)
     # Active learning parameters
 

--- a/asreview/utils.py
+++ b/asreview/utils.py
@@ -176,15 +176,31 @@ def is_iterable(i):
 
 
 def list_model_names(entry_name="asreview.models"):
-    return [entry.name
-            for entry in pkg_resources.iter_entry_points(entry_name)]
+    return [*get_entry_points(entry_name)]
 
 
-def _model_class_from_entry_point(method, entry_name="asreview.models"):
-    entry_points = {
+def get_entry_points(entry_name="asreview.entry_points"):
+    """Get the entry points for asreview.
+
+    Parameters
+    ----------
+    entry_name: str
+        Name of the submodule. Default "asreview.entry_points".
+
+    Returns
+    -------
+    dict:
+        Dictionary with the name of the entry point as key
+        and the entry point as value.
+    """
+    return {
         entry.name: entry
         for entry in pkg_resources.iter_entry_points(entry_name)
     }
+
+
+def _model_class_from_entry_point(method, entry_name="asreview.models"):
+    entry_points = get_entry_points(entry_name)
     try:
         return entry_points[method].load()
     except KeyError:

--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -10,7 +10,7 @@ from flask.templating import render_template
 from flask_cors import CORS
 
 from asreview import __version__ as asreview_version
-from asreview.entry_points.gui import _oracle_parser
+from asreview.entry_points.gui import _lab_parser
 from asreview.webapp import api
 
 # set logging level
@@ -94,7 +94,7 @@ def create_app(**kwargs):
 
 def main(argv):
 
-    parser = _oracle_parser(prog="oracle")
+    parser = _lab_parser(prog="lab")
     kwargs = vars(parser.parse_args(argv))
 
     host = kwargs.pop("ip")

--- a/docker/asreview-lab/Dockerfile
+++ b/docker/asreview-lab/Dockerfile
@@ -1,3 +1,3 @@
 FROM python:3.6
 RUN pip install asreview asreview-covid19
-ENTRYPOINT ["asreview","oracle","--ip","0.0.0.0"]
+ENTRYPOINT ["asreview","lab","--ip","0.0.0.0"]

--- a/docs/source/covid-19.rst
+++ b/docs/source/covid-19.rst
@@ -72,7 +72,7 @@ The datasets are immediately available after starting ASReview.
 
 .. code:: bash
 
-    asreview oracle
+    asreview lab
 
 The datasets are selectable in Step 2 of the project initialization. For
 more information on the usage of ASReview, please have a look at the

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,7 +22,7 @@ Start the application with the following command (in CMD.exe or Terminal):
 
 .. code:: bash
 
-    asreview oracle
+    asreview lab
 
 You are now ready to start your first Automated Systematic Review!
 
@@ -48,7 +48,7 @@ closed networks.
 
 .. code:: bash
 
-    asreview oracle --port 5555 --ip xxx.x.x.xx
+    asreview lab --port 5555 --ip xxx.x.x.xx
 
 
 Install with Docker

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -14,7 +14,7 @@ Launch ASReview LAB by running the following command in the command line (`CMD.e
 
 ::
 
-    asreview oracle
+    asreview lab
 
 
 Create a new project

--- a/setup.py
+++ b/setup.py
@@ -123,8 +123,8 @@ setup(
             'asreview=asreview.__main__:main',
         ],
         'asreview.entry_points': [
+            'lab=asreview.entry_points:GUIEntryPoint',
             'simulate=asreview.entry_points:SimulateEntryPoint',
-            'oracle=asreview.entry_points:GUIEntryPoint',
             'web_run_model = asreview.entry_points:WebRunModelEntryPoint',
             'simulate-batch = asreview.entry_points:BatchEntryPoint',
         ],

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,8 @@ setup(
             'asreview=asreview.__main__:main',
         ],
         'asreview.entry_points': [
-            'lab=asreview.entry_points:GUIEntryPoint',
+            'lab=asreview.entry_points:LABEntryPoint',
+            'oracle=asreview.entry_points:OracleEntryPoint',  # deprecated (use lab)
             'simulate=asreview.entry_points:SimulateEntryPoint',
             'web_run_model = asreview.entry_points:WebRunModelEntryPoint',
             'simulate-batch = asreview.entry_points:BatchEntryPoint',

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -44,8 +44,7 @@ def test_state_continue_json():
         reviewer.review()
 
     copyfile(inter_file, json_state_file)
-    check_model(mode="simulate",
-                model="nb",
+    check_model(model="nb",
                 state_file=json_state_file,
                 continue_from_state=True,
                 n_instances=1,
@@ -65,8 +64,7 @@ def test_state_continue_h5():
                                 n_queries=1)
         reviewer.review()
     copyfile(inter_file, h5_state_file)
-    check_model(mode="simulate",
-                model="nb",
+    check_model(model="nb",
                 state_file=h5_state_file,
                 continue_from_state=True,
                 n_instances=1,
@@ -74,8 +72,7 @@ def test_state_continue_h5():
 
 
 def test_nb():
-    check_model(mode="simulate",
-                model="nb",
+    check_model(model="nb",
                 state_file=None,
                 use_granular=True,
                 n_instances=1,
@@ -83,8 +80,7 @@ def test_nb():
 
 
 def test_svm():
-    check_model(mode="simulate",
-                model="svm",
+    check_model(model="svm",
                 state_file=json_state_file,
                 use_granular=False,
                 n_instances=1,
@@ -93,8 +89,7 @@ def test_svm():
 
 
 def test_rf():
-    check_model(mode="simulate",
-                model="rf",
+    check_model(model="rf",
                 state_file=json_state_file,
                 use_granular=False,
                 n_instances=1,
@@ -106,8 +101,7 @@ def test_rf():
                    raises=ImportError,
                    reason="requires tensorflow")
 def test_nn_2_layer():
-    check_model(mode="simulate",
-                model="nn-2-layer",
+    check_model(model="nn-2-layer",
                 state_file=json_state_file,
                 n_instances=1,
                 n_queries=2)
@@ -118,8 +112,7 @@ def test_nn_2_layer():
                    reason="requires tensorflow")
 def test_lstm_base():
 
-    check_model(mode="simulate",
-                config_file=os.path.join(cfg_dir, "lstm_base.ini"),
+    check_model(config_file=os.path.join(cfg_dir, "lstm_base.ini"),
                 state_file=h5_state_file)
 
 
@@ -127,14 +120,12 @@ def test_lstm_base():
                    raises=ImportError,
                    reason="requires tensorflow")
 def test_lstm_pool():
-    check_model(mode="simulate",
-                config_file=os.path.join(cfg_dir, "lstm_pool.ini"),
+    check_model(config_file=os.path.join(cfg_dir, "lstm_pool.ini"),
                 state_file=json_state_file)
 
 
 def test_logistic():
-    check_model(mode="simulate",
-                model="logistic",
+    check_model(model="logistic",
                 state_file=json_state_file,
                 n_instances=1,
                 n_queries=2)
@@ -145,13 +136,13 @@ def test_classifiers():
 
 
 def test_partial_simulation():
-    check_model(mode="simulate", data_fp=data_fp_partial,
+    check_model(data_fp=data_fp_partial,
                 n_prior_included=1, n_prior_excluded=1,
                 prior_idx=None, state_checker=check_partial_state)
 
 
 def test_partial_simulation_2():
-    check_model(mode="simulate", data_fp=data_fp_partial,
+    check_model(data_fp=data_fp_partial,
                 prior_idx=[0, 5], state_checker=check_partial_state)
 
 
@@ -202,7 +193,7 @@ def check_model(monkeypatch=None,
                 use_granular=False,
                 state_file=h5_state_file,
                 continue_from_state=False,
-                mode="oracle",
+                mode="simulate",
                 data_fp=data_fp,
                 state_checker=check_state,
                 prior_idx=[1, 2, 3, 4],


### PR DESCRIPTION
This PR replaces the `asreview oracle` command by `asreview lab`. The first still works, but the latter is preferred. This should avoid confusion in the future with the oracle, exploration, simulation mode in the frontend. 

The PR also sorts the entry points. The subcommands at the top are 'lab', 'simulate', and 'simulate-batch'. 
