### PR TITLE
Poorly defined record_ids now raise an error

### DIFF
--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -63,8 +63,28 @@ def type_from_column_spec(col_name, column_spec):
     return None
 
 
+def _is_record_id_unique(s):
+
+    if len(np.unique(s)) != len(s.index):
+        raise ValueError("Column 'record_id' contains duplicate values.")
+
+
+def _is_record_id_notnull(s):
+
+    if s.isnull().any():
+        raise ValueError("Column 'record_id' contains missing values.")
+
+
+def _is_record_id_int(s):
+
+    try:
+        pd.to_numeric(s).astype(int)
+    except Exception:
+        raise ValueError("Column 'record_id' should contain integer values.")
+
+
 def standardize_dataframe(df, column_spec={}):
-    """Creates a ASReview readable dataframe.
+    """Create a ASReview readable dataframe.
 
     The main purpose is to rename columns with slightly different names;
     'authors' vs 'first_authors', etc. This greatly widens the compatibility
@@ -128,21 +148,17 @@ def standardize_dataframe(df, column_spec={}):
 
     # If the we have a record_id (for example from an ASReview export) use it.
     if "record_id" in list(df):
-        if len(np.unique(df["record_id"])) != len(df.index):
-            logging.warning(
-                "Column 'record_id' found, but they are not unique. "
-                "Continuing with new index.")
-        else:
-            try:
-                df['record_id'] = pd.to_numeric(df['record_id'])
-                df.set_index('record_id', inplace=True)
-            except ValueError:
-                logging.warning("Column 'record_id' has non-integer values. "
-                                "Continuing with new index.")
+
+        # validate record_id column
+        _is_record_id_unique(df["record_id"])
+        _is_record_id_notnull(df["record_id"])
+        _is_record_id_int(df["record_id"])
 
     # Create a new index if we haven't found it in the data.
     if df.index.name != "record_id":
         df["record_id"] = np.arange(len(df.index))
-        df.set_index('record_id', inplace=True)
+
+    # set the index
+    df.set_index('record_id', inplace=True)
 
     return df, all_column_spec

--- a/tests/test_asdata.py
+++ b/tests/test_asdata.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from asreview import ASReviewData
 
 
+@pytest.mark.xfail(raises=ValueError, reason="Bad record_id")
 def test_bad_record_id():
     data_fp = Path("tests", "demo_data", "generic_bad_record_id.csv")
     as_data = ASReviewData.from_file(data_fp)


### PR DESCRIPTION
This PR remove the implicit record_id handling on datasets with poorly defined record_id values. 

In case the user has a poorly defined record_id column it should be renamed or dropped. 