### PR TITLE
Add build dependencies error to troubleshooting

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -129,3 +129,29 @@ First check whether the package is correctly installed. Do this with the command
 .. code-block:: bash
 
   python -m asreview oracle
+  
+
+Build dependencies error
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The command line returns the following message:
+
+.. code:: bash
+
+  "Installing build dependencies ... error"
+
+Some of the dependencies of ASReview are not compatible with your Python 
+installation. This error typically happens when the version of your Python 
+installation is either too old or too new. Then, the dependencies do not support 
+your version anymore, or yet.
+
+If the version of your Python installation has been released very recently, the 
+best thing to do is to install the second most recent version of Python
+instead. If your Python installation is outdated, you should install a Python 
+version that is 3.6 or higher. 
+
+Detailed step-by-step instructions to install 
+Python (and ASReview) are available for
+`Windows <https://asreview.nl/installation-guide-windows/>`__ and
+`MacOS <https://asreview.nl/installation-guide-mac/>`__ users.
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -140,18 +140,11 @@ The command line returns the following message:
 
   "Installing build dependencies ... error"
 
-Some of the dependencies of ASReview are not compatible with your Python 
-installation. This error typically happens when the version of your Python 
-installation is either too old or too new. Then, the dependencies do not support 
-your version anymore, or yet.
-
-If the version of your Python installation has been released very recently, the 
-best thing to do is to install the second most recent version of Python
-instead. If your Python installation is outdated, you should install a Python 
-version that is 3.6 or higher. 
-
-Detailed step-by-step instructions to install 
-Python (and ASReview) are available for
+This error typically happens when the version of your Python installation has been 
+released very recently. Because of this, of the dependencies of ASReview are not 
+compatible with your Python installation yet. The  best thing to do is to install 
+the second most recent version of Python instead. Detailed step-by-step instructions 
+to install Python (and ASReview) are available for
 `Windows <https://asreview.nl/installation-guide-windows/>`__ and
 `MacOS <https://asreview.nl/installation-guide-mac/>`__ users.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -141,8 +141,8 @@ The command line returns the following message:
   "Installing build dependencies ... error"
 
 This error typically happens when the version of your Python installation has been 
-released very recently. Because of this, of the dependencies of ASReview are not 
-compatible with your Python installation yet. The  best thing to do is to install 
+released very recently. Because of this, the dependencies of ASReview are not 
+compatible with your Python installation yet. It is advised to install 
 the second most recent version of Python instead. Detailed step-by-step instructions 
 to install Python (and ASReview) are available for
 `Windows <https://asreview.nl/installation-guide-windows/>`__ and


### PR DESCRIPTION
Since Python 3.9 was released, I've been getting quite some messages from new users that run into build dependency errors.  
This also happened when 3.8 was just out and will probably happen again. 

The troubleshooting section now: 

- explains what causes the `installing build depencies ... error`
- guides users to the Python installation guide on the ASReview website to either up- or downgrade their Python.