### PR TITLE
Validate project info before updating info

### DIFF
--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -74,7 +74,7 @@ PROJECT_SCHEMA = {
         "reviews": {"type": "array"},
         "feature_matrices": {"type": "array"}
     },
-    "required": ["version", "id", "mode", "reviews", "feature_matrices"]
+    "required": ["version", "id", "mode"]
 }
 
 

--- a/asreview/webapp/utils/project.py
+++ b/asreview/webapp/utils/project.py
@@ -77,6 +77,7 @@ PROJECT_SCHEMA = {
     "required": ["version", "id", "mode", "reviews", "feature_matrices"]
 }
 
+
 class ProjectNotFoundError(Exception):
     pass
 
@@ -217,7 +218,7 @@ def update_project_info(project_id, **kwargs):
     project_info.update(update_vals)
 
     # validate the project info
-    jsonschema.validate(instance=project_info, schema=schema)
+    jsonschema.validate(instance=project_info, schema=PROJECT_SCHEMA)
 
     with open(project_file_path, "w") as fp:
         json.dump(project_info, fp)

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
         'flask_cors',
         'openpyxl',
         'gevent',
+        'jsonschema'
     ],
     extras_require=DEPS,
     entry_points={


### PR DESCRIPTION
This PR proposes to validate the schema of the project file before updating the file. This should avoid potential issues for users and confusion for developers about the (undocumented) schema. @terrymyc what do you think?

I got inspired by the discussions in #928 and #952. 