### PR TITLE
add link to discussion board about when to stop screening

### DIFF
--- a/docs/source/features/post_screening.rst
+++ b/docs/source/features/post_screening.rst
@@ -1,9 +1,10 @@
 Post-Screening
 ==============
 
-After you stop screening, or anytime you want to take a break, you can
+After you decide to `stop screening <https://github.com/asreview/asreview/discussions/557>`_ 
+or anytime you want to take a break, you can
 return to the project dashboard by clicking the hamburger menu on the
-top-left. Below, you find the options in the project dashboard.
+top-left. Below, you will find the options in the project dashboard.
 
 
 Download Results

--- a/docs/source/features/screening.rst
+++ b/docs/source/features/screening.rst
@@ -118,7 +118,10 @@ you hoover over the plot you can see the moving average for any batch of 10
 labeled records.
 
 Underneath the progress plot, the number of irrelevant records after the last
-relevant is shown. This statistic might help in deciding when to stop reviewing.
+relevant is shown. This statistic might help in deciding when to stop
+reviewing, see `blogpost *ASReview Class 101*
+<https://asreview.nl/blog/asreview-class-101/>`_ for more instructions how to
+use this graph.
 
 
 DOI

--- a/docs/source/guides/activelearning.rst
+++ b/docs/source/guides/activelearning.rst
@@ -82,7 +82,8 @@ be found. So researchers might either stop too early and potentially miss many
 relevant papers, or stop too late, causing unnecessary further reading[20].
 That is, one can decide to stop reviewing after a certain amount of
 non-relevant papers have been found in succession[21], but this is up to the
-user to decide.
+user to decide. See the `discussion board <https://github.com/asreview/asreview/discussions/557>`_
+for more options. 
 
 
 1.	Harrison, H., et al., Software tools to support title and abstract screening for systematic reviews in healthcare: an evaluation. BMC Medical Research Methodology, 2020. 20(1): p. 7.

--- a/docs/source/lab/oracle.rst
+++ b/docs/source/lab/oracle.rst
@@ -95,8 +95,9 @@ understanding of your decisions, constantly updating the underlying model.
 
 As you keep reviewing documents and providing more labels, the number of
 unlabeled documents left in the dataset will decline. When to stop is left to
-the you. The `blogpost *ASReview Class 101* <https://asreview.nl/blog/asreview-class-101/>`_
-provides some tips on stopping with screening.
+the user. The `blogpost *ASReview Class 101* <https://asreview.nl/blog/asreview-class-101/>`_
+and the `discussion board <https://github.com/asreview/asreview/discussions/557>`_ 
+provide some tips on when to stop with screening.
 
 
 Download Results


### PR DESCRIPTION
This PR adds a link to the discussion board (https://github.com/asreview/asreview/discussions/557) in the documentation whenever we discuss how to decide when to stop screening. 