### PR TITLE
Adjust documentation on batch simulations

### DIFF
--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -220,7 +220,7 @@ def _batch_parser():
         description=DESCRIPTION_BATCH
     )
     parser.add_argument(
-        "-r", "--n_run",
+        "-r", "--n_run", "--n_runs",
         default=10,
         type=int,
         help="Number of runs to perform."

--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -220,7 +220,7 @@ def _batch_parser():
         description=DESCRIPTION_BATCH
     )
     parser.add_argument(
-        "-r", "--n_run", "--n_runs",
+        "-r", "--n_run",
         default=10,
         type=int,
         help="Number of runs to perform."

--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -210,7 +210,7 @@ DESCRIPTION_BATCH = """
 Automated Systematic Review (ASReview) batch system for simulation runs.
 
 It has the same interface as the simulation modus, but adds an extra option
-(--n_runs) to run a batch of simulation runs with the same configuration.
+(--n_run) to run a batch of simulation runs with the same configuration.
 """
 
 

--- a/docs/source/API/cli.rst
+++ b/docs/source/API/cli.rst
@@ -289,7 +289,7 @@ Simulate-batch
 --------------
 
 :program:`asreview simulate-batch` provides the same interface as the
-:program:`asreview simulate`, but adds an extra option (:code:`--n_runs`) to run a
+:program:`asreview simulate`, but adds an extra option (:code:`--n_run`) to run a
 batch of simulation runs with the same configuration.
 
 .. code:: bash
@@ -307,7 +307,7 @@ batch of simulation runs with the same configuration.
 
     A dataset to simulate
 
-.. option:: --n_runs
+.. option:: --n_run
 
     Number of simulation runs.
 


### PR DESCRIPTION
This will realign the batch simulator with the [documentation](https://asreview.readthedocs.io/en/latest/API/cli.html?highlight=--n_runs#simulate-batch).