### PR TITLE
Add option to select Oracle, Explore, and Simulate project types on project creation

### DIFF
--- a/asreview/webapp/src/PreReviewComponents/ProjectInit.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectInit.js
@@ -23,6 +23,8 @@ import { setProject } from '../redux/actions'
 
 import { connect } from "react-redux";
 import { api_url, mapStateToProps, projectModes } from '../globals.js';
+import ProjectModeSelect from './ProjectModeSelect';
+
 
 import './ReviewZone.css';
 
@@ -42,8 +44,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.warning.light
   },
   textfieldItem: {
-    marginTop: 0,
-    marginBottom: 40,
+    marginBottom: theme.spacing(3),
   },
   clear: {
     overflow: "auto",
@@ -92,7 +93,7 @@ const ProjectInit = (props) => {
     });
   };
 
-  const onChange = (evt) => { 
+  const onChange = (evt) => {
     setInfo({
       ...info,
       [evt.target.name]: evt.target.value
@@ -143,8 +144,15 @@ const ProjectInit = (props) => {
       <form noValidate autoComplete="off">
 
         <div className={classes.textfieldItem}>
+          <ProjectModeSelect
+
+          />
+        </div>
+
+        <div className={classes.textfieldItem}>
           <TextField
             fullWidth
+            variant="outlined"
             error={error}
             autoFocus={true}
             required
@@ -160,6 +168,7 @@ const ProjectInit = (props) => {
         <div className={classes.textfieldItem}>
           <TextField
             fullWidth
+            variant="outlined"
             name="authors"
             id="project-author"
             label="Your name"
@@ -171,6 +180,7 @@ const ProjectInit = (props) => {
         <div className={classes.textfieldItem}>
           <TextField
             fullWidth
+            variant="outlined"
             multiline
             rows={4}
             rowsMax={6}
@@ -181,19 +191,6 @@ const ProjectInit = (props) => {
             value={info.description}
           />
         </div>
-
-        <List className={classes.list}>
-            <ListItem>
-              <ListItemText id="switch-list-label-simulation" primary="Simulation" secondary="Some explanation about simulation mode.."/>
-              <ListItemSecondaryAction>
-                <Switch
-                  edge="end"
-                  onChange={toggleMode}
-                />
-              </ListItemSecondaryAction>
-            </ListItem>
-         </List>   
-
       </form>
       </DialogContent>
       <DialogActions>

--- a/asreview/webapp/src/PreReviewComponents/ProjectInit.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectInit.js
@@ -8,11 +8,6 @@ import {
   DialogContent,
   DialogActions,
   Dialog,
-  List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
-  Switch,
 } from '@material-ui/core'
 
 import { brown } from '@material-ui/core/colors';
@@ -86,12 +81,12 @@ const ProjectInit = (props) => {
   })
   const [error, setError] = React.useState(false)
 
-  const toggleMode = () => {
-    setInfo({
-      ...info,
-      mode: info.mode === projectModes.ORACLE ? projectModes.SIMULATION : projectModes.ORACLE
-    });
-  };
+  // const toggleMode = () => {
+  //   setInfo({
+  //     ...info,
+  //     mode: info.mode === projectModes.ORACLE ? projectModes.SIMULATION : projectModes.ORACLE
+  //   });
+  // };
 
   const onChange = (evt) => {
     setInfo({

--- a/asreview/webapp/src/PreReviewComponents/ProjectInit.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectInit.js
@@ -88,6 +88,14 @@ const ProjectInit = (props) => {
   //   });
   // };
 
+  // handle project type/mode change
+  const onModeChange = (event) => {
+    setInfo({
+      ...info,
+      mode: event.target.value
+    });
+  };
+
   const onChange = (evt) => {
     setInfo({
       ...info,
@@ -140,7 +148,8 @@ const ProjectInit = (props) => {
 
         <div className={classes.textfieldItem}>
           <ProjectModeSelect
-
+            mode={info.mode}
+            onModeChange={onModeChange}
           />
         </div>
 

--- a/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
@@ -44,8 +44,8 @@ export default function ProjectModeSelect() {
           <MenuItem value={1}>
             <ListItem>
               <ListItemText
-                primary="Systematic review"
-                secondary="An interactive AI-aided systematic review. Lorum Ipsum"
+                primary="Oracle"
+                secondary="Start an interactive AI-aided screening with an unlabeled dataset."
               />
             </ListItem>
           </MenuItem>
@@ -53,7 +53,7 @@ export default function ProjectModeSelect() {
             <ListItem>
               <ListItemText
                 primary="Exploration"
-                secondary="Explore an existing, fully labeled dataset in an interactive way."
+                secondary="Explore an existing, labeled dataset in an interactive way."
               />
             </ListItem>
           </MenuItem>
@@ -61,7 +61,7 @@ export default function ProjectModeSelect() {
             <ListItem>
               <ListItemText
                 primary="Simulation"
-                secondary="Simulate the performance of ASReview on a fully labeled dataset."
+                secondary="Simulate the performance of ASReview on a labeled dataset."
               />
             </ListItem>
           </MenuItem>

--- a/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
@@ -7,25 +7,23 @@ import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
 
+import { projectModes } from '../globals.js';
+
 const useStyles = makeStyles((theme) => ({
   formControl: {
     width: "100%"
   },
 }));
 
-export default function ProjectModeSelect() {
+export default function ProjectModeSelect(props) {
   const classes = useStyles();
-  const [age, setAge] = React.useState(1);
 
+  // variables for styling the menu
   const inputLabel = React.useRef(null);
   const [labelWidth, setLabelWidth] = React.useState(0);
   React.useEffect(() => {
     setLabelWidth(inputLabel.current.offsetWidth);
   }, []);
-
-  const handleChange = (event) => {
-    setAge(event.target.value);
-  };
 
   return (
     <div>
@@ -37,11 +35,11 @@ export default function ProjectModeSelect() {
         <Select
           labelId="demo-simple-select-outlined-label"
           id="demo-simple-select-outlined"
-          value={age}
-          onChange={handleChange}
+          value={props.mode}
+          onChange={props.onModeChange}
           labelWidth={labelWidth}
         >
-          <MenuItem value={1} component='div'>
+          <MenuItem value={projectModes.ORACLE} component='div'>
             <ListItem>
               <ListItemText
                 primary="Oracle"
@@ -49,7 +47,7 @@ export default function ProjectModeSelect() {
               />
             </ListItem>
           </MenuItem>
-          <MenuItem value={2} component='div'>
+          <MenuItem value={projectModes.SIMULATION} component='div'>
             <ListItem>
               <ListItemText
                 primary="Exploration"
@@ -57,7 +55,7 @@ export default function ProjectModeSelect() {
               />
             </ListItem>
           </MenuItem>
-          <MenuItem value={3} component='div'>
+          <MenuItem value={projectModes.EXPLORATION} component='div'>
             <ListItem>
               <ListItemText
                 primary="Simulation"

--- a/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
@@ -41,7 +41,7 @@ export default function ProjectModeSelect() {
           onChange={handleChange}
           labelWidth={labelWidth}
         >
-          <MenuItem value={1}>
+          <MenuItem value={1} component='div'>
             <ListItem>
               <ListItemText
                 primary="Oracle"
@@ -49,7 +49,7 @@ export default function ProjectModeSelect() {
               />
             </ListItem>
           </MenuItem>
-          <MenuItem value={2}>
+          <MenuItem value={2} component='div'>
             <ListItem>
               <ListItemText
                 primary="Exploration"
@@ -57,7 +57,7 @@ export default function ProjectModeSelect() {
               />
             </ListItem>
           </MenuItem>
-          <MenuItem value={3}>
+          <MenuItem value={3} component='div'>
             <ListItem>
               <ListItemText
                 primary="Simulation"

--- a/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectModeSelect.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import InputLabel from "@material-ui/core/InputLabel";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import MenuItem from "@material-ui/core/MenuItem";
+import FormControl from "@material-ui/core/FormControl";
+import Select from "@material-ui/core/Select";
+
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    width: "100%"
+  },
+}));
+
+export default function ProjectModeSelect() {
+  const classes = useStyles();
+  const [age, setAge] = React.useState(1);
+
+  const inputLabel = React.useRef(null);
+  const [labelWidth, setLabelWidth] = React.useState(0);
+  React.useEffect(() => {
+    setLabelWidth(inputLabel.current.offsetWidth);
+  }, []);
+
+  const handleChange = (event) => {
+    setAge(event.target.value);
+  };
+
+  return (
+    <div>
+
+      <FormControl variant="outlined" className={classes.formControl}>
+        <InputLabel ref={inputLabel} id="demo-simple-select-outlined-label">
+          Project type
+        </InputLabel>
+        <Select
+          labelId="demo-simple-select-outlined-label"
+          id="demo-simple-select-outlined"
+          value={age}
+          onChange={handleChange}
+          labelWidth={labelWidth}
+        >
+          <MenuItem value={1}>
+            <ListItem>
+              <ListItemText
+                primary="Systematic review"
+                secondary="An interactive AI-aided systematic review. Lorum Ipsum"
+              />
+            </ListItem>
+          </MenuItem>
+          <MenuItem value={2}>
+            <ListItem>
+              <ListItemText
+                primary="Exploration"
+                secondary="Explore an existing, fully labeled dataset in an interactive way."
+              />
+            </ListItem>
+          </MenuItem>
+          <MenuItem value={3}>
+            <ListItem>
+              <ListItemText
+                primary="Simulation"
+                secondary="Simulate the performance of ASReview on a fully labeled dataset."
+              />
+            </ListItem>
+          </MenuItem>
+        </Select>
+      </FormControl>
+
+    </div>
+  );
+}


### PR DESCRIPTION
Feel free to think about the labels and UX. Even after this PR is merged (the technical stuff is required to continue working on the modes). 

![localhost_3000_ (10)](https://user-images.githubusercontent.com/12981139/103478778-3fdac800-4dc9-11eb-9229-327e0120ede2.png)
![localhost_3000_ (11)](https://user-images.githubusercontent.com/12981139/103478777-3ea99b00-4dc9-11eb-9dc4-837c890c0701.png)