### PR TITLE
Remove duplicate information from the documentation

### DIFF
--- a/docs/source/extensions/extension_visualization.rst
+++ b/docs/source/extensions/extension_visualization.rst
@@ -228,13 +228,13 @@ Save the plot to the disk.
     my_plot.save("myreview_plot.png")
 
 To change the plot from relative to absolute values, an argument can be added 
-to the plot the following way. ``result_format`` can be set to "number" for 
+to the plot the following way. ``INSERT_RESULT_FORMAT`` can be set to "number" for 
 absolute values or "percentage" (default) for percentages.
 
 .. code:: python
 
     with Plot.from_paths(["myreview.h5"]) as plot:
-        my_plot = plot.new(plot_type="type", result_format="plot_format")
+        my_plot = plot.new(plot_type="type", result_format="INSERT_RESULT_FORMAT")
 
 
 Examples using the API can be found in module :code:`asreviewcontrib.visualization.quick`.

--- a/docs/source/extensions/extension_visualization.rst
+++ b/docs/source/extensions/extension_visualization.rst
@@ -174,11 +174,6 @@ Multiple plots can be generated at the same time by adding the state files to
 a list; ["myreview.h5", "myreview_2.h5"].
 
 
-.. option:: result_format="plot_format"
-
-    Can be set to "number" for absolute values or "percentage" (default) for percentages.
-
-
 API Advanced usage
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR removes a duplicate piece of information from the documentation, added on accident with PR #717 .