### PR TITLE
Add ivar documentation for data object and render it for autodoc

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -46,6 +46,34 @@ class ASReviewData():
         Specification for which column corresponds to which standard
         specification. Key is the standard specification, key is which column
         it is actually in.
+
+    Attributes
+    ----------
+    record_ids: numpy.ndarray
+        Return an array representing the data in the Index.
+    texts: numpy.ndarray
+        Returns an array with either headings, bodies, or both.
+    headings: numpy.ndarray
+        Returns an array with dataset headings.
+    title: numpy.ndarray
+        Identical to headings.
+    bodies: numpy.ndarray
+        Returns an array with dataset bodies.
+    abstract: numpy.ndarray
+        Identical to bodies.
+    keywords: numpy.ndarray
+        Returns an array with dataset keywords.
+    authors: numpy.ndarray
+        Returns an array with dataset authors.
+    doi: numpy.ndarray
+        Returns an array with dataset DOI.
+    included: numpy.ndarray
+        Returns an array with document inclusion markers.
+    final_included: numpy.ndarray
+        Pending deprecation! Returns an array with document inclusion markers.
+    labels: numpy.ndarray
+        Identical to included.
+
     """
 
     def __init__(self,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -242,6 +242,6 @@ napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = True
-napoleon_use_ivar = False
+napoleon_use_ivar = True
 napoleon_use_param = True
 napoleon_use_rtype = False


### PR DESCRIPTION
This PR adds the variables for the data base.py file to the documentation, and sets ivar to True in the conf.py file so they render correctly. It would render under https://asreview.readthedocs.io/en/latest/API/reference.html#asreview.ASReviewData.