### PR TITLE
Fix multiple calls to info api on project page

### DIFF
--- a/asreview/webapp/src/PreReviewComponents/ProjectPage.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectPage.js
@@ -182,7 +182,7 @@ const ProjectPage = (props) => {
     };
 
     fetchProjectInfo();
-  }, [props.project_id, state.finished, error.message]);
+  }, [props.project_id, error.message]);
 
   return (
     <Box>


### PR DESCRIPTION
This PR fixes multiple calls to `info` API while opening the project dashboard.