### PR TITLE
Only count labels '1' in statistics.py.

### DIFF
--- a/asreview/analysis/statistics.py
+++ b/asreview/analysis/statistics.py
@@ -36,7 +36,7 @@ def _find_inclusions(state, labels, remove_initial=True):
                 cur_inclusions += labels[label_idx[i]]
                 inclusions.append(cur_inclusions)
 
-    inclusions_after_init = sum(labels)
+    inclusions_after_init = sum(labels == 1)
     if remove_initial:
         inclusions_after_init -= n_initial_inc
     return inclusions, inclusions_after_init, n_initial


### PR DESCRIPTION
Only count labels '1' in statistics.py. This should fix https://github.com/asreview/asreview-visualization/issues/15