### PR TITLE
Improve contrast ratio

### DIFF
--- a/asreview/webapp/src/Components/ArticlePanel.js
+++ b/asreview/webapp/src/Components/ArticlePanel.js
@@ -20,10 +20,10 @@ const useStyles = makeStyles(theme => ({
   },
   titleDebug: {
     lineHeight: 1.2,
-    color: "#00C49F",
+    color: theme.overrides.debug.color,
   },
   debug: {
-    color: "#00C49F",
+    color: theme.overrides.debug.color,
   },
   abstract: {
     whiteSpace: "pre-line",

--- a/asreview/webapp/src/Components/DecisionBar.js
+++ b/asreview/webapp/src/Components/DecisionBar.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
   },
   unselectedAction: {},
   selectedAction: {
-    color: theme.palette.secondary.main
+    color: theme.palette.secondary.light,
   },
   notesField: {
     padding: theme.spacing(3),

--- a/asreview/webapp/src/Components/DecisionUndoBar.js
+++ b/asreview/webapp/src/Components/DecisionUndoBar.js
@@ -40,7 +40,7 @@ const DecisionUndoBar = (props) => {
           message={props.state.message}
           action={
             <React.Fragment>
-              <Button color="secondary" size="small" onClick={handleUndo}>
+              <Button variant="text" color="secondary" size="small" onClick={handleUndo}>
                 UNDO
               </Button>
             </React.Fragment>

--- a/asreview/webapp/src/Components/DecisionUndoBar.js
+++ b/asreview/webapp/src/Components/DecisionUndoBar.js
@@ -11,7 +11,10 @@ const useStyles = makeStyles(theme => ({
     },
   snackbar: {
     marginBottom: decisionUndoBarMarginBottom,
-  },  
+  },
+  undoButton: {
+    color: theme.palette.secondary.light,
+  },
 }));
 
 const DecisionUndoBar = (props) => {
@@ -40,7 +43,7 @@ const DecisionUndoBar = (props) => {
           message={props.state.message}
           action={
             <React.Fragment>
-              <Button variant="text" color="secondary" size="small" onClick={handleUndo}>
+              <Button className={classes.undoButton} size="small" onClick={handleUndo}>
                 UNDO
               </Button>
             </React.Fragment>

--- a/asreview/webapp/src/Components/MenuDrawer.js
+++ b/asreview/webapp/src/Components/MenuDrawer.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import {
   Drawer,
-  Link,
   List,
   // ListSubheader,
   ListItem,
@@ -138,7 +137,7 @@ const MenuDrawer = (props) => {
           <ListItem
             button
             key="menu-button-help"
-            component={Link}
+            component={"a"}
             color="inherit"
             href="https://asreview.readthedocs.io/"
             target="_blank"
@@ -149,7 +148,7 @@ const MenuDrawer = (props) => {
           <ListItem
             button
             key="menu-button-feedback"
-            component={Link}
+            component={"a"}
             color="inherit"
             href="https://github.com/asreview/asreview/blob/master/CONTRIBUTING.md"
             target="_blank"
@@ -162,7 +161,7 @@ const MenuDrawer = (props) => {
             <ListItem
               button
               key="menu-button-donate"
-              component={Link}
+              component={"a"}
               color="inherit"
               href={donateURL}
               target="_blank"
@@ -174,7 +173,7 @@ const MenuDrawer = (props) => {
           <ListItem
             button
             key="menu-button-about"
-            component={Link}
+            component={"a"}
             color="inherit"
             href="https://asreview.readthedocs.io/en/latest/intro/about.html"
             target="_blank"

--- a/asreview/webapp/src/Components/ReviewZone.js
+++ b/asreview/webapp/src/Components/ReviewZone.js
@@ -95,7 +95,7 @@ const ExplorationAlert = (props) => {
             href="https://asreview.readthedocs.io/en/latest/lab/exploration.html"
             target="_blank"
           >
-            <strong>Exploration Mode</strong>
+            Exploration Mode
           </Link>.
         </div>
       </Alert>

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -18,6 +18,11 @@ const useDarkMode = () => {
           color: "#DC004E",
         },
       },
+      MuiTypography: {
+        colorTextSecondary: {
+          color: "#555555",
+        },
+      },
     },
   };
 

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -35,6 +35,33 @@ const useDarkMode = () => {
           color: "#F48FB1",
         },
       },
+      MuiButton: {
+        textPrimary: {
+          color: "#CFA596",
+        },
+        outlinedPrimary: {
+          color: "#CFA596",
+        },
+      },
+      MuiTypography: {
+        colorPrimary: {
+          color: "#CFA596",
+        },
+      },
+      MuiFormLabel: {
+        root: {
+          "&$focused": {
+            color: "#CFA596",
+          }, 
+        },
+      },
+      MuiTab: {
+        textColorPrimary: {
+          "&$selected": {
+            color: "#CFA596",
+          },
+        },
+      },
     },
   }
 
@@ -57,8 +84,6 @@ const useDarkMode = () => {
       setTheme(darkTheme)
     }
   }, [darkTheme, theme.palette.type]);
-
-  console.log(theme);
 
   return [theme, toggleDarkMode]
 };

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -10,6 +10,9 @@ const useDarkMode = () => {
       primary: brown,
     },
     overrides: {
+      debug: {
+        color: "#1E824C",
+      },
       MuiLink: {
         root: {
           color: "#DC004E",
@@ -24,6 +27,9 @@ const useDarkMode = () => {
       primary: brown,
     },
     overrides: {
+      debug: {
+        color: "#65A665",
+      },
       MuiLink: {
         root: {
           color: "#F48FB1",

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -44,6 +44,9 @@ const useDarkMode = () => {
         textPrimary: {
           color: "#CFA596",
         },
+        textSecondary: {
+          color: "#F48FB1",
+        },
         outlinedPrimary: {
           color: "#CFA596",
         },

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -4,32 +4,55 @@ import brown from '@material-ui/core/colors/brown';
 
 const useDarkMode = () => {
 
-  let defaultTheme = {
+  let lightTheme = {
     palette: {
       type: "light",
       primary: brown,
     },
+    overrides: {
+      MuiLink: {
+        root: {
+          color: "#DC004E",
+        },
+      },
+    },
   };
 
-  const [theme, setTheme] = useState(defaultTheme);
+  let darkTheme = {
+    palette: {
+      type: "dark",
+      primary: brown,
+    },
+    overrides: {
+      MuiLink: {
+        root: {
+          color: "#F48FB1",
+        },
+      },
+    },
+  }
+
+  const [theme, setTheme] = useState(lightTheme);
 
   const toggleDarkMode = () => {
 
     if (theme.palette.type === "light") {
       window.localStorage.setItem("themeType", "dark")
-      setTheme({palette: {...defaultTheme.palette, type: "dark"}})
+      setTheme(darkTheme)
     } else {
       window.localStorage.setItem("themeType", "light")
-      setTheme(defaultTheme)
+      setTheme(lightTheme)
     }
   };
 
   useEffect(() => {
     const localTheme = window.localStorage.getItem("themeType");
     if (theme.palette.type !== localTheme && localTheme !== null) {
-      setTheme({palette: {...defaultTheme.palette, type: "dark"}})
+      setTheme(darkTheme)
     }
-  }, [defaultTheme.palette, theme.palette.type]);
+  }, [darkTheme, theme.palette.type]);
+
+  console.log(theme);
 
   return [theme, toggleDarkMode]
 };

--- a/asreview/webapp/src/hooks/SettingsHooks.js
+++ b/asreview/webapp/src/hooks/SettingsHooks.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import brown from '@material-ui/core/colors/brown';
+import red from '@material-ui/core/colors/red';
 
 
 const useDarkMode = () => {
@@ -7,7 +8,9 @@ const useDarkMode = () => {
   let lightTheme = {
     palette: {
       type: "light",
-      primary: brown,
+      primary: {
+        main: brown[500],
+      },
     },
     overrides: {
       debug: {
@@ -29,7 +32,12 @@ const useDarkMode = () => {
   let darkTheme = {
     palette: {
       type: "dark",
-      primary: brown,
+      primary: {
+        main: brown[500],
+      },
+      secondary: {
+        main: red[500],
+      },
     },
     overrides: {
       debug: {
@@ -43,9 +51,6 @@ const useDarkMode = () => {
       MuiButton: {
         textPrimary: {
           color: "#CFA596",
-        },
-        textSecondary: {
-          color: "#F48FB1",
         },
         outlinedPrimary: {
           color: "#CFA596",


### PR DESCRIPTION
In response to #362, this PR improves the contrast ratio according to [WCAG guidelines](https://webaim.org/blog/wcag-2-0-and-link-colors/) on several pages either in light or dark mode.

- [x] Links
- [x] Document texts in the Exploration Mode
- [x] Other places have brown texts with black background

![image](https://user-images.githubusercontent.com/17449217/112974145-6b641900-9152-11eb-9954-99c977a9695c.png)

![image](https://user-images.githubusercontent.com/17449217/112749777-e8fa1e80-8fc4-11eb-8f49-d60ad1e07f9b.png)

![image](https://user-images.githubusercontent.com/17449217/112973954-293ad780-9152-11eb-82d1-9e3b3ca945ea.png)
