### PR TITLE
Drop broken pickle files due to change in submodule data 

### DIFF
--- a/asreview/webapp/utils/io.py
+++ b/asreview/webapp/utils/io.py
@@ -63,7 +63,7 @@ def _read_data_from_cache(project_id, version_check=True):
     except FileNotFoundError:
         # file not available
         pass
-    except (pickle.PickleError, TypeError, ValueError) as err:
+    except Exception as err:
         # problem loading pickle file or outdated
         # remove the pickle file
         logging.error(f"Error reading cache file: {err}")


### PR DESCRIPTION
Pickle files can't be read anymore because of refactor of data submodule. This PR can catch all errors and creates a new temporary pickle file. 