### PR TITLE
Extend REST API with option to add and update notes

### DIFF
--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -620,24 +620,19 @@ class SqlStateV1(BaseState):
         con.commit()
         con.close()
 
-    def change_decision(self, record_id):
+    def update_decision(self, record_id, label, note=None):
         """Change the label of a record from 0 to 1 or vice versa."""
-        current_label = self.get_data_by_record_id(record_id)['label'][0]
-
-        # New label should be of type int, not np.int, to insert into sql.
-        new_label = int(1 - current_label)
-        current_time = datetime.now()
 
         con = self._connect_to_sql()
         cur = con.cursor()
 
         # Change the label.
-        cur.execute("UPDATE results SET label = ? WHERE record_id = ?",
-                    (new_label, record_id))
+        cur.execute("UPDATE results SET label = ?, notes = ? WHERE record_id = ?",
+                    (label, note, record_id))
 
         # Add the change to the decision changes table.
         cur.execute("INSERT INTO decision_changes VALUES (?,?, ?)",
-                    (record_id, new_label, current_time))
+                    (record_id, label, datetime.now()))
 
         con.commit()
         con.close()

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -1249,6 +1249,7 @@ def api_classify_instance(project_id, doc_id):  # noqa: F401
     # return the combination of document_id and label.
     doc_id = request.form.get('doc_id')
     label = request.form.get('label')
+    note = request.form.get('note')
     is_prior = request.form.get('is_prior', default=False)
 
     retrain_model = False if is_prior == "1" else True
@@ -1258,12 +1259,14 @@ def api_classify_instance(project_id, doc_id):  # noqa: F401
         label_instance(project_id,
                        doc_id,
                        label,
+                       note=note,
                        prior=prior,
                        retrain_model=retrain_model)
     elif request.method == 'PUT':
         update_instance(project_id,
                         doc_id,
                         label,
+                        note=note,
                         retrain_model=retrain_model)
 
     response = jsonify({'success': True})

--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -564,7 +564,8 @@ def update_instance(project_id, record_id, label, note=None, retrain_model=True)
         train_model(project_id)
 
 
-def label_instance(project_id, paper_i, label, note=None, prior=False, retrain_model=True):
+def label_instance(project_id, paper_i, label, note=None,
+                   prior=False, retrain_model=True):
     """Label a paper after reviewing the abstract.
 
     """

--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -549,35 +549,22 @@ def train_model(project_id):
     subprocess.Popen(run_command)
 
 
-def update_instance(project_id, paper_i, label, retrain_model=True):
+def update_instance(project_id, record_id, label, note=None, retrain_model=True):
     """Update a labeling decision."""
     project_path = get_project_path(project_id)
     state_path = get_state_path(project_path)
 
-    record_id = int(paper_i)
+    # check the label
     label = int(label)
 
     with open_state(state_path, read_only=False) as state:
-        record_info = state.get_data_by_record_id(record_id)
-
-        # Check if the record is actually labeled.
-        if record_info.empty:
-            raise ValueError(f"Tried to update record_id {record_id}, "
-                             f"but it has not been labeled yet.")
-        else:
-            # If the current label is the same as the updated label, do nothing.
-            current_label = record_info['label'][0]
-            if current_label == label:
-                pass
-            # Else change the labeling decision.
-            else:
-                state.change_decision(record_id)
+        state.update_decision(record_id, label, note=note)
 
     if retrain_model:
         train_model(project_id)
 
 
-def label_instance(project_id, paper_i, label, prior=False, retrain_model=True):
+def label_instance(project_id, paper_i, label, note=None, prior=False, retrain_model=True):
     """Label a paper after reviewing the abstract.
 
     """
@@ -595,7 +582,7 @@ def label_instance(project_id, paper_i, label, prior=False, retrain_model=True):
             # add the labels as prior data
             state.add_labeling_data(record_ids=[paper_i],
                                     labels=[label],
-                                    notes=[None],
+                                    notes=[note],
                                     prior=prior)
 
         elif label == -1:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -463,7 +463,7 @@ def test_add_note(tmpdir):
         assert record_data['notes'][0] == note
 
 
-def test_change_decision(tmpdir):
+def test_update_decision(tmpdir):
     project_path = Path(tmpdir, 'test.asreview')
     init_project_folder_structure(project_path)
     with open_state(project_path, read_only=False) as state:
@@ -472,12 +472,12 @@ def test_change_decision(tmpdir):
                                 prior=True)
 
         for i in range(3):
-            state.change_decision(TEST_RECORD_IDS[i])
+            state.update_decision(TEST_RECORD_IDS[i], 1 - TEST_LABELS[i])
             new_label = \
                 state.get_data_by_record_id(TEST_RECORD_IDS[i])['label'][0]
             assert new_label == 1 - TEST_LABELS[i]
 
-        state.change_decision(TEST_RECORD_IDS[1])
+        state.update_decision(TEST_RECORD_IDS[1], TEST_LABELS[1])
         new_label = \
             state.get_data_by_record_id(TEST_RECORD_IDS[1])['label'][0]
         assert new_label == TEST_LABELS[1]


### PR DESCRIPTION
#832 and #820. 

It requires also changes to the javascript code @terrymyc. Can you add that to this PR?

@peterlombaers, Can you review the "update_decision" method? Made this one slightly more flexible because everything is now properly handled in the javascript code (the difference between PUT and POST)