### PR TITLE
Fix inconsistent color on tooltip of progress recall chart

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
@@ -73,7 +73,7 @@ const StyledCard = styled(Card)(({ theme }) => ({
   [`& .${classes.tooltipLabelRandomNumber}`]: {
     marginLeft: 32,
     ...(theme.palette.mode === "dark" && {
-      color: "#CED4DC",
+      color: theme.palette.secondary.main,
     }),
   },
 


### PR DESCRIPTION
This PR fixed a minor color inconsistency on the tooltip of the progress recall chart.