### PR TITLE
Extend docs on RIS reader and writer (i.e. partly labeled RIS)

### DIFF
--- a/docs/source/features/pre_screening.rst
+++ b/docs/source/features/pre_screening.rst
@@ -80,8 +80,7 @@ prior knowledge to screen the unseen records. The labeled records will be
 recognized by ASReview LAB and are used to train the first iteration of the
 active learning model. This might be helpful if you switch from screening in
 another tool to screening with ASReview, or when updating an existing
-systematic review with more recent publications. For more options, see the
-`discussion board <https://github.com/asreview/asreview/discussions/975>`_. 
+systematic review with more recent publications. For more options, see `How to collaborate with ASReview? <https://github.com/asreview/asreview/discussions/975>`_ on the ASReview discussion board. 
 
 .. note::
 

--- a/docs/source/features/pre_screening.rst
+++ b/docs/source/features/pre_screening.rst
@@ -74,20 +74,28 @@ Select one of the :ref:`benchmark datasets <benchmark-datasets>`.
 Partly Labeled Data
 -------------------
 
-If you want to include decisions you've already made prior to setting up your
-project, you can upload a partly labeled dataset containg labels for part of
-the data and unlabeled records you want to screen with ASReview. This might be
-helpful if you switch from screening in another tool to screening with
-ASReview, or when updating an existing systematic review with more recent
-publications.
+A partly labeled dataset contains labeling decessions for part of the records,
+and part of the data does not have labels. The goal is to use the labels as
+prior knowledge to screen the unseen records. The labeled records will be
+recognized by ASReview LAB and are used to train the first iteration of the
+active learning model. This might be helpful if you switch from screening in
+another tool to screening with ASReview, or when updating an existing
+systematic review with more recent publications. For more options, see the
+`discussion board <https://github.com/asreview/asreview/discussions/975>`_. 
 
-Currently, this can be done by merging your dataset with labeled and unlabeled
-records via Excel or another reference manager. Your dataset should contain a
-column, called *label_included* (or: final_included, label, label_included,
-included_label, included_final, included, included_flag, include) which is
-filled with 1's or 0's for the publications that you have already screened,
-and is empty for the records that you still need to screen using
-ASReview.
+.. note::
+
+  Merging labeled with unlabeled data should be done outside ASReview LAB, for
+  example in reference manager software.
+
+
+For tabular datasets (:ref:`e.g., CSV, XLSX <data-format>`), the dataset should
+contain a column, called :ref:`label_included <column-names>` which is
+filled with 1's or 0's for the records that are already screened
+and is empty for the records that you still need to screen using ASReview.
+
+For RIS file format the dataset should contain ???
+
 
 To use a partly labeled dataset:
 
@@ -97,7 +105,7 @@ To use a partly labeled dataset:
 4. Select your partly labeled dataset.
 
 ASReview will recognize the column with the labels and show you the number of
-prior relevant/irrelevant papers in the section *Prior Knowledge*.
+prior relevant/irrelevant records in the section *Prior Knowledge*.
 
 .. _select-prior-knowledge:
 

--- a/docs/source/features/pre_screening.rst
+++ b/docs/source/features/pre_screening.rst
@@ -94,7 +94,7 @@ filled with 1's or 0's for the records that are already screened
 and is empty for the records that you still need to screen using ASReview.
 
 For the RIS file format, the dataset is handled automatically. The label 
-(ASReview_relevant, ASReview_irrelevant, ASReview_not_seen) is stored under the
+(`ASReview_relevant`, `ASReview_irrelevant`, `ASReview_not_seen`) is stored under the
 N1 (Notes) tag. If the N1 tag is missing, it will be created for each record
 after importing the dataset. An example of a RIS file with N1 tag in the `ASReview
 GitHub repository <https://github.com/asreview/asreview/blob/master/tests/demo_data/baseline_tag-notes_labels.ris>`_

--- a/docs/source/features/pre_screening.rst
+++ b/docs/source/features/pre_screening.rst
@@ -96,8 +96,8 @@ and is empty for the records that you still need to screen using ASReview.
 For the RIS file format, the dataset is handled automatically. The label 
 (ASReview_relevant, ASReview_irrelevant, ASReview_not_seen) is stored under the
 N1 (Notes) tag. If the N1 tag is missing, it will be created for each record
-after importing the dataset. You can find a representative demo dataset in our
-`GitHub repository <https://github.com/asreview/asreview/blob/master/tests/demo_data/baseline_tag-notes_labels.ris>`_
+after importing the dataset. An example of a RIS file with N1 tag in the `ASReview
+GitHub repository <https://github.com/asreview/asreview/blob/master/tests/demo_data/baseline_tag-notes_labels.ris>`_
 where all records are valid. You can also find a record without a
 N1 (Notes) tag defined - the tag will be created after importing to
 ASReview and populated with a label.

--- a/docs/source/intro/datasets.rst
+++ b/docs/source/intro/datasets.rst
@@ -7,8 +7,8 @@ search. To create such a dataset for a systematic review, typically an `online
 library search <https://asreview.nl/blog/the-importance-of-abstracts/>`__ is
 performed for all studies related to a particular topic.
 
-It is possible to use your own dataset with unlabeled, partly labeled (where
-the labeled records are used for training a model for the unlabeled records),
+It is possible to use your own dataset with unlabeled, :ref:`partly labeled data <partly-labeled-data>` 
+(where the labeled records are used for training a model for the unlabeled records),
 or fully labeled records (used for the Simulation mode). For testing and
 demonstrating ASReview (used for the Exploration mode), the software offers
 `Benchmark Datasets`_. Also, an extension with :doc:`Covid19 related
@@ -99,7 +99,7 @@ not have access you might want to read this `blog post
 names are allowed, see the table. The use is twofold:
 
 - **Screening**: In ASReview LAB, if labels are available for a part of the
-  dataset (see :doc:`partly labeled data <../features/pre_screening>`), the
+  dataset (see :ref:`partly labeled data <partly-labeled-data>`), the
   labels will be automatically detected and used for prior knowledge. The first
   iteration of the model will then be based on these decisions and used to
   predict relevance scores for the unlabeled part of the data.

--- a/docs/source/intro/datasets.rst
+++ b/docs/source/intro/datasets.rst
@@ -23,6 +23,7 @@ publications <../extensions/extension_covid19>` is available.
     has to offer.
 
 
+.. _data-format:
 
 Data Format
 -----------
@@ -41,6 +42,8 @@ formats:
    The preferred file encoding is *UTF-8* or *latin1*.
 
 For tabular data files, the software accepts a set of predetermined column names:
+
+.. _column-names:
 
 .. table:: Table with column name definitions
     :widths: 20 60 20


### PR DESCRIPTION
This PR adds more information about using partly labeled data. 

To do:

- [x] add description on how to prepare a partly labeled dataset in RIS file format (@ottomattas )
- [x] add a screenshot of how the RIS file should look like (@ottomattas )