### PR TITLE
Avoid file changes after running tests

### DIFF
--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -91,11 +91,8 @@ def test_state_continue_h5(tmpdir):
 
 def test_nb(tmpdir):
 
-    # copy state file to tmp dir for changes
-    tmp_h5_state_fp = Path(tmpdir, "tmp_state_nb.h5")
-
     check_model(model="nb",
-                state_file=tmp_h5_state_fp,
+                state_file=None,
                 use_granular=True,
                 n_instances=1,
                 n_queries=1)
@@ -259,19 +256,18 @@ def check_partial_state(state):
 
 def check_model(monkeypatch=None,
                 use_granular=False,
-                state_file=h5_state_file,
+                state_file=None,
                 continue_from_state=False,
                 mode="simulate",
                 data_fp=data_fp,
                 state_checker=check_state,
                 prior_idx=[1, 2, 3, 4],
                 **kwargs):
-    # if not continue_from_state:
-    #     try:
-    #         if state_file is not None:
-    #             os.unlink(state_file)
-    #     except OSError as err:
-    #         print(err)
+    if not continue_from_state:
+        try:
+            os.unlink(state_file)
+        except (OSError, TypeError) as err:
+            print(err)
 
     if monkeypatch is not None:
         monkeypatch.setattr('builtins.input', lambda _: "0")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -37,8 +37,10 @@ def test_dataset_not_found():
     reviewer.review()
 
 
-def test_state_continue_json():
+def test_state_continue_json(tmpdir):
+
     inter_file = Path(state_dir, "test_1_inst.json")
+
     if not inter_file.is_file():
         reviewer = get_reviewer(data_fp,
                                 mode="simulate",
@@ -50,16 +52,21 @@ def test_state_continue_json():
                                 n_queries=1)
         reviewer.review()
 
-    copyfile(inter_file, json_state_file)
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(inter_file, tmp_json_state_fp)
+
     check_model(model="nb",
-                state_file=json_state_file,
+                state_file=tmp_json_state_fp,
                 continue_from_state=True,
                 n_instances=1,
                 n_queries=2)
 
 
-def test_state_continue_h5():
+def test_state_continue_h5(tmpdir):
+
     inter_file = Path(state_dir, "test_1_inst.h5")
+
     if not inter_file.is_file():
         reviewer = get_reviewer(data_fp,
                                 mode="simulate",
@@ -70,35 +77,51 @@ def test_state_continue_h5():
                                 n_instances=1,
                                 n_queries=1)
         reviewer.review()
-    copyfile(inter_file, h5_state_file)
+
+    # copy state file to tmp dir for changes
+    tmp_h5_state_fp = Path(tmpdir, "tmp_state.h5")
+    copyfile(inter_file, tmp_h5_state_fp)
+
     check_model(model="nb",
-                state_file=h5_state_file,
+                state_file=tmp_h5_state_fp,
                 continue_from_state=True,
                 n_instances=1,
                 n_queries=2)
 
 
-def test_nb():
+def test_nb(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_h5_state_fp = Path(tmpdir, "tmp_state_nb.h5")
+
     check_model(model="nb",
-                state_file=None,
+                state_file=tmp_h5_state_fp,
                 use_granular=True,
                 n_instances=1,
                 n_queries=1)
 
 
-def test_svm():
+def test_svm(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(json_state_file, tmp_json_state_fp)
+
     check_model(model="svm",
-                state_file=json_state_file,
-                use_granular=False,
+                state_file=tmp_json_state_fp,
                 n_instances=1,
                 n_queries=2,
                 data_fp=data_fp_no_abs)
 
 
-def test_rf():
+def test_rf(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(json_state_file, tmp_json_state_fp)
+
     check_model(model="rf",
-                state_file=json_state_file,
-                use_granular=False,
+                state_file=tmp_json_state_fp,
                 n_instances=1,
                 n_queries=2,
                 data_fp=data_fp_no_title)
@@ -107,9 +130,14 @@ def test_rf():
 @pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
                    raises=ImportError,
                    reason="requires tensorflow")
-def test_nn_2_layer():
+def test_nn_2_layer(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(json_state_file, tmp_json_state_fp)
+
     check_model(model="nn-2-layer",
-                state_file=json_state_file,
+                state_file=tmp_json_state_fp,
                 n_instances=1,
                 n_queries=2)
 
@@ -117,23 +145,37 @@ def test_nn_2_layer():
 @pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
                    raises=ImportError,
                    reason="requires tensorflow")
-def test_lstm_base():
+def test_lstm_base(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_h5_state_fp = Path(tmpdir, "tmp_state.h5")
+    copyfile(h5_state_file, tmp_h5_state_fp)
 
     check_model(config_file=Path(cfg_dir, "lstm_base.ini"),
-                state_file=h5_state_file)
+                state_file=tmp_h5_state_fp)
 
 
 @pytest.mark.xfail(not ADVANCED_DEPS["tensorflow"],
                    raises=ImportError,
                    reason="requires tensorflow")
-def test_lstm_pool():
+def test_lstm_pool(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(json_state_file, tmp_json_state_fp)
+
     check_model(config_file=Path(cfg_dir, "lstm_pool.ini"),
-                state_file=json_state_file)
+                state_file=tmp_json_state_fp)
 
 
-def test_logistic():
+def test_logistic(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_json_state_fp = Path(tmpdir, "tmp_state.json")
+    copyfile(json_state_file, tmp_json_state_fp)
+
     check_model(model="logistic",
-                state_file=json_state_file,
+                state_file=tmp_json_state_fp,
                 n_instances=1,
                 n_queries=2)
 
@@ -142,8 +184,14 @@ def test_classifiers():
     assert len(list_classifiers()) >= 7
 
 
-def test_partial_simulation():
+def test_partial_simulation(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_h5_state_fp = Path(tmpdir, "tmp_state.h5")
+    copyfile(h5_state_file, tmp_h5_state_fp)
+
     check_model(data_fp=data_fp_partial,
+                state_file=tmp_h5_state_fp,
                 n_prior_included=1,
                 n_prior_excluded=1,
                 prior_idx=None,
@@ -154,8 +202,14 @@ def test_partial_simulation():
     raises=ValueError,
     reason="prior_idx not available for partly labeled data"
 )
-def test_partial_simulation_2():
+def test_partial_simulation_2(tmpdir):
+
+    # copy state file to tmp dir for changes
+    tmp_h5_state_fp = Path(tmpdir, "tmp_state.h5")
+    copyfile(h5_state_file, tmp_h5_state_fp)
+
     check_model(data_fp=data_fp_partial,
+                state_file=tmp_h5_state_fp,
                 prior_idx=[0, 5],
                 state_checker=check_partial_state)
 
@@ -212,12 +266,12 @@ def check_model(monkeypatch=None,
                 state_checker=check_state,
                 prior_idx=[1, 2, 3, 4],
                 **kwargs):
-    if not continue_from_state:
-        try:
-            if state_file is not None:
-                os.unlink(state_file)
-        except OSError:
-            pass
+    # if not continue_from_state:
+    #     try:
+    #         if state_file is not None:
+    #             os.unlink(state_file)
+    #     except OSError as err:
+    #         print(err)
 
     if monkeypatch is not None:
         monkeypatch.setattr('builtins.input', lambda _: "0")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -8,17 +9,27 @@ from asreview.state import open_state, state_from_asreview_file
 from asreview.settings import ASReviewSettings
 
 
-def test_read_json_state():
+def test_read_json_state(tmpdir):
 
     state_fp = Path("tests", "state_files", "test_1_inst.json")
+    state_tmp_fp = Path(tmpdir, "test_1_inst.json")
 
-    with open_state(str(state_fp)) as state:
+    # copy state to open to tmpdir
+    shutil.copyfile(state_fp, state_tmp_fp)
+
+    with open_state(state_tmp_fp) as state:
         assert isinstance(state, JSONState)
 
 
-def test_read_hdf5_state():
+def test_read_hdf5_state(tmpdir):
+
     state_fp = Path("tests", "state_files", "test_1_inst.h5")
-    with open_state(str(state_fp)) as state:
+    state_tmp_fp = Path(tmpdir, "test_1_inst.h5")
+
+    # copy state to open to tmpdir
+    shutil.copyfile(state_fp, state_tmp_fp)
+
+    with open_state(state_tmp_fp) as state:
         assert isinstance(state, HDF5State)
 
 


### PR DESCRIPTION
Running the test suite results in unintentionally changed files (4 state files used for testing). This PR proposes a solution to avoid file changes.  