### PR TITLE
Improve Help Text & Documentation of Supported Dataset Formats

### DIFF
--- a/asreview/webapp/src/PreReviewComponents/ProjectUpload.js
+++ b/asreview/webapp/src/PreReviewComponents/ProjectUpload.js
@@ -439,9 +439,11 @@ const ProjectUpload = ({
               From file/URL:
               <Typography variant="body2" gutterBottom>
                 Select a file from your computer or fill in a link to a file
-                from the Internet. The accepted file formats are CSV, Excel,
-                TSV, and RIS. The selected dataset should contain the title and
-                abstract of each record. Read more about
+                from the Internet. ASReview accepts RIS file format (
+                <code>.ris</code>, <code>.txt</code>) and tabular datasets (
+                <code>.csv</code>, <code>.tab</code>, <code>.tsv</code>,{" "}
+                <code>.xlsx</code>). The selected dataset should contain the
+                title and abstract of each record. Read more about
                 <Link
                   className={classes.link}
                   href="https://asreview.readthedocs.io/en/latest/intro/datasets.html"

--- a/docs/source/intro/datasets.rst
+++ b/docs/source/intro/datasets.rst
@@ -36,8 +36,8 @@ formats:
    IEEE Xplore, Scopus and ScienceDirect. Citation managers Mendeley, RefWorks,
    Zotero, and EndNote support the RIS file format as well.
 
- - **Tabular datasets** with extensions ``.csv``, ``.tab``, ``.tsv``, ``.xlsx``,
-   or ``.xls``. CSV and TAB files are preferably comma, semicolon, or tab-delimited.
+ - **Tabular datasets** with extensions ``.csv``, ``.tab``, ``.tsv``, or ``.xlsx``.
+   CSV and TAB files are preferably comma, semicolon, or tab-delimited.
    The preferred file encoding is *UTF-8* or *latin1*.
 
 For tabular data files, the software accepts a set of predetermined column names:


### PR DESCRIPTION
This PR adds supported dataset formats to the help text when selecting a dataset to upload and removes `xls` from the corresponding documentation.

![image](https://user-images.githubusercontent.com/17449217/123450277-dbacfa00-d5dc-11eb-9ba3-696cdf8da656.png)
