### PR TITLE
Bump minimal flask version to 2

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -780,8 +780,8 @@ def export_results(project_id):
             fp_tmp_export,
             mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # noqa
             as_attachment=True,
-            attachment_filename=f"asreview_result_{project_id}.xlsx",
-            cache_timeout=0)
+            download_name=f"asreview_result_{project_id}.xlsx",
+            max_age=0)
 
 
 @bp.route('/project/<project_id>/export_project', methods=["GET"])
@@ -815,8 +815,8 @@ def export_project(project_id):
     return send_file(
         str(Path(tmpdir.name, f"{project_id}.zip")),
         as_attachment=True,
-        attachment_filename=f"{project_id}.asreview",
-        cache_timeout=0)
+        download_name=f"{project_id}.asreview",
+        max_age=0)
 
 
 @bp.route('/project/<project_id>/finish', methods=["GET"])

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'h5py',
         'xlrd>=1.0.0',
         'setuptools',
-        'flask>=1.1',
+        'flask>=2.0',
         'flask_cors',
         'openpyxl',
         'gevent',


### PR DESCRIPTION
Fix the following warnings and bump minimal flask version. 

```
asreview/webapp/tests/test_project.py: 16 warnings
  /home/runner/work/asreview/asreview/asreview/webapp/api.py:784: DeprecationWarning: The 'attachment_filename' parameter has been renamed to 'download_name'. The old name will be removed in Flask 2.1.
    cache_timeout=0)

asreview/webapp/tests/test_api.py: 1 warning
asreview/webapp/tests/test_project.py: 16 warnings
  /home/runner/work/asreview/asreview/asreview/webapp/api.py:784: DeprecationWarning: The 'cache_timeout' parameter has been renamed to 'max_age'. The old name will be removed in Flask 2.1.
    cache_timeout=0)
```