### PR TITLE
Fix labeled_stats

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -657,6 +657,8 @@ def api_get_labeled_stats(project_id):  # noqa: F401
 
         with open_state(project_path) as s:
             data = s.get_dataset(["label", "query_strategy"])
+            # Drop pending records.
+            data = data[~data['label'].isna()]
             data_prior = data[data["query_strategy"] == "prior"]
 
         response = jsonify({


### PR DESCRIPTION
Fix the api labeled_stats call by dropping the pending records. This should fix https://github.com/asreview/asreview/issues/920
The problem is that there are records pending a decision in the results table. It might be good to have a clear philosophy about which methods of the state return the pending records and which don't, but that is something for another pull request I'd think.