### PR TITLE
Raise more informative error on dataset without titles

### DIFF
--- a/asreview/search.py
+++ b/asreview/search.py
@@ -20,6 +20,10 @@ import numpy as np
 from asreview.utils import format_to_str
 
 
+class SearchError(Exception):
+    pass
+
+
 def _create_inverted_index(match_strings):
     index = {}
     word = re.compile(r"['\w]+")
@@ -84,13 +88,24 @@ def _match_string(as_data):
     all_titles = as_data.title
     all_authors = as_data.authors
     all_keywords = as_data.keywords
+
+    if all_titles is None:
+        raise SearchError("Cannot search dataset without titles.")
+
     for i in range(len(as_data)):
         match_list = []
+
+        # add titles
+        match_list.append(all_titles[i])
+
+        # add authors if present
         if all_authors is not None:
             match_list.append(format_to_str(all_authors[i]))
-        match_list.append(all_titles[i])
+
+        # add keywords if present
         if all_keywords is not None:
             match_list.append(format_to_str(all_keywords[i]))
+
         match_str[i, ] = " ".join(match_list)
     return match_str
 

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -50,6 +50,7 @@ from asreview.models.classifiers import list_classifiers
 from asreview.models.feature_extraction import list_feature_extraction
 from asreview.models.query import list_query_strategies
 from asreview.search import fuzzy_find
+from asreview.search import SearchError
 from asreview.settings import ASReviewSettings
 from asreview.state.errors import StateNotFoundError
 from asreview.state.paths import get_data_file_path
@@ -520,6 +521,10 @@ def api_search_data(project_id):  # noqa: F401
                     "keywords": paper.keywords,
                     "included": int(paper.included)
                 })
+
+    except SearchError as search_err:
+        logging.error(search_err)
+        return jsonify(message=f"Error: {search_err}"), 500
 
     except Exception as err:
         logging.error(err)

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -49,8 +49,8 @@ from asreview.models.balance import list_balance_strategies
 from asreview.models.classifiers import list_classifiers
 from asreview.models.feature_extraction import list_feature_extraction
 from asreview.models.query import list_query_strategies
-from asreview.search import fuzzy_find
 from asreview.search import SearchError
+from asreview.search import fuzzy_find
 from asreview.settings import ASReviewSettings
 from asreview.state.errors import StateNotFoundError
 from asreview.state.paths import get_data_file_path


### PR DESCRIPTION
Resolves #875

This PR changes the error message when dataset without titles is uploaded into:

"Error: Cannot search dataset without titles."