### PR TITLE
Internal indices should be all index based.

### DIFF
--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -111,7 +111,7 @@ def add_dataset_to_project(project_id, file_name):
 
         if as_data.labels is not None:
             unlabeled = np.where(as_data.labels == LABEL_NA)[0]
-            pool_indices = as_data.record_ids[unlabeled]
+            pool_indices = unlabeled
 
             label_indices_included = \
                 [[int(x), 1] for x in np.where(as_data.labels == 1)[0]]
@@ -119,7 +119,7 @@ def add_dataset_to_project(project_id, file_name):
                 [[int(x), 0] for x in np.where(as_data.labels == 0)[0]]
             label_indices = label_indices_included + label_indices_excluded
         else:
-            pool_indices = as_data.record_ids
+            pool_indices = np.arange(len(as_data))
             label_indices = []
 
         np.random.shuffle(pool_indices)


### PR DESCRIPTION
There is in issue where record_ids are passed around, but some functions assume that they are by row number.

My suggestion is to have everything "internal" passed around as row numbers, mainly because I find that surface the easiest to remember/explain.

Either way, this is quite a big issue, since in particular the export function assumes row numbers instead of record_ids. (I guess it's a bit more complicated than that, but that's the easiest way to explain it now.) The problem is that the labels are mixed up if the record_id's are not lined up.

I think this is part of the solution, but there could be more that has to be changed. This issue probably has been there since the first time ASReview had a GUI.

My estimation right now:

Unaffected datasets:
- No column with record ids
- RIS files
- Record id column, containing non-numerical values (i.e. have non-numeric characters).
- Record id column, with duplicates values (or empty)
- Record id column, with values ranging from 0...N_row - 1 (in any order)

Affected datasets:
- Record id column with unique values that can be converted to numerical values and do not range from 0...N_row - 1

What will the user notice:
- If the values are far from 0...N_row-1, the user will almost certainly quickly notice a problem like #360 
- If values are close to 0...N_row-1, say i_row + 1, the user might not notice anything, except that when stopping the export will have the labels assigned to the wrong record_ids.
- If record ids fall between -N_row-1 and N_row-1, there might not be a crash at all even after reviewing all records. This case seems very rare though.

What can happen during the usage of ASReview that makes an unaffected dataset into an affected dataset:
- The user starts a review, exports to csv, deletes some records, and uploads it again. Depending on the number of deleted records, the user might sooner or later run into #360.
- Instead of deleting records, the user adds records with valid record_ids, but not exactly sequential to the ones generated by ASReview. This seems rather unlikely.
