### PR TITLE
Access history dialog only in review state

### DIFF
--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -185,12 +185,14 @@ const App = (props) => {
         toggleExportResult={toggleExportResult}
         exportResult={exportResult}
       />
+      {(props.app_state === 'review') &&
       <HistoryDialog
         recordState={recordState}
         setRecordState={setRecordState}
         toggleHistory={toggleHistory}
         history={history}
       />
+      }
     </ThemeProvider>
   );
 }

--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -67,6 +67,7 @@ const App = (props) => {
     'isloaded': false,
     'record': null,
     'selection': null,
+    'error': null,
   })
 
   const [textSize, handleTextSizeChange] = useTextSize();

--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -63,12 +63,6 @@ const App = (props) => {
   const [exportResult, setExportResult] = React.useState(false);
   const [history, setHistory] = React.useState(false);
   const [authors, setAuthors] = React.useState(false);
-  const [recordState, setRecordState] = React.useState({
-    'isloaded': false,
-    'record': null,
-    'selection': null,
-    'error': null,
-  })
 
   const [textSize, handleTextSizeChange] = useTextSize();
   const [undoEnabled, toggleUndoEnabled] = useUndoEnabled();
@@ -147,8 +141,6 @@ const App = (props) => {
       {(props.app_state === 'review') &&
       <ReviewZone
         handleAppState={props.setAppState}
-        recordState={recordState}
-        setRecordState={setRecordState}
         showAuthors={authors}
         textSize={textSize}
         undoEnabled={undoEnabled}
@@ -188,8 +180,6 @@ const App = (props) => {
       />
       {(props.app_state === 'review') &&
       <HistoryDialog
-        recordState={recordState}
-        setRecordState={setRecordState}
         toggleHistory={toggleHistory}
         history={history}
       />

--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -81,6 +81,9 @@ const HistoryDialog = (props) => {
     "data": null,
   });
 
+  // alert change of decision
+  const [changeDecision, setChangeDecision] = useState(false);
+
   // filter all records
   const handleSelectChange = (event) => {
     setState({...state, "select": event.target.value});
@@ -101,6 +104,8 @@ const HistoryDialog = (props) => {
         'isloaded': true,
     })});
 
+    setChangeDecision(true);
+
     const url = api_url + `project/${props.project_id}/record/${doc_id}`;
 
     // set up the form
@@ -120,6 +125,7 @@ const HistoryDialog = (props) => {
         ...s,
         'isloaded': false,
       })});
+      setChangeDecision(false);
     })
     .catch((error) => {
       console.log(error);
@@ -168,7 +174,7 @@ const HistoryDialog = (props) => {
       });
     };
 
-  }, [props.project_id, props.history, props.recordState]);
+  }, [props.project_id, props.history, changeDecision]);
 
 
   return (

--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -99,11 +99,6 @@ const HistoryDialog = (props) => {
   // change decision of labeled records
   const updateInstance = (doc_id, label) => {
 
-    props.setRecordState(s => {return({
-        ...s,
-        'isloaded': true,
-    })});
-
     setChangeDecision(true);
 
     const url = api_url + `project/${props.project_id}/record/${doc_id}`;
@@ -121,10 +116,6 @@ const HistoryDialog = (props) => {
     })
     .then((response) => {
       console.log(`${props.project_id} - add item ${doc_id} to ${label === 1 ? "exclusions" : "inclusions"}`);
-      props.setRecordState(s => {return({
-        ...s,
-        'isloaded': false,
-      })});
       setChangeDecision(false);
     })
     .catch((error) => {

--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -65,15 +65,10 @@ const HistoryDialog = (props) => {
 
   const classes = useStyles();
 
-  // indicate which record abstract collapse
-  const [openIndex, setOpenIndex] = useState({
-    "index": null,
-    "record": null,
-  });
-
   const [state, setState] = useState({
     "select": DEFAULT_SELECTION,
     "data": null,
+    "index": null,
   });
 
   // filter all records
@@ -81,15 +76,21 @@ const HistoryDialog = (props) => {
     setState({...state, "select": event.target.value});
   };
 
+  // click to fold/unfold abstract and decision button
+  const openRecord = (index) => {
+    setState(s => {return({
+      ...s,
+      "index": index,
+    })});
+  };
+
+
   const handleBack = () => {
-    setOpenIndex({
-      "index": null,
-      "record": null,
-    });
 
     setState({
       "select": state.select,
       "data": null,
+      "index": null,
     });
   };
 
@@ -149,7 +150,7 @@ const HistoryDialog = (props) => {
           console.log("Failed to load review history");
         });
     }
-  }, [props.project_id, props.history, state["data"]]);
+  }, [props.project_id, props.history, state]);
 
   useEffect(() => {
     // on open history panel, set screen
@@ -159,11 +160,6 @@ const HistoryDialog = (props) => {
         ...s,
         "select": DEFAULT_SELECTION,
       })});
-      // back to list of records
-      setOpenIndex({
-        "index": null,
-        "record": null,
-      });
     };
 
   }, [props.history]);
@@ -179,7 +175,7 @@ const HistoryDialog = (props) => {
         aria-labelledby="scroll-dialog-title"
         aria-describedby="scroll-dialog-description"
       >
-        {openIndex["index"] === null &&
+        {state.index === null &&
           <DialogTitle>
             Review History
             {state["data"] !== null &&
@@ -197,7 +193,7 @@ const HistoryDialog = (props) => {
           </DialogTitle>
         }
 
-        {openIndex["index"] !== null &&
+        {state.index !== null &&
           <DialogTitle>
             <IconButton
               aria-label="back"
@@ -212,7 +208,7 @@ const HistoryDialog = (props) => {
           </DialogTitle>
         }
 
-        {openIndex["index"] === null &&
+        {state.index === null &&
           <DialogContent dividers={true}>
             <Box>
               {state["data"] !== null && state["select"] === 1 &&
@@ -225,9 +221,7 @@ const HistoryDialog = (props) => {
                             <HistoryListCard
                               value={value}
                               index={index}
-                              state={state}
-                              setOpenIndex={setOpenIndex}
-
+                              handleClick={openRecord}
                               key={`result-item-${value.id}`}
                             />
                           );
@@ -239,20 +233,21 @@ const HistoryDialog = (props) => {
                 <List>
                   {
                     state["data"]
-                      .filter(value => value.included === 1)
                       .map((value, index) =>
                         {
-                          return (
-                            <HistoryListCard
-                              value={value}
-                              index={index}
-                              state={state}
-                              setOpenIndex={setOpenIndex}
-
-                              key={`result-item-${value.id}`}
-                            />
-                          );
-                        })
+                          if (value.included === 1){
+                            return (
+                              <HistoryListCard
+                                value={value}
+                                index={index}
+                                handleClick={openRecord}
+                                key={`result-item-${value.id}`}
+                              />
+                            )
+                          } else {
+                            return null
+                          }}
+                        )
                   }
                 </List>
               }
@@ -260,20 +255,21 @@ const HistoryDialog = (props) => {
                 <List>
                   {
                     state["data"]
-                      .filter(value => value.included !== 1)
                       .map((value, index) =>
                         {
-                          return (
-                            <HistoryListCard
-                              value={value}
-                              index={index}
-                              state={state}
-                              setOpenIndex={setOpenIndex}
-
-                              key={`result-item-${value.id}`}
-                            />
-                          );
-                        })
+                          if (value.included !== 1){
+                            return (
+                              <HistoryListCard
+                                value={value}
+                                index={index}
+                                handleClick={openRecord}
+                                key={`result-item-${value.id}`}
+                              />
+                            )
+                          } else {
+                            return null
+                          }}
+                        )
                   }
                 </List>
               }
@@ -281,14 +277,14 @@ const HistoryDialog = (props) => {
           </DialogContent>
         }
 
-        {openIndex["index"] !== null &&
+        {state.index !== null &&
           <DialogContent dividers={true}>
             <Box>
               <Typography variant="h6" gutterBottom>
-                {openIndex.record.title}
+                {state.data[state.index].title}
               </Typography>
 
-              {(openIndex.record.abstract === "" || openIndex.record.abstract === null) &&
+              {(state.data[state.index].abstract === "" || state.data[state.index].abstract === null) &&
                 <Box fontStyle="italic">
                   <Typography gutterBottom>
                     This record doesn't have an abstract.
@@ -296,9 +292,9 @@ const HistoryDialog = (props) => {
                 </Box>
               }
 
-              {!(openIndex.record.abstract === "" || openIndex.record.abstract === null) &&
+              {!(state.data[state.index].abstract === "" || state.data[state.index].abstract === null) &&
                 <Typography>
-                  {openIndex.record.abstract}
+                  {state.data[state.index].abstract}
                 </Typography>
               }
             </Box>
@@ -306,26 +302,26 @@ const HistoryDialog = (props) => {
         }
 
         <DialogActions>
-          {openIndex["index"] !== null &&
+          {state.index !== null &&
             <Box className={classes.recordLabelAction}>
               <Typography className={classes.recordLabelActionText}>
-                {openIndex.record.included === 1 ? "Relevant" : "Irrelevant"}
+                {state.data[state.index].included === 1 ? "Relevant" : "Irrelevant"}
               </Typography>
-              {openIndex.record.included === 1 ? <FavoriteIcon color="secondary" /> : <CloseIcon/>}
+              {state.data[state.index].included === 1 ? <FavoriteIcon color="secondary" /> : <CloseIcon/>}
             </Box>
           }
-          {openIndex["index"] === null &&
+          {state.index === null &&
             <Button onClick={props.toggleHistory}>
               Close
             </Button>
           }
-          {openIndex["index"] !== null &&
+          {state.index !== null &&
             <Button
               onClick={() => {
-                updateInstance(openIndex.record.id, openIndex.record.included)
+                updateInstance(state.data[state.index].id, state.data[state.index].included)
               }}
             >
-              {openIndex.record.included === 1 ? "Convert to IRRELEVANT" : "Convert to RELEVANT"}
+              {state.data[state.index].included === 1 ? "Convert to IRRELEVANT" : "Convert to RELEVANT"}
             </Button>
           }
 

--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -85,7 +85,7 @@ const HistoryDialog = (props) => {
   };
 
 
-  const handleBack = () => {
+  const reloadHistory = () => {
 
     setState({
       "select": state.select,
@@ -93,6 +93,13 @@ const HistoryDialog = (props) => {
       "index": null,
     });
   };
+
+  const closeHistory = () => {
+
+    reloadHistory();
+    props.toggleHistory();
+
+  }
 
   // change decision of labeled records
   const updateInstance = (doc_id, label) => {
@@ -112,7 +119,7 @@ const HistoryDialog = (props) => {
     })
     .then((response) => {
       console.log(`${props.project_id} - add item ${doc_id} to ${label === 1 ? "exclusions" : "inclusions"}`);
-      handleBack();
+      reloadHistory();
     })
     .catch((error) => {
       console.log(error);
@@ -132,7 +139,7 @@ const HistoryDialog = (props) => {
   // refresh after toggle the dialog and change a decision
   useEffect(() => {
 
-    if ((props.project_id !== null) && (state["data"] === null)) {
+    if ((props.project_id !== null) && props.history && (state["data"] === null)) {
 
       const url = api_url + `project/${props.project_id}/prior`;
 
@@ -150,23 +157,10 @@ const HistoryDialog = (props) => {
     }
   }, [props.project_id, props.history, state]);
 
-  useEffect(() => {
-    // on open history panel, set screen
-    if (props.history) {
-      // show all records by default
-      setState(s => {return({
-        ...s,
-        "select": DEFAULT_SELECTION,
-      })});
-    };
-
-  }, [props.history]);
-
-
   return (
       <Dialog
         open={props.history}
-        onClose={props.toggleHistory}
+        onClose={closeHistory}
         scroll="paper"
         fullWidth={true}
         maxWidth={"md"}
@@ -196,7 +190,7 @@ const HistoryDialog = (props) => {
             <IconButton
               aria-label="back"
               className={classes.backButton}
-              onClick={handleBack}
+              onClick={reloadHistory}
             >
               <ArrowBackIcon />
             </IconButton>
@@ -309,7 +303,7 @@ const HistoryDialog = (props) => {
             </Box>
           }
           {state.index === null &&
-            <Button onClick={props.toggleHistory}>
+            <Button onClick={closeHistory}>
               Close
             </Button>
           }

--- a/asreview/webapp/src/Components/HistoryDialog.js
+++ b/asreview/webapp/src/Components/HistoryDialog.js
@@ -97,8 +97,6 @@ const HistoryDialog = (props) => {
   // change decision of labeled records
   const updateInstance = (doc_id, label) => {
 
-    // setChangeDecision(true);
-
     const url = api_url + `project/${props.project_id}/record/${doc_id}`;
 
     // set up the form

--- a/asreview/webapp/src/Components/HistoryListCard.js
+++ b/asreview/webapp/src/Components/HistoryListCard.js
@@ -11,32 +11,12 @@ import CloseIcon from '@material-ui/icons/Close';
 
 const HistoryListCard = (props) => {
 
-  // click to fold/unfold abstract and decision button
-  const handleClick = (index) => {
-    if (props.state["select"] === 1) {
-      props.setOpenIndex({
-        "index": index,
-        "record": props.state["data"][index],
-      });
-    } else if (props.state["select"] === 2) {
-      props.setOpenIndex({
-        "index": index,
-        "record": props.state["data"].filter(value => value.included === 1)[index],
-      });
-    } else {
-      props.setOpenIndex({
-        "index": index,
-        "record": props.state["data"].filter(value => value.included !== 1)[index],
-      });
-    }
-  };
-
 
   return (
 	<Box>
 		<ListItem
 		  button
-		  onClick={() => {handleClick(props.index)}}
+		  onClick={() => {props.handleClick(props.index)}}
 		>
 		  <ListItemIcon>
 		    {props.value.included === 1 ? <FavoriteIcon color="secondary" /> : <CloseIcon />}

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -108,17 +108,6 @@ const ReviewZone = (props) => {
     'message': null,
   })
 
-  // const [recordState, setRecordState] = useState({
-  //   // is loaded
-  //   'isloaded': false,
-  //   // record object with metadata
-  //   'record': null,
-  //   // ...
-  //   'selection': null,
-  //   // error loading record
-  //   'error': null,
-  // })
-
   const [previousRecordState, setPreviousRecordState] = useState({
       'record': null,
       'decision': null,

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -108,16 +108,16 @@ const ReviewZone = (props) => {
     'message': null,
   })
 
-  const [recordState, setRecordState] = useState({
-    // is loaded
-    'isloaded': false,
-    // record object with metadata
-    'record': null,
-    // ...
-    'selection': null,
-    // error loading record
-    'error': null,
-  })
+  // const [recordState, setRecordState] = useState({
+  //   // is loaded
+  //   'isloaded': false,
+  //   // record object with metadata
+  //   'record': null,
+  //   // ...
+  //   'selection': null,
+  //   // error loading record
+  //   'error': null,
+  // })
 
   const [previousRecordState, setPreviousRecordState] = useState({
       'record': null,
@@ -315,7 +315,7 @@ const ReviewZone = (props) => {
       })
       .catch((error) => {
         console.log(error);
-        setRecordState({
+        props.setRecordState({
           'record':null,
           'isloaded': true,
           'selection': null,
@@ -373,7 +373,7 @@ const ReviewZone = (props) => {
         }
 
         {/* Article panel */}
-        {recordState.error === null && recordState['isloaded'] &&
+        {props.recordState.error === null && props.recordState['isloaded'] &&
           <ArticlePanel
             record={props.recordState['record']}
             showAuthors={props.showAuthors}
@@ -382,12 +382,12 @@ const ReviewZone = (props) => {
         }
 
         {/* Article panel */}
-        {recordState.error !== null &&
+        {props.recordState.error !== null &&
           <Typography
             variant="h5"
             color="textSecondary"
           >
-            Unexpected error: {recordState.error}
+            Unexpected error: {props.recordState.error}
           </Typography>
         }
 
@@ -395,8 +395,8 @@ const ReviewZone = (props) => {
         <DecisionBar
           reviewDrawerOpen={props.reviewDrawerOpen}
           makeDecision={makeDecision}
-          block={(!recordState['isloaded']) || (recordState.error !== null)}
-          recordState={recordState}
+          block={(!props.recordState['isloaded']) || (props.recordState.error !== null)}
+          recordState={props.recordState}
         />
 
       {/* Decision undo bar */}

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -103,6 +103,13 @@ const ExplorationAlert = (props) => {
 const ReviewZone = (props) => {
   const classes = useStyles();
 
+  const [recordState, setRecordState] = React.useState({
+    'isloaded': false,
+    'record': null,
+    'selection': null,
+    'error': null,
+  })
+
   const [undoState, setUndoState] = useState({
     'open': false,
     'message': null,
@@ -132,7 +139,7 @@ const ReviewZone = (props) => {
 
   const storeRecordState = (label) => {
     setPreviousRecordState({
-      'record': props.recordState.record,
+      'record': recordState.record,
       'decision': label,
     })
   }
@@ -145,7 +152,7 @@ const ReviewZone = (props) => {
   }
 
   const loadPreviousRecordState = () => {
-    props.setRecordState({
+    setRecordState({
       'isloaded': true,
       'record': previousRecordState.record,
       'selection': previousRecordState.decision,
@@ -154,7 +161,7 @@ const ReviewZone = (props) => {
 }
 
   const startLoadingNewDocument = () => {
-    props.setRecordState({
+    setRecordState({
       'isloaded': false,
       'record': null,
       'selection': null,
@@ -185,7 +192,7 @@ const ReviewZone = (props) => {
   }
 
   const isUndoModeActive = () => {
-    return props.recordState.record.doc_id === previousRecordState['record']?.doc_id
+    return recordState.record.doc_id === previousRecordState['record']?.doc_id
   }
 
   const needsClassification = (label) => {
@@ -223,11 +230,11 @@ const ReviewZone = (props) => {
    */
   const classifyInstance = (label, initial) => {
 
-    const url = api_url + `project/${props.project_id}/record/${props.recordState['record'].doc_id}`;
+    const url = api_url + `project/${props.project_id}/record/${recordState['record'].doc_id}`;
 
     // set up the form
     let body = new FormData();
-    body.set('doc_id', props.recordState['record'].doc_id);
+    body.set('doc_id', recordState['record'].doc_id);
     body.set('label', label);
 
     return axios({
@@ -237,7 +244,7 @@ const ReviewZone = (props) => {
       headers: { 'Content-Type': 'application/json' }
     })
     .then((response) => {
-      console.log(`${props.project_id} - add item ${props.recordState['record'].doc_id} to ${label?"inclusions":"exclusions"}`);
+      console.log(`${props.project_id} - add item ${recordState['record'].doc_id} to ${label?"inclusions":"exclusions"}`);
       startLoadingNewDocument()
       showUndoBarIfNeeded(label, initial);
     })
@@ -293,7 +300,7 @@ const ReviewZone = (props) => {
         } else {
 
           /* New article found and set */
-          props.setRecordState({
+          setRecordState({
             'record':result.data["result"],
             'isloaded': true,
             'selection': null,
@@ -304,7 +311,7 @@ const ReviewZone = (props) => {
       })
       .catch((error) => {
         console.log(error);
-        props.setRecordState({
+        setRecordState({
           'record':null,
           'isloaded': true,
           'selection': null,
@@ -317,12 +324,12 @@ const ReviewZone = (props) => {
 
     getProgressHistory();
 
-    if (!props.recordState['isloaded']) {
+    if (!recordState['isloaded']) {
 
       getDocument();
 
     }
-  },[props.project_id, props.recordState, props]);
+  },[props.project_id, recordState, props]);
 
   useEffect(() => {
 
@@ -331,10 +338,10 @@ const ReviewZone = (props) => {
      */
     if (props.keyPressEnabled) {
 
-      if (relevantPress && props.recordState.isloaded) {
+      if (relevantPress && recordState.isloaded) {
         makeDecision(1);
       }
-      if (irrelevantPress && props.recordState.isloaded) {
+      if (irrelevantPress && recordState.isloaded) {
         makeDecision(0);
       }
       if (undoPress && undoState.open && props.undoEnabled) {
@@ -357,26 +364,26 @@ const ReviewZone = (props) => {
       >
 
         {/* Alert Exploration Mode */}
-        {props.recordState.record !== null && props.recordState.record._debug_label !== null  &&
+        {recordState.record !== null && recordState.record._debug_label !== null  &&
           <ExplorationAlert/>
         }
 
         {/* Article panel */}
-        {props.recordState.error === null && props.recordState['isloaded'] &&
+        {recordState.error === null && recordState['isloaded'] &&
           <ArticlePanel
-            record={props.recordState['record']}
+            record={recordState['record']}
             showAuthors={props.showAuthors}
             textSize={props.textSize}
           />
         }
 
         {/* Article panel */}
-        {props.recordState.error !== null &&
+        {recordState.error !== null &&
           <Typography
             variant="h5"
             color="textSecondary"
           >
-            Unexpected error: {props.recordState.error}
+            Unexpected error: {recordState.error}
           </Typography>
         }
 
@@ -384,8 +391,8 @@ const ReviewZone = (props) => {
         <DecisionBar
           reviewDrawerOpen={props.reviewDrawerOpen}
           makeDecision={makeDecision}
-          block={(!props.recordState['isloaded']) || (props.recordState.error !== null)}
-          recordState={props.recordState}
+          block={(!recordState['isloaded']) || (recordState.error !== null)}
+          recordState={recordState}
         />
 
       {/* Decision undo bar */}


### PR DESCRIPTION
While opening a project waiting for setup or initialing a new project, the history dialog is unavailable. Currently, it tries to access the history dialog, which throws an internal error. The history dialog should be accessible only after the start of the review.