### PR TITLE
Added quick link to Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Upgrade ASReview with the following command:
 pip install --upgrade asreview
 ```
 
-Instructions for usage with Docker are [here](docker/README.md)
+Instructions for usage with Docker are [here](docker/README.md).
 
 ## ASReview LAB
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Upgrade ASReview with the following command:
 pip install --upgrade asreview
 ```
 
+Instructions for usage with Docker are [here](docker/README.md)
+
 ## ASReview LAB
 
 ASReview LAB is a user-friendly interface for screening documents and


### PR DESCRIPTION
I just learned from Rens, that the Docker version of asreview is very successful, but I did not find a "quick link" to the Docker instructions in the main README.