### PR TITLE
Move statistics from asreview-stats into asreview

### DIFF
--- a/asreview/data/__init__.py
+++ b/asreview/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+# Copyright 2019-2021 The ASReview Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/asreview/data/__init__.py
+++ b/asreview/data/__init__.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 from asreview.data.base import ASReviewData
+from asreview.data.utils import describe_data
+from asreview.data.utils import format_describe_data

--- a/asreview/data/statistics.py
+++ b/asreview/data/statistics.py
@@ -1,0 +1,203 @@
+# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+
+def n_records(data):
+    """Return the number of records.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    return len(data)
+
+
+def n_included(data):
+    """Return the number of included records.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.labels is not None:
+        return len(np.where(data.labels == 1)[0])
+    return None
+
+
+def n_excluded(data):
+    """Return the number of excluded records.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.labels is None:
+        return None
+    return len(np.where(data.labels == 0)[0])
+
+
+def n_unlabeled(data):
+    """Return the number of unlabeled records.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.labels is None:
+        return None
+    return len(data.labels) - n_included() - n_excluded()
+
+
+def n_missing_title(data):
+    """Return the number of records with missing titles.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    n_missing = 0
+    if data.title is None:
+        return None, None
+    if data.labels is None:
+        n_missing_included = None
+    else:
+        n_missing_included = 0
+    for i in range(len(data.title)):
+        if len(data.title[i]) == 0:
+            n_missing += 1
+            if (data.labels is not None and data.labels[i] == 1):
+                n_missing_included += 1
+    return n_missing, n_missing_included
+
+
+def n_missing_abstract(data):
+    """Return the number of records with missing abstracts.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    n_missing = 0
+    if data.abstract is None:
+        return None, None
+    if data.labels is None:
+        n_missing_included = None
+    else:
+        n_missing_included = 0
+
+    for i in range(len(data.abstract)):
+        if len(data.abstract[i]) == 0:
+            n_missing += 1
+            if (data.labels is not None and data.labels[i] == 1):
+                n_missing_included += 1
+
+    return n_missing, n_missing_included
+
+
+def title_length(data):
+    """Return the average length of the titles.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.title is None:
+        return None
+    avg_len = 0
+    for i in range(len(data.title)):
+        avg_len += len(data.title[i])
+    return avg_len / len(data.title)
+
+
+def abstract_length(data):
+    """Return the average length of the abstracts.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.abstract is None:
+        return None
+    avg_len = 0
+    for i in range(len(data.abstract)):
+        avg_len += len(data.abstract[i])
+    return avg_len / len(data.abstract)
+
+
+def n_keywords(data):
+    """Return the number of keywords.
+
+    Arguments
+    ---------
+    data: asreview.data.ASReviewData
+        An ASReviewData object with the records to review.
+
+    Return
+    ------
+    int:
+        The statistic
+    """
+    if data.keywords is None:
+        return None
+    return np.average([len(keywords) for keywords in data.keywords])

--- a/asreview/data/statistics.py
+++ b/asreview/data/statistics.py
@@ -82,7 +82,7 @@ def n_unlabeled(data):
     """
     if data.labels is None:
         return None
-    return len(data.labels) - n_included() - n_excluded()
+    return len(data.labels) - n_included(data) - n_excluded(data)
 
 
 def n_missing_title(data):

--- a/asreview/data/statistics.py
+++ b/asreview/data/statistics.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+# Copyright 2019-2021 The ASReview Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ def n_records(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -31,13 +31,13 @@ def n_records(data):
     return len(data)
 
 
-def n_included(data):
-    """Return the number of included records.
+def n_relevant(data):
+    """Return the number of relevant records.
 
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -49,13 +49,13 @@ def n_included(data):
     return None
 
 
-def n_excluded(data):
-    """Return the number of excluded records.
+def n_irrelevant(data):
+    """Return the number of irrelevant records.
 
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -73,7 +73,7 @@ def n_unlabeled(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -82,7 +82,7 @@ def n_unlabeled(data):
     """
     if data.labels is None:
         return None
-    return len(data.labels) - n_included(data) - n_excluded(data)
+    return len(data.labels) - n_relevant(data) - n_irrelevant(data)
 
 
 def n_missing_title(data):
@@ -91,7 +91,7 @@ def n_missing_title(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -119,7 +119,7 @@ def n_missing_abstract(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -149,7 +149,7 @@ def title_length(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -170,7 +170,7 @@ def abstract_length(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------
@@ -191,7 +191,7 @@ def n_keywords(data):
     Arguments
     ---------
     data: asreview.data.ASReviewData
-        An ASReviewData object with the records to review.
+        An ASReviewData object with the records.
 
     Return
     ------

--- a/asreview/data/utils.py
+++ b/asreview/data/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+# Copyright 2019-2021 The ASReview Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from asreview.data.statistics import n_records
-from asreview.data.statistics import n_included
-from asreview.data.statistics import n_excluded
+from asreview.data.statistics import n_relevant
+from asreview.data.statistics import n_irrelevant
 from asreview.data.statistics import n_unlabeled
 from asreview.data.statistics import n_missing_title
 from asreview.data.statistics import n_missing_abstract
@@ -24,7 +24,7 @@ from asreview.data.statistics import n_keywords
 
 
 def describe_data(data):
-    """Compute dataset statisticsg.
+    """Compute dataset statistics.
 
     Returns
     -------
@@ -36,8 +36,8 @@ def describe_data(data):
 
     return {
         "n_records": n_records(data),
-        "n_relevant": n_included(data),
-        "n_irrelevant": n_excluded(data),
+        "n_relevant": n_relevant(data),
+        "n_irrelevant": n_irrelevant(data),
         "n_unlabeled": n_unlabeled(data),
         "n_missing_title": _n_missing_title,
         "n_missing_title_relevant": _n_missing_title_included,

--- a/asreview/data/utils.py
+++ b/asreview/data/utils.py
@@ -36,13 +36,13 @@ def describe_data(data):
 
     return {
         "n_records": n_records(data),
-        "n_included": n_included(data),
-        "n_excluded": n_excluded(data),
+        "n_relevant": n_included(data),
+        "n_irrelevant": n_excluded(data),
         "n_unlabeled": n_unlabeled(data),
         "n_missing_title": _n_missing_title,
-        "n_missing_title_included": _n_missing_title_included,
+        "n_missing_title_relevant": _n_missing_title_included,
         "n_missing_abstract": _n_missing_abs,
-        "n_missing_abstract_included": _n_missing_abs_included,
+        "n_missing_abstract_relevant": _n_missing_abs_included,
         "title_length": title_length(data),
         "abstract_length": abstract_length(data),
         "n_keywords": n_keywords(data),
@@ -63,11 +63,11 @@ def format_describe_data(data):
     else:
         avg_keywords = None
     values_str = (
-        f"Number of papers:            {values['n_records']}\n"
-        f"Number of inclusions:        {values['n_included']} "
-        f"({100*values['n_included']/values['n_records']:.2f}%)\n"
-        f"Number of exclusions:        {values['n_excluded']} "
-        f"({100*values['n_excluded']/values['n_records']:.2f}%)\n"
+        f"Number of records:           {values['n_records']}\n"
+        f"Number of relevant:          {values['n_relevant']} "
+        f"({100*values['n_relevant']/values['n_records']:.2f}%)\n"
+        f"Number of irrelevant:        {values['n_irrelevant']} "
+        f"({100*values['n_irrelevant']/values['n_records']:.2f}%)\n"
         f"Number of unlabeled:         {values['n_unlabeled']} "
         f"({100*values['n_unlabeled']/values['n_records']:.2f}%)\n"
         f"Average title length:        {values['title_length']:.0f}\n"
@@ -75,13 +75,13 @@ def format_describe_data(data):
         f"Average number of keywords:  {avg_keywords}\n"
         f"Number of missing titles:    {values['n_missing_title']}"
     )
-    if values['n_missing_title_included'] is not None:
-        values_str += (f" (of which {values['n_missing_title_included']}"
-                       " included)")
+    if values['n_missing_title_relevant'] is not None:
+        values_str += (f" (of which {values['n_missing_title_relevant']}"
+                       " relevant)")
     values_str += (f"\nNumber of missing abstracts: "
                    f"{values['n_missing_abstract']}")
-    if values['n_missing_abstract_included'] is not None:
-        val = values['n_missing_abstract_included']
-        values_str += (f" (of which {val} included)")
+    if values['n_missing_abstract_relevant'] is not None:
+        val = values['n_missing_abstract_relevant']
+        values_str += (f" (of which {val} relevant)")
     values_str += "\n"
     return values_str

--- a/asreview/data/utils.py
+++ b/asreview/data/utils.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from asreview.data.statistics import n_records
+from asreview.data.statistics import n_included
+from asreview.data.statistics import n_excluded
+from asreview.data.statistics import n_unlabeled
+from asreview.data.statistics import n_missing_title
+from asreview.data.statistics import n_missing_abstract
+from asreview.data.statistics import title_length
+from asreview.data.statistics import abstract_length
+from asreview.data.statistics import n_keywords
+
+
+def describe_data(data):
+    """Compute dataset statisticsg.
+
+    Returns
+    -------
+    dict:
+        Output the statistics to a dict.
+    """
+    _n_missing_title, _n_missing_title_included = n_missing_title(data)
+    _n_missing_abs, _n_missing_abs_included = n_missing_abstract(data)
+
+    return {
+        "n_records": n_records(data),
+        "n_included": n_included(data),
+        "n_excluded": n_excluded(data),
+        "n_unlabeled": n_unlabeled(data),
+        "n_missing_title": _n_missing_title,
+        "n_missing_title_included": _n_missing_title_included,
+        "n_missing_abstract": _n_missing_abs,
+        "n_missing_abstract_included": _n_missing_abs_included,
+        "title_length": title_length(data),
+        "abstract_length": abstract_length(data),
+        "n_keywords": n_keywords(data),
+    }
+
+
+def format_describe_data(data):
+    """Format the dataset statistics to string.
+
+    Returns
+    -------
+    str:
+        Output with datasets to string.
+    """
+    values = describe_data(data)
+    if values['n_keywords'] is not None:
+        avg_keywords = f"{values['n_keywords']:.1f}"
+    else:
+        avg_keywords = None
+    values_str = (
+        f"Number of papers:            {values['n_records']}\n"
+        f"Number of inclusions:        {values['n_included']} "
+        f"({100*values['n_included']/values['n_records']:.2f}%)\n"
+        f"Number of exclusions:        {values['n_excluded']} "
+        f"({100*values['n_excluded']/values['n_records']:.2f}%)\n"
+        f"Number of unlabeled:         {values['n_unlabeled']} "
+        f"({100*values['n_unlabeled']/values['n_records']:.2f}%)\n"
+        f"Average title length:        {values['title_length']:.0f}\n"
+        f"Average abstract length:     {values['abstract_length']:.0f}\n"
+        f"Average number of keywords:  {avg_keywords}\n"
+        f"Number of missing titles:    {values['n_missing_title']}"
+    )
+    if values['n_missing_title_included'] is not None:
+        values_str += (f" (of which {values['n_missing_title_included']}"
+                       " included)")
+    values_str += (f"\nNumber of missing abstracts: "
+                   f"{values['n_missing_abstract']}")
+    if values['n_missing_abstract_included'] is not None:
+        val = values['n_missing_abstract_included']
+        values_str += (f" (of which {val} included)")
+    values_str += "\n"
+    return values_str

--- a/asreview/entry_points/__init__.py
+++ b/asreview/entry_points/__init__.py
@@ -14,6 +14,7 @@
 
 from asreview.entry_points.algorithms import AlgorithmsEntryPoint
 from asreview.entry_points.base import BaseEntryPoint
+from asreview.entry_points.describe import DescribeEntryPoint
 from asreview.entry_points.lab import LABEntryPoint
 from asreview.entry_points.lab import OracleEntryPoint
 from asreview.entry_points.lab import WebRunModelEntryPoint

--- a/asreview/entry_points/describe.py
+++ b/asreview/entry_points/describe.py
@@ -1,0 +1,67 @@
+# Copyright 2019-2020 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import logging
+
+from asreview.entry_points import BaseEntryPoint
+
+from asreview.data import ASReviewData
+from asreview.data import describe_data
+from asreview.data import format_describe_data
+
+
+class DescribeEntryPoint(BaseEntryPoint):
+    description = "Describe data, state, and ASReview files."
+
+    def execute(self, argv):
+        logging.getLogger().setLevel(logging.ERROR)
+        version_name = f"{self.extension_name}: {self.version}"
+        parser = _parse_arguments(version=version_name)
+        args = parser.parse_args(argv)
+
+        try:
+            data = ASReviewData.from_file(args.path)
+
+            if args.output_data is None:
+                formatted_data = format_describe_data(data)
+
+                # print result
+                print(f"************  {args.path}  ************\n")
+                print(formatted_data, "\n")
+            else:
+                describe_dict = describe_data(data)
+                with open(args.output_data, "w") as fp:
+                    json.dump(describe_dict, fp)
+
+        except Exception as err:
+            raise err
+
+
+def _parse_arguments(version="?"):
+    parser = argparse.ArgumentParser(prog='asreview describe')
+    parser.add_argument(
+        'path',
+        metavar='PATH',
+        type=str,
+        help='Data, state, or ASReview file.'
+    )
+    parser.add_argument(
+        "--output_data",
+        default=None,
+        type=str,
+        help="Export the results to a JSON file."
+    )
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
             'simulate=asreview.entry_points:SimulateEntryPoint',
             'simulate-batch = asreview.entry_points:BatchEntryPoint',
             'algorithms = asreview.entry_points:AlgorithmsEntryPoint',
+            "describe = asreview.entry_points:DescribeEntryPoint",
         ],
         'asreview.readers': [
             '.csv = asreview.io.csv_reader:read_csv',


### PR DESCRIPTION
This PR moves the first part of https://github.com/asreview/asreview-statistics into asreview. Starting with the most urgent part: the dataset statistics.