### PR TITLE
Add Extension CNN-HPO to documentation

### DIFF
--- a/docs/source/extensions/overview_extensions.rst
+++ b/docs/source/extensions/overview_extensions.rst
@@ -62,13 +62,11 @@ The following extensions are developed and maintained by the ASReview community:
 * ASReview NB + CNN classifier with HPO
     - This extension adds a model consisting out of two seperate classifiers 
       for use during simulation mode. The first *X* amount of iterations 
-      (default = 500) are run with a Naïve Bayes model. After the switchpoint 
-      of 500 iterations, a switch to a CNN is made. Immediately at this 
-      switching point, and subsequently after each 150 iterations, 
-      hyperparamater optimisation is conducted in order to find the most 
-      suitable CNN architecture for the specific amount of data that is being 
-      utilised at that moment.
-    - `Github <https://github.com/BartJanBoverhof/asreview-cnn-hpo>`__
+      (default = 500) are run with a Naïve Bayes model. After the switchpoint,
+      a switch to a CNN is made. Immediately at this switching point, and 
+      then after each 150 iterations, hyperparameter optimisation is conducted 
+      to find the most suitable CNN architecture for current iteration.
+    - `Github <https://github.com/BartJanBoverhof/asreview-cnn-hpo>`__ 
 
 
 If an extension is not on this list, or you made one and you would like it to 

--- a/docs/source/extensions/overview_extensions.rst
+++ b/docs/source/extensions/overview_extensions.rst
@@ -28,9 +28,12 @@ of the core project:
 - `ASReview-statistics <https://github.com/asreview/asreview-statistics>`__: 
   Tool to give some basic properties of a dataset, such as number of papers, 
   number of inclusions. 
-
-.. - `ASReview-vocab-extractor <https://github.com/asreview/asreview-extension-vocab-extractor>`__: This extension adds two feature extractors that extract vocabulary and vector matrices during simulation phases.
-.. - ``asreview-hyperopt``: Optimize the hyperparameters of the models in ASReview. `GitHub <https://github.com/asreview/asreview-hyperopt>`__
+- `ASReview-vocab-extractor <https://github.com/asreview/asreview-extension-vocab-extractor>`__: 
+  This extension adds two feature extractors that extract vocabulary and 
+  vector matrices during simulation phases. Might one day be integrated to the 
+  core.
+- `ASReview-hyperopt <https://github.com/asreview/asreview-hyperopt>`__: 
+  Optimize the hyperparameters of the models in ASReview.
 
 
 
@@ -55,6 +58,17 @@ The following extensions are developed and maintained by the ASReview community:
       runtime. It can be useful for when later stages of data classification 
       require different models.
     - `Github <https://github.com/JTeijema/asreview-plugin-model-switcher>`__
+
+* ASReview NB + CNN classifier with HPO
+    - This extension adds a model consisting out of two seperate classifiers 
+      for use during simulation mode. The first *X* amount of iterations 
+      (default = 500) are run with a Naïve Bayes model. After the switchpoint 
+      of 500 iterations, a switch to a CNN is made. Immediately at this 
+      switching point, and subsequently after each 150 iterations, 
+      hyperparamater optimisation is conducted in order to find the most 
+      suitable CNN architecture for the specific amount of data that is being 
+      utilised at that moment.
+    - `Github <https://github.com/BartJanBoverhof/asreview-cnn-hpo>`__
 
 
 If an extension is not on this list, or you made one and you would like it to 


### PR DESCRIPTION
This PR adds another extension to the list of community extensions. I would add to the page https://asreview.readthedocs.io/en/latest/extensions/overview_extensions.html. This extension and its description are written by @BartJanBoverhof . The extension in question is https://github.com/BartJanBoverhof/asreview-cnn-hpo.

On top of that; this PR uncomments two ASReview extensions, that were previously hidden.