### PR TITLE
Add word LAB to site title

### DIFF
--- a/asreview/webapp/public/index.html
+++ b/asreview/webapp/public/index.html
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ASReview - A tool for AI-assisted systematic reviews</title>
+    <title>ASReview LAB - A tool for AI-assisted systematic reviews</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/asreview/webapp/tests/test_webapp.py
+++ b/asreview/webapp/tests/test_webapp.py
@@ -22,7 +22,7 @@ def test_landing(client):
     response = client.get("/")
     html = response.data.decode()
 
-    assert "<title>ASReview - A tool for AI-assisted systematic reviews</title>" in html  # noqa
+    assert "<title>ASReview LAB - A tool for AI-assisted systematic reviews</title>" in html  # noqa
 
 
 def test_boot(client):


### PR DESCRIPTION
This PR adds the word LAB to the site title.

![image](https://user-images.githubusercontent.com/17449217/146320910-83d623ee-c7e0-44cd-b136-2da845b9e7d8.png)
