### PR TITLE
Add alert to record card of prior selection in exploration mode

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -1,7 +1,6 @@
 import React from "react";
 import clsx from "clsx";
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -16,13 +15,13 @@ import { styled } from "@mui/material/styles";
 
 import { BoxErrorHandler } from "../../Components";
 import { NoteSheet } from "../ReviewComponents";
+import { ExplorationModeRecordAlert } from "../../StyledComponents/StyledAlert.js";
 
 const PREFIX = "RecordCard";
 
 const classes = {
   loadedCard: `${PREFIX}-loadedCard`,
   loadingCard: `${PREFIX}-loadingCard`,
-  alert: `${PREFIX}-alert`,
   titleAbstract: `${PREFIX}-titleAbstract`,
   title: `${PREFIX}-title`,
   abstract: `${PREFIX}-abstract`,
@@ -56,14 +55,6 @@ const Root = styled("div")(({ theme }) => ({
   [`& .${classes.loadingCard}`]: {
     justifyContent: "center",
     alignItems: "center",
-  },
-
-  [`& .${classes.alert}`]: {
-    borderBottomRightRadius: 0,
-    borderBottomLeftRadius: 0,
-    [theme.breakpoints.down("md")]: {
-      borderRadius: 0,
-    },
   },
 
   [`& .${classes.titleAbstract}`]: {
@@ -142,13 +133,7 @@ const RecordCard = (props) => {
           aria-label="record loaded"
         >
           {/* Previous decision alert */}
-          {isDebugInclusion() && (
-            <Box aria-label="pre-labeled record alert">
-              <Alert className={classes.alert} severity="info">
-                This record was pre-labeled as relevant.
-              </Alert>
-            </Box>
-          )}
+          {isDebugInclusion() && <ExplorationModeRecordAlert />}
 
           <CardContent
             className={classes.titleAbstract}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -15,6 +15,7 @@ import {
 import { styled } from "@mui/material/styles";
 
 import { InlineErrorHandler } from "../../../Components";
+import { ExplorationModeRecordAlert } from "../../../StyledComponents/StyledAlert.js";
 import { ProjectAPI } from "../../../api/index.js";
 import { mapStateToProps } from "../../../globals.js";
 
@@ -85,6 +86,12 @@ const PriorUnlabeled = (props) => {
     }
   );
 
+  const isDebugInclusion = () => {
+    if (props.record) {
+      return props.record._debug_label === 1;
+    }
+  };
+
   return (
     <Root>
       {isError && (
@@ -98,6 +105,7 @@ const PriorUnlabeled = (props) => {
       )}
       {!isError && (
         <Card elevation={3} className={classes.root}>
+          {isDebugInclusion() && <ExplorationModeRecordAlert />}
           <CardContent>
             <Typography gutterBottom variant="h6">
               {props.record.title ? props.record.title : "No title available."}

--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -7,7 +7,7 @@ export function ExplorationModeRecordAlert(props) {
       severity="info"
       sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
     >
-      This record was pre-labeled as relevant
+      Labeled as relevant in an earlier study
     </Alert>
   );
 }

--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { Alert } from "@mui/material";
+
+export function ExplorationModeRecordAlert(props) {
+  return (
+    <Alert
+      severity="info"
+      sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
+    >
+      This record was pre-labeled as relevant
+    </Alert>
+  );
+}


### PR DESCRIPTION
This PR adds an information alert to the record card when searching for records or getting random records in exploration mode.

![image](https://user-images.githubusercontent.com/17449217/149369267-6b32f824-38a3-4dfb-b623-1f20d01489bc.png)
