### PR TITLE
Restore sbert.py functionality with new transformer

### DIFF
--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -42,7 +42,7 @@ class SBERT(BaseFeatureExtraction):
     Sentence BERT is a sentence embedding model that is trained on a large
     corpus of human written text. It is a fast and accurate model that can
     be used for many tasks.
-    
+
     The huggingface library includes multilingual text classification models. If
     your dataset contains records with multiple languages, you can use the
     ``transformer_model`` parameter to select the model that is most suitable

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -34,9 +34,19 @@ def _check_st():
 class SBERT(BaseFeatureExtraction):
     """Sentence BERT feature extraction technique.
 
-    Feature extraction technique based on Sentence BERT. Implementation based on
-    the `sentence_transformers <https://github.com/UKPLab/sentence-
-    transformers>`__ package. It is relatively slow.
+    By setting the ``transformer_model`` parameter, you can use other
+    transformer models. For example, ``transformer_model='bert-base-nli-stsb-
+    large'``. For a list of available models, see the `Sentence BERT
+    documentation <https://huggingface.co/sentence-transformers>`__.
+
+    Sentence BERT is a sentence embedding model that is trained on a large
+    corpus of human written text. It is a fast and accurate model that can
+    be used for many tasks.
+    
+    The huggingface library includes multilingual text classification models. If
+    your dataset contains records with multiple languages, you can use the
+    ``transformer_model`` parameter to select the model that is most suitable
+    for your data.
 
     .. note::
 

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -55,16 +55,26 @@ class SBERT(BaseFeatureExtraction):
         all optional ASReview dependencies with ``pip install asreview[all]``
         to install the package.
 
+    Parameters
+    ----------
+    transformer_model : str, optional
+        The transformer model to use.
+        Default: 'all-mpnet-base-v2'
 
     """
 
     name = "sbert"
     label = "Sentence BERT"
 
+    def __init__(self, *args, transformer_model='all-mpnet-base-v2', **kwargs):
+        """Initialize the SBERT feature extraction technique."""
+        super(SBERT, self).__init__(*args, **kwargs)
+        self.transformer_model = transformer_model
+
     def transform(self, texts):
 
         _check_st()
 
-        model = SentenceTransformer('all-mpnet-base-v2')
+        model = SentenceTransformer(self.transformer_model)
         X = np.array(model.encode(texts))
         return X

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -53,6 +53,6 @@ class SBERT(BaseFeatureExtraction):
 
         _check_st()
 
-        model = SentenceTransformer('bert-base-nli-mean-tokens')
+        model = SentenceTransformer('all-mpnet-base-v2')
         X = np.array(model.encode(texts))
         return X

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -67,7 +67,6 @@ class SBERT(BaseFeatureExtraction):
     label = "Sentence BERT"
 
     def __init__(self, *args, transformer_model='all-mpnet-base-v2', **kwargs):
-        """Initialize the SBERT feature extraction technique."""
         super(SBERT, self).__init__(*args, **kwargs)
         self.transformer_model = transformer_model
 

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -53,6 +53,8 @@ class SBERT(BaseFeatureExtraction):
         This feature extraction technique requires ``sentence_transformers``
         to be installed. Use ``pip install sentence_transformers`` or install
         all optional ASReview dependencies with ``pip install asreview[all]``
+        to install the package.
+
 
     """
 


### PR DESCRIPTION
As the functionality is broken in version 0.18, this PR pulls directly into the master branch. This PR replaces the sentence transformer as a result of #874 (deprecated transformer). The old transformer is not available anymore.