### PR TITLE
Fix error with loading benchmark datasets with dataset plugin

### DIFF
--- a/asreview/webapp/utils/datasets.py
+++ b/asreview/webapp/utils/datasets.py
@@ -73,7 +73,7 @@ def get_dataset_metadata(exclude=None, include=None):
             include = [include]
 
         # pop items
-        for group_id in groups:
+        for group_id in groups.copy():
             if group_id not in include:
                 groups.remove(group_id)
 


### PR DESCRIPTION
This PR fixes a problem with loading the benchmark datasets when a (Plugin) 
dataset extension is installed to ASReview. This side effect is now resolved. 

This should make this template work now: https://github.com/asreview/template-extension-new-dataset