### PR TITLE
Refactor prior REST API and return prior label

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -555,7 +555,7 @@ def api_get_labeled(project_id):  # noqa: F401
         return jsonify(message=message), 400
 
     try:
-  
+
         with open_state(project_path) as s:
             data = s.get_dataset(["record_ids", "labels", "query_strategies"])
             data["prior"] = (data["query_strategies"] == "prior").astype(int)
@@ -629,7 +629,7 @@ def api_get_labeled_stats(project_id):  # noqa: F401
 
         with open_state(project_path) as s:
             data = s.get_dataset(["labels", "query_strategies"])
-            
+
         data_prior = data[data["query_strategies"] == "prior"].copy()
 
         counter_prior = Counter([x for x in data_prior["labels"].tolist()])

--- a/asreview/webapp/src/PreReviewComponents/PriorKnowledge.js
+++ b/asreview/webapp/src/PreReviewComponents/PriorKnowledge.js
@@ -115,8 +115,8 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
   const [priorDialog, setPriorDialog] = React.useState(false);
 
   const [priorStats, setPriorStats] = React.useState({
-    n_exclusions: null,
-    n_inclusions: null,
+    n_prior_exclusions: null,
+    n_prior_inclusions: null,
     n_prior: null,
   });
   const [help, openHelp, closeHelp] = useHelp();
@@ -171,7 +171,7 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
 
   useEffect(() => {
     if (state.loading) {
-      ProjectAPI.prior_stats(project_id)
+      ProjectAPI.labeled_stats(project_id)
         .then((result) => {
           setState((s) => {
             return {
@@ -190,7 +190,7 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
 
   // check if there is enough prior knowledge
   useEffect(() => {
-    if (priorStats["n_inclusions"] > 0 && priorStats["n_exclusions"] > 0) {
+    if (priorStats["n_prior_inclusions"] > 0 && priorStats["n_prior_exclusions"] > 0) {
       setNext(true);
     } else {
       setNext(false);
@@ -234,15 +234,15 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
 
             <CardContent className="cardHighlight">
               <Typography variant="h4" noWrap={true}>
-                {priorStats["n_inclusions"]} relevant documents
+                {priorStats["n_prior_inclusions"]} relevant documents
               </Typography>
               <Typography variant="h4" noWrap={true}>
-                {priorStats["n_exclusions"]} irrelevant documents
+                {priorStats["n_prior_exclusions"]} irrelevant documents
               </Typography>
               <Box>
                 {/* nothing */}
-                {priorStats["n_inclusions"] === 0 &&
-                  priorStats["n_exclusions"] === 0 && (
+                {priorStats["n_prior_inclusions"] === 0 &&
+                  priorStats["n_prior_exclusions"] === 0 && (
                     <Typography>
                       You don't have prior knowledge yet. Find yourself prior
                       knowledge by searching relevant documents and label some
@@ -251,8 +251,8 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
                   )}
 
                 {/* only inclusions, no exclusions */}
-                {priorStats["n_inclusions"] > 0 &&
-                  priorStats["n_exclusions"] === 0 && (
+                {priorStats["n_prior_inclusions"] > 0 &&
+                  priorStats["n_prior_exclusions"] === 0 && (
                     <Typography>
                       Find yourself irrelevant documents. Tip: label some random
                       documents. Random documents are usually exclusions because
@@ -261,8 +261,8 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
                   )}
 
                 {/* only exclusions, no inclusions */}
-                {priorStats["n_inclusions"] === 0 &&
-                  priorStats["n_exclusions"] > 0 && (
+                {priorStats["n_prior_inclusions"] === 0 &&
+                  priorStats["n_prior_exclusions"] > 0 && (
                     <Typography>
                       Find yourself relevant documents. Tip: use the search
                       function and find some relevant documents you know of.
@@ -270,10 +270,10 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
                   )}
 
                 {/* bare minimum was met */}
-                {priorStats["n_inclusions"] > 0 &&
-                  priorStats["n_exclusions"] > 0 &&
-                  (priorStats["n_exclusions"] < 3 ||
-                    priorStats["n_inclusions"] < 3) && (
+                {priorStats["n_prior_inclusions"] > 0 &&
+                  priorStats["n_prior_exclusions"] > 0 &&
+                  (priorStats["n_prior_exclusions"] < 3 ||
+                    priorStats["n_prior_inclusions"] < 3) && (
                     <Typography>
                       <CheckIcon />
                       Enough prior knowledge, however a bit more would help!
@@ -281,8 +281,8 @@ const PriorKnowledge = ({ project_id, setNext, scrollToBottom }) => {
                   )}
 
                 {/* ready */}
-                {priorStats["n_inclusions"] >= 3 &&
-                  priorStats["n_exclusions"] >= 3 && (
+                {priorStats["n_prior_inclusions"] >= 3 &&
+                  priorStats["n_prior_exclusions"] >= 3 && (
                     <Typography style={{ color: green[500] }}>
                       <CheckIcon />
                       Enough prior knowledge, feel free to go to the next step.

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -146,7 +146,7 @@ class ProjectAPI {
 
   // TODO{Terry}: deprecating, replaced by fetchLabeledRecord
   static prior(project_id) {
-    const url = api_url + `project/${project_id}/prior`;
+    const url = api_url + `project/${project_id}/labeled`;
     return new Promise((resolve, reject) => {
       axios
         .get(url)
@@ -161,7 +161,7 @@ class ProjectAPI {
 
   static fetchLabeledRecord({ pageParam = 1, queryKey }) {
     const { project_id, select, per_page } = queryKey[1];
-    const url = api_url + `project/${project_id}/prior`;
+    const url = api_url + `project/${project_id}/labeled`;
     return new Promise((resolve, reject) => {
       axios
         .get(url, {
@@ -176,8 +176,8 @@ class ProjectAPI {
     });
   }
 
-  static prior_stats(project_id) {
-    const url = api_url + `project/${project_id}/prior_stats`;
+  static labeled_stats(project_id) {
+    const url = api_url + `project/${project_id}/labeled_stats`;
     return new Promise((resolve, reject) => {
       axios
         .get(url)

--- a/asreview/webapp/tests/test_api.py
+++ b/asreview/webapp/tests/test_api.py
@@ -149,20 +149,20 @@ def test_label_item(client):
     assert response_relevant.status_code == 200
 
 
-def test_get_prior(client):
-    """Test get all papers classified as prior documents"""
+def test_get_labeled(client):
+    """Test get all papers classified as labeled documents"""
 
-    response = client.get("/api/project/project-id/prior")
+    response = client.get("/api/project/project-id/labeled")
     json_data = response.get_json()
 
     assert "result" in json_data
     assert isinstance(json_data["result"], list)
 
 
-def test_get_prior_stat(client):
+def test_get_labeled_stats(client):
     """Test get all papers classified as prior documents"""
 
-    response = client.get("/api/project/project-id/prior_stats")
+    response = client.get("/api/project/project-id/labeled_stats")
     json_data = response.get_json()
 
     assert "n_prior" in json_data

--- a/asreview/webapp/tests/test_project.py
+++ b/asreview/webapp/tests/test_project.py
@@ -105,7 +105,7 @@ def test_project_file(tmp_path, client, url):
     assert response_update_classify.status_code == 200
 
     # Test retrieve review history
-    response_prior = client.get(f"{api_url}/prior")
+    response_prior = client.get(f"{api_url}/labeled")
     json_data_prior = response_prior.get_json()
     assert "result" in json_data_prior
     assert isinstance(json_data_prior["result"], list)


### PR DESCRIPTION
This PR makes it easier to retrieve prior information from the REST API. 

```
{
  "count": 15, 
  "next_page": null, 
  "previous_page": 0, 
  "result": [
    {
      "abstract": "To evaluate the effects of antihypertensive agents on the circadian blood pressure (BP) of patients with previous brain infarction, the ambulatory BP was measured non-invasively for 24 h before and after administration of antihypertensive agents. One hundred milligrams of acebutolol twice daily (n = 15) is effective in lowering the BP during the daytime, but has little effect during the night and the morning. Twenty milligrams of slow-release nifedipine twice daily (n = 14) produced a consistent reduction in the BP over the entire 24-h period and effectively blunted the rise in BP in the morning. Captopril (12.5 mg) twice daily (n = 15) produced a mild reduction in BP with little change in the circadian pattern. The slow-release nifedipine group had the greatest decrease in mean systolic and diastolic BP. The heart rate significantly increased after administration of slow-release nifedipine and decreased after administration of acebutolol. To reduce stroke recurrence, we should consider the effects of antihypertensive agents on circadian BP in hypertensive patients with previous brain infarction.", 
      "authors": "T Azuma; T Matsubara; Y Nagai; M Funauchi; T Fujimoto; T Saito; K Tone; S Sakoda", 
      "id": 2270, 
      "included": 0, 
      "keywords": null, 
      "prior": 1, 
      "title": "Effects of antihypertensive agents on circadian blood pressure in hypertensive patients with previous brain infarction."
    }, 
    {
      "abstract": "We conducted this study to compare the effects of fosinopril versus atenolol on peripheral blood pressure, central arterial wave reflection, and left ventricular mass in a group of patients with essential hypertension. We conducted a double-blind, randomized trial of fosinopril and atenolol in 79 hypertensive patients (52 men, 27 women; mean age, 45.8 +/- 8.5 years; range, 30 to 68 years). Carotid pressure waveforms were recorded noninvasively by applanation tonometry with a Millar micromanometer-tipped probe. The extent of wave reflection was estimated by the augmentation index defined as the ratio of the amplitude of pressure wave above its systolic shoulder to the pulse pressure. The augmentation index, left ventricular mass index by two-dimensional echocardiography, and 24-hour ambulatory blood pressures were determined before and after 8 weeks of daily treatment with fosinopril (10 to 20 mg) or atenolol (50 to 100 mg) with or without diuretics and compared with those values in 79 normotensive control subjects. After 8 weeks of treatment, both drugs lowered 24-hour ambulatory peripheral systolic and diastolic pressures into the normal range to a similar extent (fosinopril, -18/-13 mm Hg; atenolol, -23/-17 mm Hg, both P = NS). On the other hand, whereas the elevated augmentation index in hypertensive patients compared with normotensive subjects (16 +/- 11% versus 10 +/- 8%) was completely normalized by fosinopril (-9.3 +/- 9.8%, P < or = .002), it was lowered by atenolol (-4.8 +/- 8.9%, P < .002) but to a significantly smaller extent (fosinopril versus atenolol effect, P = .04).(ABSTRACT TRUNCATED AT 250 WORDS)", 
      "authors": "C H Chen; C T Ting; S J Lin; T L Hsu; F C Yin; C O Siu; P Chou; S P Wang; M S Chang", 
      "id": 1422, 
      "included": 1, 
      "keywords": null, 
      "prior": 0, 
      "title": "Different effects of fosinopril and atenolol on wave reflections in hypertensive patients."
    }, 
    {
```