### PR TITLE
Benchmark platform integration

### DIFF
--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -413,5 +413,23 @@ class BuiltinDataGroup(BaseDataGroup):
         )
 
 
+class BenchmarkDataGroup(BaseDataGroup):
+    group_id = "benchmark"
+    description = "A collections of fully labeled datasets for benchmarking."
+
+    def __init__(self):
+        meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/config/index.json"  # noqa
+        with urlopen(meta_file) as f:
+            meta_data = json.loads(f.read().decode())
+
+        datasets = []
+        for data in meta_data.values():
+            datasets.append(_create_dataset_from_meta(data))
+
+        super(BenchmarkDataGroup, self).__init__(
+            *datasets
+        )
+
+
 def find_data(project_id):
     return DatasetManager().find(project_id).get()

--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -35,7 +35,7 @@ def _create_dataset_from_meta(data):
             datasets.append(BaseDataSet.from_config(config))
         return BaseVersionedDataSet(base_dataset_id, datasets, title)
     elif data["type"] == "base":
-        return BaseVersionedDataSet.from_config(data["configs"][0])
+        return BaseDataSet.from_config(data)
     else:
         raise ValueError(f"Dataset type {data['type']} unknown.")
 
@@ -418,7 +418,7 @@ class BenchmarkDataGroup(BaseDataGroup):
     description = "A collections of fully labeled datasets for benchmarking."
 
     def __init__(self):
-        meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/config/index.json"  # noqa
+        meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/metadata/index.json"  # noqa
         with urlopen(meta_file) as f:
             meta_data = json.loads(f.read().decode())
 

--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -415,7 +415,7 @@ class BuiltinDataGroup(BaseDataGroup):
 
 class BenchmarkDataGroup(BaseDataGroup):
     group_id = "benchmark"
-    description = "A collections of fully labeled datasets for benchmarking."
+    description = "A collections of labeled datasets for benchmarking."
 
     def __init__(self):
         meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/metadata/index.json"  # noqa

--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -418,7 +418,7 @@ class BenchmarkDataGroup(BaseDataGroup):
     description = "A collections of labeled datasets for benchmarking."
 
     def __init__(self):
-        meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/metadata/index.json"  # noqa
+        meta_file = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/index.json"  # noqa
         with urlopen(meta_file) as f:
             meta_data = json.loads(f.read().decode())
 

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
         ],
         'asreview.datasets': [
             'builtin = asreview.datasets:BuiltinDataGroup',
+            'benchmark = asreview.datasets:BenchmarkDataGroup',
         ],
         'asreview.models.classifiers': [
             'svm = asreview.models.classifiers:SVMClassifier',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -34,6 +34,8 @@ def test_fuzzy_finder(keywords, paper_id):
     "ptsd",
     "ace",
     "hall",
+    "benchmark:Bos_2018",
+    "benchmark:van_de_Schoot_2017"
 ])
 def test_datasets(data_name):
     data = DatasetManager().find(data_name)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,7 +36,7 @@ def test_fuzzy_finder(keywords, paper_id):
     "hall",
     "benchmark:van_de_Schoot_2017",
     "benchmark:Hall_2012",
-    "benchmark:ACEInhibitors",
+    "benchmark:Cohen_2006_ACEInhibitors",
     "benchmark:Bos_2018",
 ])
 def test_datasets(data_name):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -34,8 +34,10 @@ def test_fuzzy_finder(keywords, paper_id):
     "ptsd",
     "ace",
     "hall",
+    "benchmark:van_de_Schoot_2017",
+    "benchmark:Hall_2012",
+    "benchmark:ACEInhibitors",
     "benchmark:Bos_2018",
-    "benchmark:van_de_Schoot_2017"
 ])
 def test_datasets(data_name):
     data = DatasetManager().find(data_name)


### PR DESCRIPTION
This PR integrates the datasets of https://github.com/asreview/systematic-review-datasets in the ASReview software. Currently only available for simulation mode. 

Usage:

- Select dataset by name. This is the name of the metadata file (the JSON file). For example [Bos_2018](https://github.com/asreview/systematic-review-datasets/tree/metadata/datasets/Bos_2018).
- Prefix with  benchmark: `benchmark:Bos_2018`
- run simulation:

```
$ python -m asreview simulate benchmark:Bos_2018

            _____ _____            _
     /\    / ____|  __ \          (_)
    /  \  | (___ | |__) |_____   ___  _____      __
   / /\ \  \___ \|  _  // _ \ \ / / |/ _ \ \ /\ / /
  / ____ \ ____) | | \ \  __/\ V /| |  __/\ V  V /
 /_/    \_\_____/|_|  \_\___| \_/ |_|\___| \_/\_/

---------------------------------------------------------------------------------
|                                                                                |
|  Welcome to the ASReview Automated Systematic Review software.                 |
|  In this mode the computer will simulate how well the ASReview software        |
|  could have accelerate the systematic review of your dataset.                  |
|  You can sit back and relax while the computer runs this simulation.           |
|                                                                                |
|  GitHub page:        https://github.com/asreview/asreview                      |
|  Questions/remarks:  asreview@uu.nl                                            |
|                                                                                |
---------------------------------------------------------------------------------

Labeled during review:

3519 => 1
2096 => 0

The following records are prior knowledge:

3519 - Long-Term Clinical Impact of Vascular Brain Lesions on Magnetic Resonance Imag..   Kaffashian, S.;Soumare, A.;Zhu, Y. C.;..
2096 - A SPECT imaging study of MRI white matter hyperintensity in patients with dege..   Ott, B. R.;Faberman, R. S.;Noto, R. B...

```

## TODO
- [x] Update URL after https://github.com/asreview/systematic-review-datasets/pull/36 is merged
- [ ] Documentation (maybe we can wait with his one because more updates on this are upcoming)

## Question

@Rensvandeschoot what is a good name for this integration? `benchmark` or should we use something else? (In the end, this might replace the example datasets tab in LAB, so the name should fit that tab as well)