### PR TITLE
Add Styled OpenInNewIcon Component

### DIFF
--- a/asreview/webapp/src/Components/OpenInNewIconStyled.js
+++ b/asreview/webapp/src/Components/OpenInNewIconStyled.js
@@ -1,0 +1,23 @@
+import React from "react";
+import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "inline-flex",
+    alignSelf: "center",
+    top: ".125em",
+    position: "relative",
+  },
+}));
+
+const OpenInNewIconStyled = (props) => {
+  const classes = useStyles();
+
+  return (
+    <OpenInNewIcon className={classes.root} color="disabled" fontSize="small" />
+  );
+};
+
+export default OpenInNewIconStyled;

--- a/asreview/webapp/src/Components/index.js
+++ b/asreview/webapp/src/Components/index.js
@@ -9,3 +9,4 @@ export { default as ImportDialog } from "./ImportDialog";
 export { default as DialogTitleWithClose } from "./DialogTitleWithClose";
 export { default as AppBarWithinDialog } from "./AppBarWithinDialog";
 export { default as QuickTourDialog } from "./QuickTourDialog";
+export { default as OpenInNewIconStyled } from "./OpenInNewIconStyled";


### PR DESCRIPTION
This PR adds a styled OpenInNewIcon component. It is used in different cases when a clickable button directs users to a new window.