### PR TITLE
Add doi to Configuration File

### DIFF
--- a/asreview/config.py
+++ b/asreview/config.py
@@ -49,4 +49,5 @@ COLUMN_DEFINITIONS = {
     "authors": ["authors", "author names", "first_authors"],
     "abstract": ["abstract", "abstract note", "notes_abstract"],
     "keywords": ["keywords"],
+    "doi": ["doi"],
 }

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -322,6 +322,13 @@ class ASReviewData():
         except KeyError:
             return None
 
+    @property
+    def doi(self):
+        try:
+            return self.df[self.column_spec["doi"]].values
+        except KeyError:
+            return None
+
     def get(self, name):
         "Get column with name."
         try:

--- a/asreview/io/paper_record.py
+++ b/asreview/io/paper_record.py
@@ -131,7 +131,7 @@ class PaperRecord():
     def __init__(self, record_id, column_spec={}, **kwargs):
 
         for attr in [
-                "title", "abstract", "authors", "keywords", "included"
+                "title", "abstract", "authors", "keywords", "doi", "included"
         ]:
             if attr in column_spec:
                 col = column_spec[attr]

--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -273,6 +273,7 @@ def get_paper_data(project_id,
                    return_title=True,
                    return_authors=True,
                    return_abstract=True,
+                   return_doi=True,
                    return_debug_label=False):
     """Get the title/authors/abstract for a paper."""
     as_data = read_data(project_id)
@@ -285,14 +286,12 @@ def get_paper_data(project_id,
         paper_data['authors'] = record.authors
     if return_abstract and record.abstract is not None:
         paper_data['abstract'] = record.abstract
+    if return_doi and record.doi is not None:
+        paper_data['doi'] = record.doi
 
     # return the publication data if available
     pub_time = record.extra_fields.get("publish_time", None)
     paper_data['publish_time'] = pub_time if pd.notnull(pub_time) else None
-
-    # return the doi if available
-    doi = record.extra_fields.get("doi", None)
-    paper_data['doi'] = doi if pd.notnull(doi) else None
 
     # return the debug label
     debug_label = record.extra_fields.get("debug_label", None)


### PR DESCRIPTION
This PR adds `doi` to the configuration file of the software. The column name `doi` of a dataset file is then not case-sensitive.