### PR TITLE
Fix error in error catch on run_model entry point

### DIFF
--- a/asreview/webapp/run_model.py
+++ b/asreview/webapp/run_model.py
@@ -146,15 +146,16 @@ def main(argv):
     try:
         train_model(args.project_id, args.label_method)
     except Exception as err:
-        logging.error(f"Project {args.project_id} - " + err)
+        err_type = type(err).__name__
+        logging.error(f"Project {args.project_id} - {err_type}: {err}")
 
         # write error to file is label method is prior (first iteration)
         if args.label_method == "prior":
-            message = {"message": str(err)}
+            message = {"message": f"{err_type}: {err}"}
 
-        fp = get_project_path(args.project_id) / "error.json"
-        with open(fp, 'w') as f:
-            json.dump(message, f)
+            fp = get_project_path(args.project_id) / "error.json"
+            with open(fp, 'w') as f:
+                json.dump(message, f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR resolves an unhandled error in the error handler of the run_model script. This makes the frontend hang on model training after the setup without feedback to the user.