### PR TITLE
change name max sampling

### DIFF
--- a/asreview/webapp/src/PreReviewComponents/ProjectAlgorithms.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectAlgorithms.js
@@ -281,7 +281,7 @@ const ProjectAlgorithms = ({project_id, scrollToBottom}) => {
                             value="max"
                             color="default"
                           >
-                            {"Max (default)"}
+                            {"Certainty-based (default)"}
                           </MenuItem>
 
                           <MenuItem


### PR DESCRIPTION
I propose to change the name 'max' in the front-end to 'certainty-based' so that it matches the paper and documentation. I did not change any of the labels, only the the wording in the dropdown menu.