### PR TITLE
Add min stopping plots

### DIFF
--- a/asreview/analysis/analysis.py
+++ b/asreview/analysis/analysis.py
@@ -165,8 +165,18 @@ class Analysis():
             x_norm /= len(labels)
             y_norm /= self.inc_found[fl]["inc_after_init"]
 
-        norm_xr = (np.arange(1,
-                             len(self.inc_found[fl]["avg"]) + 1) - dx) / x_norm
+        # extend the arrays if all relevant records have been found
+        total_inc_found = int(self.inc_found[fl]["avg"][-1])
+        if total_inc_found == self.inc_found[fl]["inc_after_init"]:
+            norm_xr = np.arange(1, 1 + len(labels) -
+                                self.inc_found[fl]["n_initial"]) / x_norm
+            missing_y = len(labels) - self.inc_found[fl]["n_initial"] - \
+                len(self.inc_found[fl]["avg"])
+            self.inc_found[fl]["avg"].extend([total_inc_found] * missing_y)
+        else:
+            norm_xr = (np.arange(1, len(self.inc_found[fl]["avg"]) + 1) - dx)\
+                      / x_norm
+
         norm_yr = (np.array(self.inc_found[fl]["avg"]) - dy) / y_norm
         norm_y_err = np.array(self.inc_found[fl]["err"]) / y_norm
 


### PR DESCRIPTION
Continuation of [#605](https://github.com/asreview/asreview/pull/605) (see also [#598](https://github.com/asreview/asreview/issues/598)). Currently when using the min stopping option to run simulations, the visualization plugin will create a recall plot that looks like this:

![image](https://user-images.githubusercontent.com/42623130/129489899-bfa21764-0369-4548-b763-bb10d1625986.png)

The code in this pull request extends the recall plot (when all relevant records have been found), so it looks this instead:

![1000](https://user-images.githubusercontent.com/42623130/129489924-9b3193ab-a937-4402-8708-bb671e621d9d.png)

By making the changes in analysis.py as suggested here, no changes are needed to the state file or to the visualization plugin. One downside of the current implementation is that it would become default behavior and cannot be turned off by the user through the CLI. I'm not sure how to best address that.