### PR TITLE
Fix line chart read data before loaded

### DIFF
--- a/asreview/webapp/src/SideStats/ProgressLineChart.js
+++ b/asreview/webapp/src/SideStats/ProgressLineChart.js
@@ -16,8 +16,8 @@ const CustomTooltip = ({ active, payload, label }) => {
       <div className="custom-tooltip">
         <p className="label">{`Total reviewed: ${label}`}</p>
         <p className="intro">Relevant found</p>
-        <p className="asreview">{`By ASReview: ${payload[0].value}`}</p>
-        <p className="random">{`At random: ${payload[1].value}`}</p>
+        <p className="asreview">{`By ASReview: ${payload ? payload[0].value : "null"}`}</p>
+        <p className="random">{`At random: ${payload ? payload[1].value : "null"}`}</p>
       </div>
     );
   }


### PR DESCRIPTION
This PR fixes the possible failure of the progress line chart on the project page. The custom tooltip might try to read data before it is loaded.