### PR TITLE
Fix missing values displayed as 'nan'

### DIFF
--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -92,9 +92,8 @@ def standardize_dataframe(df, column_spec={}):
     # Replace NA values with empty strings.
     for col in ["title", "abstract", "authors", "keywords"]:
         try:
-            df[all_column_spec[col]] = df[all_column_spec[col]] \
-                .astype(pd.StringDtype()) \
-                .fillna("")
+            df[all_column_spec[col]] = df[all_column_spec[col]].astype(str)
+            df[all_column_spec[col]].fillna("", inplace=True)
         except KeyError:
             pass
 

--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -92,8 +92,9 @@ def standardize_dataframe(df, column_spec={}):
     # Replace NA values with empty strings.
     for col in ["title", "abstract", "authors", "keywords"]:
         try:
-            df[all_column_spec[col]] = df[all_column_spec[col]].astype(str)
-            df[all_column_spec[col]].fillna("", inplace=True)
+            df[all_column_spec[col]] = df[all_column_spec[col]] \
+                .astype(pd.StringDtype()) \
+                .fillna("")
         except KeyError:
             pass
 

--- a/tests/demo_data/missing_values.csv
+++ b/tests/demo_data/missing_values.csv
@@ -1,0 +1,5 @@
+title,abstract
+"Title of reference",""
+"","BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium."
+"Title of reference",
+,"BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium."

--- a/tests/demo_data/missing_values.ris
+++ b/tests/demo_data/missing_values.ris
@@ -1,0 +1,21 @@
+TY  - JOUR
+ID  - 1
+TI  - Title of reference
+N2  -
+ER  -
+
+TY  - JOUR
+ID  - 2
+TI  -
+N2  - BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+ER  -
+
+TY  - JOUR
+ID  - 3
+TI  - Title of reference
+ER  -
+
+TY  - JOUR
+ID  - 4
+N2  - BACKGROUND: Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  RESULTS: Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. CONCLUSIONS: Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+ER  -

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -43,12 +43,12 @@ def test_nan_values_ris():
     as_data = ASReviewData.from_file(fp)
 
     # check missing titles
-    assert pd.isnull(as_data.record(1, by_index=True).title)
-    assert pd.isnull(as_data.record(3, by_index=True).title)
+    assert as_data.record(1, by_index=True).title == ""
+    assert as_data.record(3, by_index=True).title == ""
 
     # check missing abstracts
-    assert pd.isnull(as_data.record(0, by_index=True).abstract)
-    assert pd.isnull(as_data.record(2, by_index=True).abstract)
+    assert as_data.record(0, by_index=True).abstract == ""
+    assert as_data.record(2, by_index=True).abstract == ""
 
 
 def test_nan_values_csv():

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from pytest import mark
 import numpy as np
+import pandas as pd
 
 from asreview import ASReviewData
 
@@ -34,6 +35,34 @@ def test_reader(test_file, n_lines, labels, ignore_col):
     for col in cols:
         values = as_data.get(col)
         assert len(values) == n_lines
+
+
+def test_nan_values_ris():
+
+    fp = Path("tests", "demo_data", "missing_values.ris")
+    as_data = ASReviewData.from_file(fp)
+
+    # check missing titles
+    assert pd.isnull(as_data.record(1, by_index=True).title)
+    assert pd.isnull(as_data.record(3, by_index=True).title)
+
+    # check missing abstracts
+    assert pd.isnull(as_data.record(0, by_index=True).abstract)
+    assert pd.isnull(as_data.record(2, by_index=True).abstract)
+
+
+def test_nan_values_csv():
+
+    fp = Path("tests", "demo_data", "missing_values.csv")
+    as_data = ASReviewData.from_file(fp)
+
+    # check missing titles
+    assert pd.isnull(as_data.record(1, by_index=True).title)
+    assert pd.isnull(as_data.record(3, by_index=True).title)
+
+    # check missing abstracts
+    assert pd.isnull(as_data.record(0, by_index=True).abstract)
+    assert pd.isnull(as_data.record(2, by_index=True).abstract)
 
 
 def test_csv_write_data():

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from pytest import mark
 import numpy as np
-import pandas as pd
 
 from asreview import ASReviewData
 
@@ -57,12 +56,12 @@ def test_nan_values_csv():
     as_data = ASReviewData.from_file(fp)
 
     # check missing titles
-    assert pd.isnull(as_data.record(1, by_index=True).title)
-    assert pd.isnull(as_data.record(3, by_index=True).title)
+    assert as_data.record(1, by_index=True).title == ""
+    assert as_data.record(3, by_index=True).title == ""
 
     # check missing abstracts
-    assert pd.isnull(as_data.record(0, by_index=True).abstract)
-    assert pd.isnull(as_data.record(2, by_index=True).abstract)
+    assert as_data.record(0, by_index=True).abstract == ""
+    assert as_data.record(2, by_index=True).abstract == ""
 
 
 def test_csv_write_data():


### PR DESCRIPTION
Somehow, missing abstracts are displayed as 'nan' internally and in the frontend. Don't know why yet and I think this wasn't the behavior before. This PR starts with adding some tests that should pass. 

<img width="1063" alt="image (14)" src="https://user-images.githubusercontent.com/12981139/98384680-5fb27180-204e-11eb-9479-b084d0cccb63.png">
