### PR TITLE
Separate FAB buttons for creating and importing a project

### DIFF
--- a/asreview/webapp/src/App.css
+++ b/asreview/webapp/src/App.css
@@ -44,6 +44,11 @@
   display: flex;
   justify-content: center;
 }
+.main-page-fab {
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+}
 
 .navBar {
   background-color: #ffcc00;

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPage.js
@@ -1,16 +1,6 @@
 import React from "react";
-import { connect } from "react-redux";
-import {
-  Backdrop,
-  Box,
-  Fade,
-  SpeedDial,
-  SpeedDialIcon,
-  SpeedDialAction,
-  Stack,
-} from "@mui/material";
+import { Box, Fade, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { AddOutlined, CreateNewFolderOutlined } from "@mui/icons-material";
 
 import { ActionsFeedbackBar, QuickTourDialog } from "../../Components";
 import { ProjectImportDialog } from "../../ProjectComponents";
@@ -21,40 +11,13 @@ import {
 } from "../DashboardComponents";
 import { SetupDialog } from "../../ProjectComponents/SetupComponents";
 
-const PREFIX = "DashboardPage";
+import { useToggle } from "../../hooks/useToggle";
 
-const classes = {
-  fab: `${PREFIX}-fab`,
-  noProjects: `${PREFIX}-noProjects`,
-  backdropZ: `${PREFIX}-backdropZ`,
-};
-
-const Root = styled("div")(({ theme }) => ({
-  [`& .${classes.fab}`]: {
-    position: "fixed",
-    right: theme.spacing(3),
-    bottom: theme.spacing(3),
-  },
-
-  [`& .${classes.backdropZ}`]: {
-    zIndex: 1000,
-  },
-}));
-
-const mapStateToProps = (state) => {
-  return {
-    nav_state: state.nav_state,
-    project_id: state.project_id,
-  };
-};
+const Root = styled("div")(({ theme }) => ({}));
 
 const DashboardPage = (props) => {
-  const [open, setOpen] = React.useState({
-    dial: false,
-    newProject: false,
-    importProject: false,
-  });
-
+  const [onSetupDialog, toggleSetupDialog] = useToggle();
+  const [onImportDialog, toggleImportDialog] = useToggle();
   const [feedbackBar, setFeedbackBar] = React.useState({
     open: false,
     message: null,
@@ -67,73 +30,24 @@ const DashboardPage = (props) => {
     });
   };
 
-  const handleOpen = () => {
-    setOpen({
-      ...open,
-      dial: true,
-    });
-  };
-
-  const handleClose = () => {
-    setOpen({
-      ...open,
-      dial: false,
-    });
-  };
-
-  const handleCloseNewProject = () => {
-    setOpen({
-      ...open,
-      newProject: false,
-    });
-  };
-
-  const handleCloseProjectImport = () => {
-    setOpen({
-      ...open,
-      importProject: false,
-    });
-  };
-
-  const handleClickAdd = (event, operation) => {
-    event.preventDefault();
-    if (operation === "newProject") {
-      setOpen({
-        ...open,
-        dial: false,
-        newProject: true,
-      });
-    } else if (operation === "importProject") {
-      setOpen({
-        ...open,
-        dial: false,
-        importProject: true,
-      });
-    }
-  };
-
-  const handleProjectSetup = () => {
-    setOpen({
-      ...open,
-      newProject: true,
-    });
-  };
-
   return (
     <Root aria-label="dashboard page">
       <Fade in>
         <Box>
-          <DashboardPageHeader mobileScreen={props.mobileScreen} />
+          <DashboardPageHeader
+            mobileScreen={props.mobileScreen}
+            toggleSetupDialog={toggleSetupDialog}
+            toggleImportDialog={toggleImportDialog}
+          />
           <Box className="main-page-body-wrapper">
             <Stack className="main-page-body" spacing={6}>
               <NumberCard mobileScreen={props.mobileScreen} />
               <ProjectTable
-                handleClickAdd={handleClickAdd}
-                handleProjectSetup={handleProjectSetup}
                 handleAppState={props.handleAppState}
                 handleNavState={props.handleNavState}
                 onNavDrawer={props.onNavDrawer}
                 toggleNavDrawer={props.toggleNavDrawer}
+                toggleSetupDialog={toggleSetupDialog}
               />
             </Stack>
           </Box>
@@ -141,16 +55,16 @@ const DashboardPage = (props) => {
       </Fade>
       <ProjectImportDialog
         mobileScreen={props.mobileScreen}
-        open={open.importProject}
-        onClose={handleCloseProjectImport}
+        open={onImportDialog}
+        onClose={toggleImportDialog}
         setFeedbackBar={setFeedbackBar}
       />
       <SetupDialog
         handleAppState={props.handleAppState}
         handleNavState={props.handleNavState}
         mobileScreen={props.mobileScreen}
-        open={open.newProject}
-        onClose={handleCloseNewProject}
+        open={onSetupDialog}
+        onClose={toggleSetupDialog}
         setFeedbackBar={setFeedbackBar}
       />
       <ActionsFeedbackBar
@@ -159,41 +73,9 @@ const DashboardPage = (props) => {
         open={feedbackBar.open}
         feedback={feedbackBar.message}
       />
-
-      {/* Add button for new or importing project */}
-      <Backdrop open={open.dial} className={classes.backdropZ} />
-      <SpeedDial
-        ariaLabel="add"
-        className={classes.fab}
-        FabProps={{ color: "primary" }}
-        icon={<SpeedDialIcon />}
-        onClose={handleClose}
-        onOpen={handleOpen}
-        open={open.dial}
-      >
-        <SpeedDialAction
-          key={"Import\u00A0project"}
-          icon=<CreateNewFolderOutlined />
-          tooltipTitle={"Import\u00A0project"}
-          tooltipOpen
-          onClick={(event) => {
-            handleClickAdd(event, "importProject");
-          }}
-        />
-        <SpeedDialAction
-          key={"New\u00A0project"}
-          icon=<AddOutlined />
-          tooltipTitle={"New\u00A0project"}
-          tooltipOpen
-          onClick={(event) => {
-            handleClickAdd(event, "newProject");
-          }}
-        />
-      </SpeedDial>
-
       <QuickTourDialog />
     </Root>
   );
 };
 
-export default connect(mapStateToProps)(DashboardPage);
+export default DashboardPage;

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPage.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { Box, Fade, Stack } from "@mui/material";
+import { Box, Fab, Fade, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { Add } from "@mui/icons-material";
 
 import { ActionsFeedbackBar, QuickTourDialog } from "../../Components";
 import { ProjectImportDialog } from "../../ProjectComponents";
@@ -31,12 +32,11 @@ const DashboardPage = (props) => {
   };
 
   return (
-    <Root aria-label="dashboard page">
+    <Root aria-label="projects page">
       <Fade in>
         <Box>
           <DashboardPageHeader
             mobileScreen={props.mobileScreen}
-            toggleSetupDialog={toggleSetupDialog}
             toggleImportDialog={toggleImportDialog}
           />
           <Box className="main-page-body-wrapper">
@@ -53,6 +53,15 @@ const DashboardPage = (props) => {
           </Box>
         </Box>
       </Fade>
+      <Fab
+        className="main-page-fab"
+        color="primary"
+        onClick={toggleSetupDialog}
+        variant="extended"
+      >
+        <Add sx={{ mr: 1 }} />
+        Create
+      </Fab>
       <ProjectImportDialog
         mobileScreen={props.mobileScreen}
         open={onImportDialog}

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPageHeader.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPageHeader.js
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { Add, Upload } from "@mui/icons-material";
+import { Upload } from "@mui/icons-material";
 
 import { TypographyH5Medium } from "../../StyledComponents/StyledTypography.js";
 
@@ -38,24 +38,8 @@ export default function DashboardPageHeader(props) {
     <Root className="main-page-sticky-header-wrapper">
       <Box className="main-page-sticky-header with-button">
         {!props.mobileScreen && <TypographyH5Medium></TypographyH5Medium>}
-        {props.mobileScreen && (
-          <Typography variant="h6">Home dashboard</Typography>
-        )}
+        {props.mobileScreen && <Typography variant="h6">Projects</Typography>}
         <Stack direction="row" spacing={1}>
-          <Tooltip title="New project">
-            <IconButton
-              disableRipple
-              onClick={props.toggleSetupDialog}
-              size={!props.mobileScreen ? "medium" : "small"}
-            >
-              <Avatar className={classes.headerButton}>
-                <Add
-                  color="primary"
-                  fontSize={!props.mobileScreen ? "medium" : "small"}
-                />
-              </Avatar>
-            </IconButton>
-          </Tooltip>
           <Tooltip title="Import project">
             <IconButton
               disableRipple

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPageHeader.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/DashboardPageHeader.js
@@ -1,16 +1,16 @@
 import * as React from "react";
 import {
-  // Avatar,
+  Avatar,
   Box,
-  // IconButton,
-  // Stack,
-  // Tooltip,
-  // Typography,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-// import { Add, Upload } from "@mui/icons-material";
+import { Add, Upload } from "@mui/icons-material";
 
-// import { TypographyH5Medium } from "../../StyledComponents/StyledTypography.js";
+import { TypographyH5Medium } from "../../StyledComponents/StyledTypography.js";
 
 const PREFIX = "DashboardPageHeader";
 
@@ -19,6 +19,7 @@ const classes = {
 };
 
 const Root = styled("div")(({ theme }) => ({
+  background: theme.palette.background.paper,
   [`& .${classes.headerButton}`]: {
     backgroundColor: [
       theme.palette.mode === "dark"
@@ -34,44 +35,42 @@ const Root = styled("div")(({ theme }) => ({
 
 export default function DashboardPageHeader(props) {
   return (
-    <Root>
-      <Box className="main-page-sticky-header-wrapper">
-        <Box className="main-page-sticky-header with-button">
-          {/*
-          {!props.mobileScreen && <TypographyH5Medium></TypographyH5Medium>}
-          {props.mobileScreen && (
-            <Typography variant="h6">Home dashboard</Typography>
-          )}
-          <Stack direction="row" spacing={1}>
-            <Tooltip title="New project">
-              <IconButton
-                disableRipple
-                size={!props.mobileScreen ? "medium" : "small"}
-              >
-                <Avatar className={classes.headerButton}>
-                  <Add
-                    color="primary"
-                    fontSize={!props.mobileScreen ? "medium" : "small"}
-                  />
-                </Avatar>
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Import project">
-              <IconButton
-                disableRipple
-                size={!props.mobileScreen ? "medium" : "small"}
-              >
-                <Avatar className={classes.headerButton}>
-                  <Upload
-                    color="primary"
-                    fontSize={!props.mobileScreen ? "medium" : "small"}
-                  />
-                </Avatar>
-              </IconButton>
-            </Tooltip>
-          </Stack>
-          */}
-        </Box>
+    <Root className="main-page-sticky-header-wrapper">
+      <Box className="main-page-sticky-header with-button">
+        {!props.mobileScreen && <TypographyH5Medium></TypographyH5Medium>}
+        {props.mobileScreen && (
+          <Typography variant="h6">Home dashboard</Typography>
+        )}
+        <Stack direction="row" spacing={1}>
+          <Tooltip title="New project">
+            <IconButton
+              disableRipple
+              onClick={props.toggleSetupDialog}
+              size={!props.mobileScreen ? "medium" : "small"}
+            >
+              <Avatar className={classes.headerButton}>
+                <Add
+                  color="primary"
+                  fontSize={!props.mobileScreen ? "medium" : "small"}
+                />
+              </Avatar>
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Import project">
+            <IconButton
+              disableRipple
+              onClick={props.toggleImportDialog}
+              size={!props.mobileScreen ? "medium" : "small"}
+            >
+              <Avatar className={classes.headerButton}>
+                <Upload
+                  color="primary"
+                  fontSize={!props.mobileScreen ? "medium" : "small"}
+                />
+              </Avatar>
+            </IconButton>
+          </Tooltip>
+        </Stack>
       </Box>
     </Root>
   );

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
@@ -137,7 +137,7 @@ const ProjectTable = (props) => {
 
     if (!project["projectInitReady"]) {
       // open project setup dialog
-      props.handleProjectSetup();
+      props.toggleSetupDialog();
     } else if (!project["projectNeedsUpgrade"]) {
       // open project page
       console.log("Opening project " + project["id"]);
@@ -364,13 +364,7 @@ const ProjectTable = (props) => {
               <Typography sx={{ color: "text.secondary", marginTop: "64px" }}>
                 Your projects will show up here
               </Typography>
-              <Button
-                onClick={(event) => {
-                  props.handleClickAdd(event, "newProject");
-                }}
-              >
-                Get Started
-              </Button>
+              <Button onClick={props.toggleSetupDialog}>Get Started</Button>
               <img
                 src={ElasArrowRightAhead}
                 alt="ElasArrowRightAhead"

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
@@ -140,7 +140,7 @@ const AnalyticsPage = (props) => {
       {allQueriesReady() && (
         <SpeedDial
           ariaLabel="share project analytics"
-          sx={{ position: "absolute", bottom: 24, right: 24 }}
+          className="main-page-fab"
           icon={<Share />}
         >
           {actions.map((action) => (


### PR DESCRIPTION
This PR corrected the misuse of the speed dial according to the material design. A speed dial should include at least three options. The button for importing a project is placed on the header of the page.

![image](https://user-images.githubusercontent.com/17449217/154483449-439e0bc7-1502-4280-b9b0-32b8a114b000.png)

![image](https://user-images.githubusercontent.com/17449217/154483493-fd4bbd59-b6ed-4919-943e-6bae7ae53929.png)