### PR TITLE
Rephrase exploration mode banner and labeled record alert

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/ExplorationModeBanner.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/ExplorationModeBanner.js
@@ -8,17 +8,18 @@ const ExplorationModeBanner = (props) => {
       <Banner
         open={props.explorationMode}
         onClose={() => props.setExplorationMode(false)}
-        label="You are screening through a manually pre-labeled dataset."
+        label="You are screening through a completely labeled dataset."
         icon={<InfoOutlinedIcon sx={{ color: "text.secondary" }} />}
         iconProps={{
           sx: { bgcolor: "transparent" },
         }}
-        buttonLabel="read more"
+        buttonLabel="Learn more"
         buttonProps={{
           href: "https://asreview.readthedocs.io/en/latest/lab/exploration.html",
           target: "_blank",
           sx: { color: "text.secondary" },
         }}
+        dismissButtonLabel="Got it"
         dismissButtonProps={{
           sx: { color: "text.secondary" },
         }}

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -131,7 +131,11 @@ const RecordCard = (props) => {
           aria-label="record loaded"
         >
           {/* Previous decision alert */}
-          {isDebugInclusion() && <ExplorationModeRecordAlert />}
+          {props.activeRecord._debug_label !== null && (
+            <ExplorationModeRecordAlert
+              label={!isDebugInclusion() ? "irrelevant" : "relevant"}
+            />
+          )}
 
           <CardContent
             className={`${classes.titleAbstract} record-card-content`}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -31,7 +31,7 @@ const Root = styled("div")(({ theme }) => ({
   [`& .${classes.root}`]: {
     borderRadius: 16,
     marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
+    // marginBottom: theme.spacing(3),
     maxWidth: 960,
   },
 
@@ -106,7 +106,11 @@ const PriorUnlabeled = (props) => {
       )}
       {!isError && (
         <Card elevation={3} className={classes.root}>
-          {isDebugInclusion() && <ExplorationModeRecordAlert />}
+          {props.record._debug_label !== null && (
+            <ExplorationModeRecordAlert
+              label={!isDebugInclusion() ? "irrelevant" : "relevant"}
+            />
+          )}
           <CardContent className="record-card-content">
             <Typography gutterBottom variant="h6">
               {props.record.title ? props.record.title : "No title available"}

--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -7,7 +7,7 @@ export function ExplorationModeRecordAlert(props) {
       severity="info"
       sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
     >
-      Labeled as relevant in the dataset
+      {`Labeled as ${props.label} in the dataset`}
     </Alert>
   );
 }

--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -7,7 +7,7 @@ export function ExplorationModeRecordAlert(props) {
       severity="info"
       sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
     >
-      Labeled as relevant in an earlier study
+      Labeled as relevant in the dataset
     </Alert>
   );
 }


### PR DESCRIPTION
This PR rephrased the text of the exploration mode banner on the project review page and the text of the existing label alert on the record card.

![image](https://user-images.githubusercontent.com/17449217/151382785-6b70db04-c25f-46fc-b9d6-c7e89f61e1ac.png)

![image](https://user-images.githubusercontent.com/17449217/151386200-f3839a3b-61c8-4976-975d-5005951c881a.png)