### PR TITLE
Add prior knowledge option to project history filter

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -566,14 +566,16 @@ def api_get_labeled(project_id):  # noqa: F401
 
         if any(s in subset for s in ["relevant", "included"]):
             data = data[data["label"] == 1]
-            if "note" in subset:
-                data = data[~data["notes"].isnull()]
         elif any(s in subset for s in ["irrelevant", "excluded"]):
             data = data[data["label"] == 0]
-            if "note" in subset:
-                data = data[~data["notes"].isnull()]
         else:
             data = data[~data["label"].isnull()]
+
+        if "note" in subset:
+            data = data[~data["notes"].isnull()]
+
+        if "prior" in subset:
+            data = data[data["prior"] == 1]
 
         if latest_first == 1:
             data = data.iloc[::-1]

--- a/asreview/webapp/src/ProjectComponents/DetailsComponents/DataForm.js
+++ b/asreview/webapp/src/ProjectComponents/DetailsComponents/DataForm.js
@@ -88,6 +88,7 @@ const DataForm = (props) => {
           refetch={refetchData}
         />
         <DataFormCard
+          handleNavState={props.handleNavState}
           isError={isFetchLabeledStatsError}
           primary={
             !isFetchLabeledStatsError
@@ -95,6 +96,7 @@ const DataForm = (props) => {
               : fetchLabeledStatsError.message
           }
           secondary={returnLabeledStatsSecondary()}
+          setHistoryFilterQuery={props.setHistoryFilterQuery}
           refetch={refetchLabeledStats}
         />
       </Stack>

--- a/asreview/webapp/src/ProjectComponents/DetailsComponents/DataFormCard.js
+++ b/asreview/webapp/src/ProjectComponents/DetailsComponents/DataFormCard.js
@@ -1,8 +1,17 @@
 import * as React from "react";
-import { Box, Card, CardContent, Link, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Link,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { styled } from "@mui/material/styles";
 
 import { TypographySubtitle1Medium } from "../../StyledComponents/StyledTypography.js";
+import { historyFilterOptions } from "../../globals.js";
 
 const PREFIX = "DataFormCard";
 
@@ -31,6 +40,13 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 const DataFormCard = (props) => {
+  const handleClickViewPriors = () => {
+    props.handleNavState("history");
+    props.setHistoryFilterQuery([
+      historyFilterOptions.find((e) => e.value === "prior"),
+    ]);
+  };
+
   return (
     <Root>
       <Card
@@ -62,6 +78,9 @@ const DataFormCard = (props) => {
               </Link>
             )}
           </Stack>
+          {props.primary === "Prior knowledge" && (
+            <Button onClick={handleClickViewPriors}>View</Button>
+          )}
         </CardContent>
       </Card>
     </Root>

--- a/asreview/webapp/src/ProjectComponents/DetailsComponents/DataFormCard.js
+++ b/asreview/webapp/src/ProjectComponents/DetailsComponents/DataFormCard.js
@@ -40,7 +40,7 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 const DataFormCard = (props) => {
-  const handleClickViewPriors = () => {
+  const handleClickViewPrior = () => {
     props.handleNavState("history");
     props.setHistoryFilterQuery([
       historyFilterOptions.find((e) => e.value === "prior"),
@@ -79,7 +79,7 @@ const DataFormCard = (props) => {
             )}
           </Stack>
           {props.primary === "Prior knowledge" && (
-            <Button onClick={handleClickViewPriors}>View</Button>
+            <Button onClick={handleClickViewPrior}>View</Button>
           )}
         </CardContent>
       </Card>

--- a/asreview/webapp/src/ProjectComponents/DetailsComponents/DetailsPage.js
+++ b/asreview/webapp/src/ProjectComponents/DetailsComponents/DetailsPage.js
@@ -174,7 +174,10 @@ const DetailsPage = (props) => {
                 spacing={3}
                 sx={{ width: !props.mobileScreen ? "40%" : "100%" }}
               >
-                <DataForm />
+                <DataForm
+                  handleNavState={props.handleNavState}
+                  setHistoryFilterQuery={props.setHistoryFilterQuery}
+                />
                 <ModelForm />
               </Stack>
             </Stack>

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
@@ -3,6 +3,8 @@ import { Autocomplete, IconButton, InputBase, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { FilterList } from "@mui/icons-material";
 
+import { historyFilterOptions } from "../../globals.js";
+
 const PREFIX = "Filter";
 
 const classes = {
@@ -21,24 +23,12 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 export default function Filter(props) {
-  const [placeholder, setPlaceholder] = React.useState("Filter");
   const filterInput = React.useRef(null);
 
   const customPopper = (props) => {
     return (
       <Popper {...props} style={{ width: 160 }} placement="bottom-start" />
     );
-  };
-
-  const handleFilterQuery = (value) => {
-    // hide place holder
-    if (value.length) {
-      setPlaceholder("");
-    } else {
-      setPlaceholder("Filter");
-    }
-    // pass filter query
-    props.setFilterQuery(value);
   };
 
   const onClickFilter = () => {
@@ -59,7 +49,7 @@ export default function Filter(props) {
         filterSelectedOptions
         multiple
         openOnFocus
-        options={props.filterOptions}
+        options={historyFilterOptions}
         getOptionLabel={(option) => option.label}
         PopperComponent={customPopper}
         renderInput={(params) => {
@@ -69,14 +59,15 @@ export default function Filter(props) {
               {...params.InputProps}
               {...rest}
               inputRef={filterInput}
-              placeholder={placeholder}
+              placeholder={!props.filterQuery.length ? "Filter" : ""}
               readOnly
             />
           );
         }}
         onChange={(event, value) => {
-          handleFilterQuery(value);
+          props.setFilterQuery(value);
         }}
+        value={props.filterQuery}
       />
       {/*
       <Tooltip title="Remove filter">

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
@@ -70,6 +70,7 @@ export default function Filter(props) {
               {...rest}
               inputRef={filterInput}
               placeholder={placeholder}
+              readOnly
             />
           );
         }}

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
@@ -26,7 +26,7 @@ export default function Filter(props) {
 
   const customPopper = (props) => {
     return (
-      <Popper {...props} style={{ width: 140 }} placement="bottom-start" />
+      <Popper {...props} style={{ width: 160 }} placement="bottom-start" />
     );
   };
 

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
@@ -1,25 +1,14 @@
 import * as React from "react";
-import { connect } from "react-redux";
 import { Box, Divider, Fade } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
 import { PageHeader } from "../../Components";
 import { Filter, LabelChip, LabeledRecord } from "../HistoryComponents";
-
-import { mapStateToProps } from "../../globals.js";
 import "../../App.css";
-
-const filterOptions = [
-  { value: "note", label: "Contains note" },
-  { value: "prior", label: "Prior knowledge" },
-];
 
 const Root = styled("div")(({ theme }) => ({}));
 
 const HistoryPage = (props) => {
-  const [label, setLabel] = React.useState("relevant");
-  const [filterQuery, setFilterQuery] = React.useState(null);
-
   return (
     <Root aria-label="history page">
       <Fade in>
@@ -34,22 +23,22 @@ const HistoryPage = (props) => {
           >
             <LabelChip
               mobileScreen={props.mobileScreen}
-              label={label}
-              setLabel={setLabel}
+              label={props.label}
+              setLabel={props.setLabel}
             />
             <Divider />
             <Filter
               mobileScreen={props.mobileScreen}
-              filterOptions={filterOptions}
-              setFilterQuery={setFilterQuery}
+              filterQuery={props.filterQuery}
+              setFilterQuery={props.setFilterQuery}
             />
             <Divider />
           </Box>
           <Box className="main-page-body-wrapper">
             <Box className="main-page-body">
               <LabeledRecord
-                label={label}
-                filterQuery={filterQuery}
+                label={props.label}
+                filterQuery={props.filterQuery}
                 mobileScreen={props.mobileScreen}
               />
             </Box>
@@ -60,4 +49,4 @@ const HistoryPage = (props) => {
   );
 };
 
-export default connect(mapStateToProps)(HistoryPage);
+export default HistoryPage;

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
@@ -9,7 +9,10 @@ import { Filter, LabelChip, LabeledRecord } from "../HistoryComponents";
 import { mapStateToProps } from "../../globals.js";
 import "../../App.css";
 
-const filterOptions = [{ value: "note", label: "Contains note" }];
+const filterOptions = [
+  { value: "note", label: "Contains note" },
+  { value: "prior", label: "Prior knowledge" },
+];
 
 const Root = styled("div")(({ theme }) => ({}));
 

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecord.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecord.js
@@ -53,6 +53,15 @@ const LabeledRecord = (props) => {
     return !subset ? [props.label] : [props.label].concat(subset);
   };
 
+  const enableQuery = () => {
+    return !props.is_prior
+      ? true
+      : !(
+          (props.label === "relevant" && !props.n_prior_inclusions) ||
+          (props.label === "irrelevant" && !props.n_prior_exclusions)
+        );
+  };
+
   const {
     data,
     error,
@@ -72,11 +81,7 @@ const LabeledRecord = (props) => {
     ],
     ProjectAPI.fetchLabeledRecord,
     {
-      enabled: !props.is_prior
-        ? true
-        : !props.n_prior_inclusions
-        ? false
-        : true,
+      enabled: enableQuery(),
       getNextPageParam: (lastPage) => lastPage.next_page ?? false,
       refetchOnWindowFocus: false,
     }
@@ -111,8 +116,7 @@ const LabeledRecord = (props) => {
           <CircularProgress />
         </Box>
       )}
-      {props.n_prior_exclusions !== 0 &&
-        props.n_prior_inclusions !== 0 &&
+      {enableQuery() &&
         !isError &&
         !(isLoading || !mounted.current) &&
         isFetched && (

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
@@ -197,16 +197,22 @@ const LabeledRecordCard = (props) => {
             <CardActions className={classes.cardActions}>
               <Tooltip
                 title={
-                  note.editing !== value.id
-                    ? value.included === 1
-                      ? "Convert to irrelevant"
-                      : "Convert to relevant"
-                    : "Save note before converting"
+                  !value.prior
+                    ? note.editing !== value.id
+                      ? value.included === 1
+                        ? "Convert to irrelevant"
+                        : "Convert to relevant"
+                      : "Save note before converting"
+                    : "Prior knowledge cannot be converted"
                 }
               >
                 <span>
                   <IconButton
-                    disabled={isLoading || note.editing === value.id}
+                    disabled={
+                      value.prior === 1 ||
+                      isLoading ||
+                      note.editing === value.id
+                    }
                     onClick={() => {
                       handleClickLabelConvert(value);
                     }}

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
@@ -156,6 +156,11 @@ const LabeledRecordCard = (props) => {
     return doc_id !== note.editing && note.editing !== null;
   };
 
+  // only on history page
+  const disableConvertPrior = (prior) => {
+    return !props.is_prior && prior === 1;
+  };
+
   return (
     <Root>
       {isError && (
@@ -197,19 +202,19 @@ const LabeledRecordCard = (props) => {
             <CardActions className={classes.cardActions}>
               <Tooltip
                 title={
-                  !value.prior
-                    ? note.editing !== value.id
-                      ? value.included === 1
-                        ? "Convert to irrelevant"
-                        : "Convert to relevant"
-                      : "Save note before converting"
-                    : "Prior knowledge cannot be converted"
+                  disableConvertPrior(value.prior)
+                    ? "Prior knowledge cannot be converted"
+                    : note.editing !== value.id
+                    ? value.included === 1
+                      ? "Convert to irrelevant"
+                      : "Convert to relevant"
+                    : "Save note before converting"
                 }
               >
                 <span>
                   <IconButton
                     disabled={
-                      value.prior === 1 ||
+                      disableConvertPrior(value.prior) ||
                       isLoading ||
                       note.editing === value.id
                     }

--- a/asreview/webapp/src/ProjectComponents/ProjectPage.js
+++ b/asreview/webapp/src/ProjectComponents/ProjectPage.js
@@ -74,6 +74,10 @@ const mapStateToProps = (state) => {
 };
 
 const ProjectPage = (props) => {
+  // History page state
+  const [historyLabel, setHistoryLabel] = React.useState("relevant");
+  const [historyFilterQuery, setHistoryFilterQuery] = React.useState([]);
+
   const { data, error, isError, isSuccess } = useQuery(
     ["fetchInfo", { project_id: props.project_id }],
     ProjectAPI.fetchInfo,
@@ -153,7 +157,13 @@ const ProjectPage = (props) => {
 
           {/* History page */}
           {props.nav_state === "history" && (
-            <HistoryPage mobileScreen={props.mobileScreen} />
+            <HistoryPage
+              filterQuery={historyFilterQuery}
+              label={historyLabel}
+              setFilterQuery={setHistoryFilterQuery}
+              setLabel={setHistoryLabel}
+              mobileScreen={props.mobileScreen}
+            />
           )}
 
           {/* Export page */}
@@ -166,7 +176,12 @@ const ProjectPage = (props) => {
 
           {/* Details page */}
           {isSuccess && props.nav_state === "details" && (
-            <DetailsPage info={data} mobileScreen={props.mobileScreen} />
+            <DetailsPage
+              handleNavState={props.handleNavState}
+              info={data}
+              mobileScreen={props.mobileScreen}
+              setHistoryFilterQuery={setHistoryFilterQuery}
+            />
           )}
         </Box>
       </Box>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorLabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorLabeled.js
@@ -49,9 +49,8 @@ export default function PriorLabeled(props) {
           n_prior_exclusions={props.n_prior_exclusions}
           n_prior_inclusions={props.n_prior_inclusions}
         />
-        {(props.n_prior === 0 ||
-          props.n_prior_inclusions === 0 ||
-          props.n_prior_exclusions === 0) && (
+        {((label === "relevant" && props.n_prior_inclusions === 0) ||
+          (label === "irrelevant" && props.n_prior_exclusions === 0)) && (
           <Box className={classes.noPrior}>
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
               {`You have not provided ${label} prior knowledge`}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -51,9 +51,15 @@ const PriorUnlabeled = (props) => {
       onSuccess: (data, variables) => {
         queryClient.invalidateQueries("fetchLabeledStats");
         if (!variables.label) {
-          queryClient.invalidateQueries("fetchIrrelevantLabeledRecord");
+          queryClient.invalidateQueries([
+            "fetchLabeledRecord",
+            { subset: ["irrelevant"] },
+          ]);
         } else {
-          queryClient.invalidateQueries("fetchRelevantLabeledRecord");
+          queryClient.invalidateQueries([
+            "fetchLabeledRecord",
+            { subset: ["relevant"] },
+          ]);
         }
         if (props.keyword) {
           // update cached data

--- a/asreview/webapp/src/globals.js
+++ b/asreview/webapp/src/globals.js
@@ -90,3 +90,9 @@ export const projectModes = {
   SIMULATION: "simulate",
   EXPLORATION: "explore",
 };
+
+// project history filter options
+export const historyFilterOptions = [
+  { value: "note", label: "Contains note" },
+  { value: "prior", label: "Prior knowledge" },
+];


### PR DESCRIPTION
This PR added the prior knowledge option to the filter of the project history page and added a "view" button to the prior knowledge information card of the project details page. This PR also fixed #912 to prevent converting prior knowledge.

![image](https://user-images.githubusercontent.com/17449217/151154986-084576a9-8fe4-41a2-912b-c5e9b2bc1c1e.png)

![image](https://user-images.githubusercontent.com/17449217/151154937-6a7569cb-6186-4d94-a39a-f8061afee621.png)
