### PR TITLE
Create entry point to inspect tables in state file

### DIFF
--- a/asreview/entry_points/__init__.py
+++ b/asreview/entry_points/__init__.py
@@ -18,5 +18,6 @@ from asreview.entry_points.lab import LABEntryPoint
 from asreview.entry_points.lab import WebRunModelEntryPoint
 from asreview.entry_points.simulate import BatchEntryPoint
 from asreview.entry_points.simulate import SimulateEntryPoint
+from asreview.entry_points.state_inspect import StateInspectEntryPoint
 
 """Default entry points for asreview."""

--- a/asreview/entry_points/state_inspect.py
+++ b/asreview/entry_points/state_inspect.py
@@ -1,0 +1,57 @@
+# Copyright 2019-2021 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+import pandas as pd
+
+from asreview.entry_points.base import BaseEntryPoint
+from asreview.state.utils import open_state
+from asreview.webapp.utils.project_path import get_project_path
+
+
+def _parse_state_inspect_args():
+
+    # parse arguments if available
+    parser = argparse.ArgumentParser(prog="state-inspect",
+                                     description="Inspect state file.")
+    parser.add_argument("project_id", type=str, help="Project_id or url.")
+    parser.add_argument(
+        "table",
+        type=str,
+        help="Table to view (e.g. results, record_table, last_ranking).")
+
+    return parser
+
+
+class StateInspectEntryPoint(BaseEntryPoint):
+    description = "Inspect state files in ASReview."
+
+    def execute(self, argv):
+        parser = _parse_state_inspect_args()
+        args = parser.parse_args(argv)
+
+        project_path = get_project_path(args.project_id)
+
+        with open_state(project_path) as s:
+            conn = s._connect_to_sql()
+
+        df = pd.read_sql(f"select * from {args.table}", conn)
+
+        if args.table == "results":
+            df["label"] = df["label"].astype(pd.Int64Dtype())
+
+        print(f"Table '{args.table}':\n")
+        print(df)
+        print("\n")

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
             'simulate=asreview.entry_points:SimulateEntryPoint',
             'simulate-batch = asreview.entry_points:BatchEntryPoint',
             'algorithms = asreview.entry_points:AlgorithmsEntryPoint',
+            'state-inspect = asreview.entry_points:StateInspectEntryPoint'
         ],
         'asreview.readers': [
             '.csv = asreview.io.csv_reader:read_csv',


### PR DESCRIPTION
Subcommand to inspect tables in state file via command line. Might be useful to move to a plugin later on. 

```
(asreview_m1) Bruin056@UU083226 asreview % python -m asreview state-inspect test-peter-2 results
Table 'results':

    record_id  label classifier query_strategy balance_strategy feature_extraction  training_set               labeling_time notes
0        3921      0       None          prior             None               None            -1  2021-11-06 01:14:36.386503  None
1        5699      1       None          prior             None               None            -1  2021-11-06 01:14:37.168362  None
2        5803      0       None          prior             None               None            -1  2021-11-06 01:14:37.854991  None
3        5543      1       None          prior             None               None            -1  2021-11-06 01:14:38.587924  None
4         495      1         nb            max           double              tfidf             4  2021-11-06 01:15:34.998711  None
5        1738      0         nb            max           double              tfidf             4  2021-11-06 01:15:35.940111  None
6        5323      0         nb            max           double              tfidf             4  2021-11-06 01:15:37.413584  None
7         162      0         nb            max           double              tfidf             6  2021-11-06 01:15:38.650004  None
8         843      0         nb            max           double              tfidf             7  2021-11-06 01:15:39.746451  None
9         820      0         nb            max           double              tfidf             8  2021-11-06 01:15:40.559671  None
10       5383      0         nb            max           double              tfidf             8  2021-11-06 01:15:41.574353  None
11        209   <NA>         nb            max           double              tfidf            10                        None  None
```