### PR TITLE
Add npm install to compile_assets.sh

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -12,9 +12,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "10.x"
-      - name: Install node_modules
-        run: |
-          cd asreview/webapp
       - name: Compile assets
         run: |
           python setup.py compile_assets

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -4,25 +4,24 @@ jobs:
   compile-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.6' # Version range or exact version of a Python version to use, using semvers version range syntax.
-        architecture: 'x64' # (x64 or x86)
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-    - name: Install node_modules
-      run: |
-        cd asreview/webapp
-        npm install
-    - name: Compile assets
-      run: |
-        python setup.py compile_assets
-    - name: Install pytest and package
-      run: |
-        pip install pytest
-        pip install --no-cache-dir .
-    - name: Test flask app
-      run: |
-        pytest asreview/webapp/tests
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.6" # Version range or exact version of a Python version to use, using semvers version range syntax.
+          architecture: "x64" # (x64 or x86)
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+      - name: Install node_modules
+        run: |
+          cd asreview/webapp
+      - name: Compile assets
+        run: |
+          python setup.py compile_assets
+      - name: Install pytest and package
+        run: |
+          pip install pytest
+          pip install --no-cache-dir .
+      - name: Test flask app
+        run: |
+          pytest asreview/webapp/tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,9 +26,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "10.x"
-      - name: Install node_modules
-        run: |
-          cd asreview/webapp
       - name: Compile assets
         run: |
           python setup.py compile_assets

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,71 +3,70 @@ name: Deploy and release
 on:
   push:
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Get the version (git tag)
-      id: get_version
-      run: |
-        echo ${GITHUB_REF/refs\/tags\/v/}
-        echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-    - name: Install node_modules
-      run: |
-        cd asreview/webapp
-        npm install
-    - name: Compile assets
-      run: |
-        python setup.py compile_assets
-    - name: Build
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Upload Release Asset (Wheel)
-      id: upload-release-asset-whl
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/asreview-${{ steps.get_version.outputs.VERSION }}-py3-none-any.whl
-        asset_name: asreview-${{ steps.get_version.outputs.VERSION }}-py3-none-any.whl
-        asset_content_type: application/x-wheel+zip
-    - name: Upload Release Asset (Sdist)
-      id: upload-release-asset-sdist
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/asreview-${{ steps.get_version.outputs.VERSION }}.tar.gz
-        asset_name: asreview-${{ steps.get_version.outputs.VERSION }}.tar.gz
-        asset_content_type: application/zip
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Get the version (git tag)
+        id: get_version
+        run: |
+          echo ${GITHUB_REF/refs\/tags\/v/}
+          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+      - name: Install node_modules
+        run: |
+          cd asreview/webapp
+      - name: Compile assets
+        run: |
+          python setup.py compile_assets
+      - name: Build
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset (Wheel)
+        id: upload-release-asset-whl
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/asreview-${{ steps.get_version.outputs.VERSION }}-py3-none-any.whl
+          asset_name: asreview-${{ steps.get_version.outputs.VERSION }}-py3-none-any.whl
+          asset_content_type: application/x-wheel+zip
+      - name: Upload Release Asset (Sdist)
+        id: upload-release-asset-sdist
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/asreview-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: asreview-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/zip
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/asreview/webapp/compile_assets.sh
+++ b/asreview/webapp/compile_assets.sh
@@ -1,3 +1,4 @@
 cd asreview/webapp/
 rm -rf build
+npm install
 npm run-script build


### PR DESCRIPTION
Add `npm install` to `asreview/webapp/compile_assets.sh` to fix the call `python setup.py compile_assets` used when manually setting up asreview. Fixes #488.