### PR TITLE
Style project delete dialog

### DIFF
--- a/asreview/webapp/src/Components/ProjectDeleteDialog.js
+++ b/asreview/webapp/src/Components/ProjectDeleteDialog.js
@@ -8,6 +8,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Stack,
   Typography,
   TextField,
 } from "@mui/material";
@@ -83,26 +84,31 @@ const ProjectDeleteDialog = (props) => {
       fullWidth
       maxWidth="sm"
     >
-      <DialogTitle>Delete project</DialogTitle>
+      <DialogTitle>Permanently delete this project?</DialogTitle>
       <DialogContent dividers>
-        {isError && (
-          <Alert severity="error" sx={{ marginBottom: "16px" }}>
-            {error["message"]}
-          </Alert>
-        )}
-        <Typography sx={{ marginBottom: "16px" }}>
-          Confirm the project you want to delete by typing the title{" "}
-          <b>{props.projectTitle}</b> below.
-        </Typography>
-        <TextField
-          autoFocus
-          fullWidth
-          required
-          name="project-title"
-          id="project-title"
-          label="Title"
-          onChange={onChangeTitle}
-        />
+        <Stack spacing={3}>
+          {isError && <Alert severity="error">{error["message"]}</Alert>}
+          <Stack spacing={2}>
+            <Typography>
+              This action <b>cannot</b> be undone. This will permanently delete
+              the <b>{props.projectTitle}</b> project, including the dataset,
+              review history, notes, and model configuration.
+            </Typography>
+            <Typography>
+              Please type <b>{props.projectTitle}</b> to confirm.
+            </Typography>
+          </Stack>
+          <TextField
+            autoComplete="off"
+            autoFocus
+            fullWidth
+            required
+            name="project-title"
+            id="project-title"
+            label="Title"
+            onChange={onChangeTitle}
+          />
+        </Stack>
       </DialogContent>
       <DialogActions>
         <Button onClick={cancelDelete}>Cancel</Button>
@@ -110,7 +116,7 @@ const ProjectDeleteDialog = (props) => {
           onClick={() => mutate({ project_id: props.project_id })}
           disabled={disableConfirmButton()}
         >
-          Confirm
+          Delete Forever
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
This PR styled the project delete dialog and added an explicit explanation.

![Screenshot 2022-01-14 09 11 31](https://user-images.githubusercontent.com/17449217/149474117-16cbf354-b585-4da9-baed-71b733322604.png)

The text referenced GitHub:
![image](https://user-images.githubusercontent.com/17449217/149474659-ec89d442-5bb1-471b-9001-3718de96072b.png)
