### PR TITLE
Add experimental info alert when choose to export RIS file

### DIFF
--- a/asreview/webapp/src/Components/ExportDialog.js
+++ b/asreview/webapp/src/Components/ExportDialog.js
@@ -43,7 +43,7 @@ const mapStateToProps = (state) => {
 const ExportDialog = (props) => {
   const classes = useStyles();
 
-  const [exportFileType, setExportFileType] = React.useState("ris");
+  const [exportFileType, setExportFileType] = React.useState("xlsx");
   const [error, setError] = React.useState({
     code: null,
     message: null,
@@ -119,12 +119,18 @@ const ExportDialog = (props) => {
             value={exportFileType}
             onChange={handleExportFileTypeChange}
           >
-            <MenuItem value={"ris"}>RIS (UTF-8)</MenuItem>
+            <MenuItem value={"xlsx"}>Excel</MenuItem>
             <MenuItem value={"csv"}>CSV (UTF-8)</MenuItem>
             <MenuItem value={"tsv"}>TSV (UTF-8)</MenuItem>
-            <MenuItem value={"excel"}>Excel</MenuItem>
+            <MenuItem value={"ris"}>RIS (UTF-8)</MenuItem>
           </Select>
         </Box>
+        {exportFileType === "ris" && (
+          <Alert severity="info">
+            Experimental feature: available only if you imported the RIS file
+            when creating the project
+          </Alert>
+        )}
         {error.message && <Alert severity="error">{error["message"]}</Alert>}
       </DialogContent>
 

--- a/asreview/webapp/src/Components/ExportDialog.js
+++ b/asreview/webapp/src/Components/ExportDialog.js
@@ -127,8 +127,9 @@ const ExportDialog = (props) => {
         </Box>
         {exportFileType === "ris" && (
           <Alert severity="info">
-            Experimental feature: available only if you imported a RIS file
-            when creating the project
+            Experimental. RIS export is a new export option and might be further improved.
+            Feedback is welcome and can be sent to asreview@uu.nl or posted on the
+            <Link className={classes.link} href={"https://github.com/asreview/asreview/discussions"} target="_blank">Discussion platform</Link>.
           </Alert>
         )}
         {error.message && <Alert severity="error">{error["message"]}</Alert>}

--- a/asreview/webapp/src/Components/ExportDialog.js
+++ b/asreview/webapp/src/Components/ExportDialog.js
@@ -127,7 +127,7 @@ const ExportDialog = (props) => {
         </Box>
         {exportFileType === "ris" && (
           <Alert severity="info">
-            Experimental feature: available only if you imported the RIS file
+            Experimental feature: available only if you imported a RIS file
             when creating the project
           </Alert>
         )}

--- a/asreview/webapp/src/Components/ExportDialog.js
+++ b/asreview/webapp/src/Components/ExportDialog.js
@@ -26,9 +26,6 @@ const useStyles = makeStyles((theme) => ({
   button: {
     marginTop: "16px",
   },
-  link: {
-    paddingLeft: "3px",
-  },
   file_type: {
     margin: theme.spacing(1),
     width: "100%",
@@ -127,9 +124,19 @@ const ExportDialog = (props) => {
         </Box>
         {exportFileType === "ris" && (
           <Alert severity="info">
-            Experimental. RIS export is a new export option and might be further improved.
-            Feedback is welcome and can be sent to asreview@uu.nl or posted on the
-            <Link className={classes.link} href={"https://github.com/asreview/asreview/discussions"} target="_blank">Discussion platform</Link>.
+            Experimental. RIS export is a new option and might be further
+            improved. You can send feedback to{" "}
+            <Link href={"mailto:asreview@uu.nl"} target="_blank">
+              asreview@uu.nl
+            </Link>{" "}
+            or post it on{" "}
+            <Link
+              href={"https://github.com/asreview/asreview/discussions"}
+              target="_blank"
+            >
+              GitHub Discussions
+            </Link>
+            .
           </Alert>
         )}
         {error.message && <Alert severity="error">{error["message"]}</Alert>}
@@ -139,8 +146,8 @@ const ExportDialog = (props) => {
         {donateURL !== undefined && (
           <Typography>
             Our software is made with love and freely available for everyone.
-            Help the development of the ASReview with a donation:
-            <Link className={classes.link} href={donateURL} target="_blank">
+            Help the development of the ASReview with a donation:{" "}
+            <Link href={donateURL} target="_blank">
               asreview.nl/donate
             </Link>
           </Typography>

--- a/asreview/webapp/src/Components/ExportDialog.js
+++ b/asreview/webapp/src/Components/ExportDialog.js
@@ -122,7 +122,7 @@ const ExportDialog = (props) => {
             <MenuItem value={"xlsx"}>Excel</MenuItem>
             <MenuItem value={"csv"}>CSV (UTF-8)</MenuItem>
             <MenuItem value={"tsv"}>TSV (UTF-8)</MenuItem>
-            <MenuItem value={"ris"}>RIS (UTF-8)</MenuItem>
+            <MenuItem value={"ris"}>RIS</MenuItem>
           </Select>
         </Box>
         {exportFileType === "ris" && (


### PR DESCRIPTION
This PR added an experimental feature alert when choosing to export the RIS file. This PR also fixed the problem of exporting the Excel file and restored the default file type to Excel.

![image](https://user-images.githubusercontent.com/17449217/145193283-364e3150-16a9-48c8-8fc7-44848389df5e.png)