### PR TITLE
Add Mobile Screen State to Top Level

### DIFF
--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { CssBaseline, createMuiTheme } from "@material-ui/core";
+import { CssBaseline, createMuiTheme, useMediaQuery } from "@material-ui/core";
 import { ThemeProvider } from "@material-ui/core/styles";
 import "./App.css";
 
@@ -57,6 +57,7 @@ const App = (props) => {
   const [keyPressEnabled, toggleKeyPressEnabled] = useKeyPressEnabled();
 
   const muiTheme = createMuiTheme(theme);
+  const mobileScreen = useMediaQuery(muiTheme.breakpoints.down("sm"));
 
   // Dialog toggle
   const toggleSettings = () => {
@@ -119,12 +120,20 @@ const App = (props) => {
       {props.app_state === "review" && (
         <ReviewDialog
           handleAppState={props.setAppState}
+          mobileScreen={mobileScreen}
           onReview={review}
           toggleReview={toggleReview}
           toggleHistory={toggleHistory}
           fontSize={fontSize}
           undoEnabled={undoEnabled}
           keyPressEnabled={keyPressEnabled}
+        />
+      )}
+      {props.app_state === "review" && (
+        <HistoryDialog
+          mobileScreen={mobileScreen}
+          toggleHistory={toggleHistory}
+          history={history}
         />
       )}
 
@@ -137,6 +146,7 @@ const App = (props) => {
 
       {/* Dialogs */}
       <SettingsDialog
+        mobileScreen={mobileScreen}
         onSettings={settings}
         onDark={theme}
         fontSize={fontSize}
@@ -148,15 +158,16 @@ const App = (props) => {
         toggleKeyPressEnabled={toggleKeyPressEnabled}
         toggleUndoEnabled={toggleUndoEnabled}
       />
-      <HelpDialog onHelp={help} toggleHelp={toggleHelp} />
+      <HelpDialog
+        mobileScreen={mobileScreen}
+        onHelp={help}
+        toggleHelp={toggleHelp}
+      />
       <ExitDialog toggleExit={toggleExit} exit={exit} />
       <ExportDialog
         toggleExportResult={toggleExportResult}
         exportResult={exportResult}
       />
-      {props.app_state === "review" && (
-        <HistoryDialog toggleHistory={toggleHistory} history={history} />
-      )}
     </ThemeProvider>
   );
 };

--- a/asreview/webapp/src/HelpDialog.js
+++ b/asreview/webapp/src/HelpDialog.js
@@ -12,14 +12,13 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
-  useMediaQuery,
 } from "@material-ui/core";
 
 import FeedbackIcon from "@material-ui/icons/Feedback";
 import DescriptionIcon from "@material-ui/icons/Description";
 import QuestionAnswerIcon from "@material-ui/icons/QuestionAnswer";
 
-import { makeStyles, useTheme } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 
 import { UtilsAPI } from "./api/index.js";
 
@@ -56,8 +55,6 @@ const useStyles = makeStyles((theme) => ({
 const HelpDialog = (props) => {
   const classes = useStyles();
   const descriptionElementRef = useRef(null);
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   const [faq, setFaq] = useState(null);
   const [error, setError] = useState({
@@ -96,7 +93,7 @@ const HelpDialog = (props) => {
   return (
     <div>
       <Dialog
-        fullScreen={fullScreen}
+        fullScreen={props.mobileScreen}
         open={props.onHelp}
         onClose={props.toggleHelp}
         scroll="paper"

--- a/asreview/webapp/src/InReviewComponents/DecisionButton.js
+++ b/asreview/webapp/src/InReviewComponents/DecisionButton.js
@@ -47,12 +47,12 @@ const DecisionButton = (props) => {
   return (
     <div
       className={clsx(classes.root, {
-        [classes.rootMobile]: props.mobile,
+        [classes.rootMobile]: props.mobileScreen,
       })}
     >
       <Fab
         onClick={() => props.makeDecision(0)}
-        size={props.mobile ? "small" : "large"}
+        size={props.mobileScreen ? "small" : "large"}
         variant="extended"
       >
         <FavoriteBorder className={classes.extendedFab} />
@@ -61,7 +61,7 @@ const DecisionButton = (props) => {
       <Fab
         onClick={() => props.makeDecision(1)}
         color="primary"
-        size={props.mobile ? "small" : "large"}
+        size={props.mobileScreen ? "small" : "large"}
         variant="extended"
       >
         <Favorite className={classes.extendedFab} />

--- a/asreview/webapp/src/InReviewComponents/ReviewDialog.js
+++ b/asreview/webapp/src/InReviewComponents/ReviewDialog.js
@@ -1,12 +1,7 @@
 import React, { useState, useEffect } from "react";
 import clsx from "clsx";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
-import {
-  Dialog,
-  DialogContent,
-  DialogActions,
-  useMediaQuery,
-} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { Dialog, DialogContent, DialogActions } from "@material-ui/core";
 
 import { AppBarWithinDialog } from "../Components";
 import {
@@ -61,8 +56,6 @@ const mapStateToProps = (state) => {
 
 const ReviewDialog = (props) => {
   const classes = useStyles();
-  const theme = useTheme();
-  const mobile = !useMediaQuery(theme.breakpoints.up("sm"));
 
   /**
    * Exploration mode banner state
@@ -354,12 +347,12 @@ const ReviewDialog = (props) => {
    * Hide side statistics on mobile screen
    */
   useEffect(() => {
-    if (mobile) {
+    if (props.mobileScreen) {
       setSideSheet(false);
     } else {
       setSideSheet(true);
     }
-  }, [mobile]);
+  }, [props.mobileScreen]);
 
   /**
    * Use keyboard shortcuts
@@ -407,7 +400,7 @@ const ReviewDialog = (props) => {
         {/* Banner Exploration Mode */}
         <div
           className={clsx(classes.content, {
-            [classes.contentShift]: !mobile && sideSheet,
+            [classes.contentShift]: !props.mobileScreen && sideSheet,
           })}
         >
           <ExplorationModeBanner banner={banner} setBanner={setBanner} />
@@ -417,7 +410,7 @@ const ReviewDialog = (props) => {
         <DialogContent
           style={{ height: "100%" }}
           className={clsx(classes.content, {
-            [classes.contentShift]: !mobile && sideSheet,
+            [classes.contentShift]: !props.mobileScreen && sideSheet,
           })}
         >
           <RecordCard
@@ -432,12 +425,12 @@ const ReviewDialog = (props) => {
         {/* Decision button */}
         <DialogActions
           className={clsx(classes.content, {
-            [classes.contentShift]: !mobile && sideSheet,
+            [classes.contentShift]: !props.mobileScreen && sideSheet,
           })}
         >
           <DecisionButton
             makeDecision={makeDecision}
-            mobile={mobile}
+            mobileScreen={props.mobileScreen}
             previousSelection={recordState["selection"]}
           />
         </DialogActions>
@@ -450,7 +443,7 @@ const ReviewDialog = (props) => {
         {/* Decision undo bar */}
         <div
           className={clsx(classes.content, {
-            [classes.contentShift]: !mobile && sideSheet,
+            [classes.contentShift]: !props.mobileScreen && sideSheet,
           })}
         >
           <DecisionUndoBar
@@ -462,7 +455,7 @@ const ReviewDialog = (props) => {
 
         {/* Statistics side sheet */}
         <StatsSheet
-          mobile={mobile}
+          mobileScreen={props.mobileScreen}
           onSideSheet={sideSheet}
           toggleSideSheet={toggleSideSheet}
           statistics={statistics}

--- a/asreview/webapp/src/InReviewComponents/StatsSheet.js
+++ b/asreview/webapp/src/InReviewComponents/StatsSheet.js
@@ -57,7 +57,7 @@ const StatsSheet = (props) => {
 
   const drawer = (
     <div>
-      {!props.mobile && (
+      {!props.mobileScreen && (
         <div>
           <Toolbar />
           <div className={classes.drawerHeader}>
@@ -100,7 +100,7 @@ const StatsSheet = (props) => {
           container={container}
           variant="temporary"
           anchor="right"
-          open={props.mobile && props.onSideSheet}
+          open={props.mobileScreen && props.onSideSheet}
           onClose={props.toggleSideSheet}
           classes={{ paper: classes.drawerPaper }}
           ModalProps={{
@@ -118,7 +118,7 @@ const StatsSheet = (props) => {
           }}
           variant="persistent"
           anchor="right"
-          open={!props.mobile && props.onSideSheet}
+          open={!props.mobileScreen && props.onSideSheet}
         >
           {drawer}
         </Drawer>

--- a/asreview/webapp/src/SettingsDialog.js
+++ b/asreview/webapp/src/SettingsDialog.js
@@ -16,9 +16,8 @@ import {
   Switch,
   Slider,
   Typography,
-  useMediaQuery,
 } from "@material-ui/core";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 
 import { AppBarWithinDialog, OpenInNewIconStyled } from "./Components";
@@ -72,8 +71,6 @@ const SettingsDialog = (props) => {
   const classes = useStyles();
 
   const descriptionElementRef = useRef(null);
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   // second layer state
   const [fontSizeSetting, setFontSizeSetting] = useState(false);
@@ -116,7 +113,7 @@ const SettingsDialog = (props) => {
   return (
     <div>
       <Dialog
-        fullScreen={fullScreen}
+        fullScreen={props.mobileScreen}
         open={props.onSettings}
         onClose={props.toggleSettings}
         onExited={exitSettings}


### PR DESCRIPTION
This PR adds a state that indicates the screen size to the top level. This state has already been used in the settings, help, and review dialog and will be used in the history dialog.