### PR TITLE
Add one-click-deploy buttons

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,3 +109,13 @@ follow the guidelines below.
 4. [OPTIONAL] Crop relevant part. Keep ratio if possible.
 5. Resize image to **1280x800** maximum and **960x600** minimum.
 6. [OPTIONAL] Use a red box to highlight relevant components.
+
+## EXPERIMENTAL: One Click Deploy for ASReview LAB
+
+You can deploy ASReview LAB right now in one click on any of these clouds providers:
+
+[<img src="https://aka.ms/deploytoazurebutton" height="30px">](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fasreview%2Fasreview%2Fmaster%2Fazuredeploy.json)
+[<img src="https://deploy.cloud.run/button.svg" height="30px">](https://deploy.cloud.run)
+[<img src="https://www.herokucdn.com/deploy/button.svg" height="30px">](https://heroku.com/deploy?template=https://github.com/asreview/asreview/tree/master)
+
+❗❗❗ ASReview doens't have builtin authentication. You are responsible for the authentication and security of the server yourself.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Tour](https://asreview.readthedocs.io/en/latest/lab/overview_lab.html).
 
 [![ASReview LAB](https://github.com/asreview/asreview/blob/master/images/ASReviewWebApp.png?raw=true)](https://asreview.readthedocs.io/en/latest/lab/overview_lab.html "ASReview LAB Quick Tour")
 
+## One Click Deploy for ASReview LAB
+
+You can deploy ASReview LAB right now in one click on any of these clouds providers:
+
+[<img src="https://aka.ms/deploytoazurebutton" height="30px">](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fasreview%2Fasreview%2Fmaster%2Fazuredeploy.json)
+[<img src="https://deploy.cloud.run/button.svg" height="30px">](https://deploy.cloud.run)
+[<img src="https://www.herokucdn.com/deploy/button.svg" height="30px">](https://heroku.com/deploy?template=https://github.com/asreview/asreview/tree/master)
+
 ## Covid-19 plugin
 
 [![Covid-19 Plugin](https://github.com/asreview/asreview/blob/master/images/intro-covid19-small.png?raw=true)](https://github.com/asreview/asreview-covid19 "ASReview against COVID-19")

--- a/README.md
+++ b/README.md
@@ -63,14 +63,6 @@ Tour](https://asreview.readthedocs.io/en/latest/lab/overview_lab.html).
 
 [![ASReview LAB](https://github.com/asreview/asreview/blob/master/images/ASReviewWebApp.png?raw=true)](https://asreview.readthedocs.io/en/latest/lab/overview_lab.html "ASReview LAB Quick Tour")
 
-## One Click Deploy for ASReview LAB
-
-You can deploy ASReview LAB right now in one click on any of these clouds providers:
-
-[<img src="https://aka.ms/deploytoazurebutton" height="30px">](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fasreview%2Fasreview%2Fmaster%2Fazuredeploy.json)
-[<img src="https://deploy.cloud.run/button.svg" height="30px">](https://deploy.cloud.run)
-[<img src="https://www.herokucdn.com/deploy/button.svg" height="30px">](https://heroku.com/deploy?template=https://github.com/asreview/asreview/tree/master)
-
 ## Covid-19 plugin
 
 [![Covid-19 Plugin](https://github.com/asreview/asreview/blob/master/images/intro-covid19-small.png?raw=true)](https://github.com/asreview/asreview-covid19 "ASReview against COVID-19")

--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+    "name": "ASReview",
+    "description": "Active learning for Systematic Reviews",
+    "keywords": [
+        "active learning",
+        "systematic reviews"
+    ],
+    "website": "https://asreview.nl/",
+    "repository": "https://github.com/asreview/asreview/docker/asreview-lab/",
+    "logo": "https://github.com/asreview/asreview/blob/master/images/RepoCardGithub-1280x640px.png",
+    "stack": "container",
+    "env": {
+        "ASREVIEW_ONE_CLICK_DEPLOY": {
+            "description": "ASReview One Click Deploy Environmental Flag",
+            "value": "1",
+            "required": false
+        }
+    },
+    "options": {
+        "allow-unauthenticated": false,
+        "memory": "512Mi",
+        "cpu": "2",
+        "port": "80",
+        "http2": false
+    }
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,112 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "type": "string",
+            "defaultValue": "asreview-container-group",
+            "metadata": {
+                "description": "Name for the container group"
+            }
+        },
+        "containername": {
+            "type": "string",
+            "metadata": {
+                "description": "Name for the container"
+            }
+        },
+        "image": {
+            "type": "string",
+            "defaultValue": "asreview/asreview:latest",
+            "metadata": {
+                "description": "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."
+            }
+        },
+        "port": {
+            "type": "string",
+            "defaultValue": "5000",
+            "metadata": {
+                "description": "Port to open on the container and the public IP address."
+            }
+        },
+        "cpuCores": {
+            "type": "string",
+            "defaultValue": "1.0",
+            "metadata": {
+                "description": "The number of CPU cores to allocate to the container."
+            }
+        },
+        "memoryInGb": {
+            "type": "string",
+            "defaultValue": "1.5",
+            "metadata": {
+                "description": "The amount of memory to allocate to the container in gigabytes."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "restartPolicy": {
+            "type": "string",
+            "defaultValue": "always",
+            "allowedValues": [
+                "never",
+                "always",
+                "onfailure"
+            ],
+            "metadata": {
+                "description": "The behavior of Azure runtime if container has stopped."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ContainerInstance/containerGroups",
+            "apiVersion": "2019-12-01",
+            "name": "[parameters('name')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "containers": [
+                    {
+                        "name": "[parameters('name')]",
+                        "properties": {
+                            "image": "[parameters('image')]",
+                            "ports": [
+                                {
+                                    "port": "[parameters('port')]"
+                                }
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "cpu": "[parameters('cpuCores')]",
+                                    "memoryInGb": "[parameters('memoryInGb')]"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "osType": "Linux",
+                "restartPolicy": "[parameters('restartPolicy')]",
+                "ipAddress": {
+                    "type": "Public",
+                    "ports": [
+                        {
+                            "protocol": "Tcp",
+                            "port": "[parameters('port')]"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "containerIPv4Address": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('name'))).ipAddress.ip]"
+        }
+    }
+}

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -1,0 +1,12 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "containername": {
+         "value": "GEN-UNIQUE"
+      },
+      "volumename": {
+         "value": "GEN-UNIQUE"
+      }
+   }
+}


### PR DESCRIPTION
Add one-click-deploy buttons:
- Azure
- Heroku
- Google Cloud

Given that Heroku and GC could not be tested on a private repository, this PR will be used to test them (thus more commits will follow).