### PR TITLE
change open_state function in state.utils.py

### DIFF
--- a/asreview/state/utils.py
+++ b/asreview/state/utils.py
@@ -60,10 +60,14 @@ def open_state(fp, *args, read_only=False, **kwargs):
         - Anything else -> JSONstate.
     """
     state_class = _get_state_class(fp)
+
     if state_class is None:
         raise ValueError("Bad state file extension, choose one of the"
                          f" following:\n   {', '.join(STATE_EXTENSIONS)}")
+
+    # init state class
     state = state_class(state_fp=fp, *args, read_only=read_only, **kwargs)
+
     try:
         yield state
     finally:

--- a/asreview/state/utils.py
+++ b/asreview/state/utils.py
@@ -63,8 +63,8 @@ def open_state(fp, *args, read_only=False, **kwargs):
     if state_class is None:
         raise ValueError("Bad state file extension, choose one of the"
                          f" following:\n   {', '.join(STATE_EXTENSIONS)}")
+        state = state_class(state_fp=fp, *args, read_only=read_only, **kwargs) 
     try:
-        state = state_class(state_fp=fp, *args, read_only=read_only, **kwargs)
         yield state
     finally:
         state.close()

--- a/asreview/state/utils.py
+++ b/asreview/state/utils.py
@@ -63,7 +63,7 @@ def open_state(fp, *args, read_only=False, **kwargs):
     if state_class is None:
         raise ValueError("Bad state file extension, choose one of the"
                          f" following:\n   {', '.join(STATE_EXTENSIONS)}")
-        state = state_class(state_fp=fp, *args, read_only=read_only, **kwargs) 
+    state = state_class(state_fp=fp, *args, read_only=read_only, **kwargs)
     try:
         yield state
     finally:


### PR DESCRIPTION
Moved definition of ```state``` to before the 'try' part, so that it is always defined when the 'finally' part is executed.