### PR TITLE
Fix regex not supported by Safari

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
@@ -21,10 +21,6 @@ const StyledCard = styled(Card)(({ theme }) => ({
   },
 }));
 
-function numberWithCommas(x) {
-  return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
-}
-
 export default function ProgressChart(props) {
   const theme = useTheme();
 
@@ -39,7 +35,7 @@ export default function ProgressChart(props) {
     : null;
 
   const formattedTotal = React.useCallback(() => {
-    return n_papers ? numberWithCommas(n_papers) : 0;
+    return n_papers ? n_papers.toLocaleString("en-US") : 0;
   }, [n_papers]);
 
   /**


### PR DESCRIPTION
This PR fixed the lookbehind in regular expressions that is not supported by Safari. Fixed #896 