### PR TITLE
title pop-up history overview

### DIFF
--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -209,7 +209,7 @@ const HistoryDialog = (props) => {
               <ArrowBackIcon />
             </IconButton>
             <div className={classes.detailTitle}>
-              Details
+              Overview
             </div>
           </DialogTitle>
         }


### PR DESCRIPTION
I propose to change the title of the pop-up screen from 'details' into 'overview'. This is because clicking the button brings you back to the overview page and not not more details about the record.