### PR TITLE
Fix get statistics of number since last relevant

### DIFF
--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -488,7 +488,7 @@ def get_statistics(project_id):
     n_included = int(sum(labels == 1))
     n_excluded = int(sum(labels == 0))
 
-    if len(labels) > 0:
+    if n_included > 0:
         n_since_last_relevant = int(labels.tolist()[::-1].index(1))
     else:
         n_since_last_relevant = 0


### PR DESCRIPTION
This PR fixed the `get_statistics` function if no relevant prior knowledge is added when creating a new project. It is not possible to return `n_since_last_relevant` if no relevant record is provided. The dashboard analytics uses this function and may return the error.