### PR TITLE
add information about a-synchronic labeling to documentation

### DIFF
--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -93,9 +93,10 @@ You are asked to make a decision: relevant or irrelevant?
 While you review the documents, the software continuously improves its
 understanding of your decisions, constantly updating the underlying model.
 
-More specifically, each labeling decision of the user starts the training of a new model given there is no model being trained at that time.
+More specifically, each labeling decision of the user starts the training 
+of a new model given there is no model being trained at that time.
 When this new model is trained, the unseen records' rank order is
-updated. Training and labeling occur a-synchronic. With fast models, a new
+updated. Training and labeling occur asynchronous. With fast models, a new
 ranking will probably be available before the user finished reading the text. With
 slower models, training continues until a new model is trained, and the user can
 continue screening the next record in line (2nd, 3rd, etc.). Therefore, the

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -93,6 +93,16 @@ You are asked to make a decision: relevant or irrelevant?
 While you review the documents, the software continuously improves its
 understanding of your decisions, constantly updating the underlying model.
 
+More specifically, each labeling decision of the user triggers a new model.
+When this new model is done training, the unseen records' rank order is
+updated. Training and labeling occur a-synchronic. With fast models, a new
+model will probably be ready before the user is done reading the text. With
+slower models, training continues until a new model is done, and the user can
+continue screening the next record in line (2nd, 3rd, etc.). Therefore, the
+record shown to the user can be the one with the highest relevance score of
+the new model or the highest-ranked as resulted from the old model until a new
+model is done. 
+
 As you keep reviewing documents and providing more labels, the number of
 unlabeled documents left in the dataset will decline. When to stop is left to
 the you. The `blogpost *ASReview Class 101* <https://asreview.nl/blog/asreview-class-101/>`_

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -93,7 +93,7 @@ You are asked to make a decision: relevant or irrelevant?
 While you review the documents, the software continuously improves its
 understanding of your decisions, constantly updating the underlying model.
 
-More specifically, each labeling decision of the user triggers a new model.
+More specifically, each labeling decision of the user starts the training of a new model given there is no model being trained at that time.
 When this new model is done training, the unseen records' rank order is
 updated. Training and labeling occur a-synchronic. With fast models, a new
 model will probably be ready before the user is done reading the text. With

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -96,7 +96,7 @@ understanding of your decisions, constantly updating the underlying model.
 More specifically, each labeling decision of the user starts the training of a new model given there is no model being trained at that time.
 When this new model is trained, the unseen records' rank order is
 updated. Training and labeling occur a-synchronic. With fast models, a new
-model will probably be ready before the user is done reading the text. With
+ranking will probably be available before the user finished reading the text. With
 slower models, training continues until a new model is done, and the user can
 continue screening the next record in line (2nd, 3rd, etc.). Therefore, the
 record shown to the user can be the one with the highest relevance score of

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -97,7 +97,7 @@ More specifically, each labeling decision of the user starts the training of a n
 When this new model is trained, the unseen records' rank order is
 updated. Training and labeling occur a-synchronic. With fast models, a new
 ranking will probably be available before the user finished reading the text. With
-slower models, training continues until a new model is done, and the user can
+slower models, training continues until a new model is trained, and the user can
 continue screening the next record in line (2nd, 3rd, etc.). Therefore, the
 record shown to the user can be the one with the highest relevance score of
 the second last model or the highest-ranked as resulted from the latest model until a new

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -94,7 +94,7 @@ While you review the documents, the software continuously improves its
 understanding of your decisions, constantly updating the underlying model.
 
 More specifically, each labeling decision of the user starts the training of a new model given there is no model being trained at that time.
-When this new model is done training, the unseen records' rank order is
+When this new model is trained, the unseen records' rank order is
 updated. Training and labeling occur a-synchronic. With fast models, a new
 model will probably be ready before the user is done reading the text. With
 slower models, training continues until a new model is done, and the user can

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -101,7 +101,7 @@ slower models, training continues until a new model is done, and the user can
 continue screening the next record in line (2nd, 3rd, etc.). Therefore, the
 record shown to the user can be the one with the highest relevance score of
 the new model or the highest-ranked as resulted from the old model until a new
-model is done. 
+model is trained. 
 
 As you keep reviewing documents and providing more labels, the number of
 unlabeled documents left in the dataset will decline. When to stop is left to

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -100,7 +100,7 @@ ranking will probably be available before the user finished reading the text. Wi
 slower models, training continues until a new model is done, and the user can
 continue screening the next record in line (2nd, 3rd, etc.). Therefore, the
 record shown to the user can be the one with the highest relevance score of
-the new model or the highest-ranked as resulted from the old model until a new
+the second last model or the highest-ranked as resulted from the latest model until a new
 model is trained. 
 
 As you keep reviewing documents and providing more labels, the number of


### PR DESCRIPTION
This PR adds more detailed information to the documentation about the a-synchronic labeling/training. 

