### PR TITLE
Adjust interface of settings and help dialog

### DIFF
--- a/asreview/webapp/src/App.css
+++ b/asreview/webapp/src/App.css
@@ -104,3 +104,20 @@
 .number-card-content-text {
   font-weight: 600;
 }
+
+.dialog-header {
+  align-items: center;
+  justify-content: space-between;
+}
+.dialog-header-button {
+  align-items: center;
+}
+.dialog-header-button.left {
+  padding-left: 24px;
+}
+.dialog-header-button.left-empty {
+  padding-left: 48px;
+}
+.dialog-header-button.right {
+  padding-right: 24px;
+}

--- a/asreview/webapp/src/Components/HelpDialog.js
+++ b/asreview/webapp/src/Components/HelpDialog.js
@@ -7,19 +7,28 @@ import {
   CardHeader,
   Dialog,
   DialogContent,
+  DialogTitle,
   Divider,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
+  Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 
-import { Description, Feedback, QuestionAnswer } from "@mui/icons-material";
+import {
+  Close,
+  Description,
+  Feedback,
+  QuestionAnswer,
+} from "@mui/icons-material";
 
 import ErrorHandler from "../ErrorHandler";
 import { AppBarWithinDialog, OpenInNewIconStyled } from "../Components";
+import { StyledIconButton } from "../StyledComponents/StyledButton.js";
 
 import { UtilsAPI } from "../api/index.js";
 import { toggleHelpDialog } from "../redux/actions";
@@ -82,15 +91,32 @@ const HelpDialog = (props) => {
       open={props.onHelpDialog}
       onClose={props.toggleHelpDialog}
       scroll="paper"
-      fullWidth={true}
-      maxWidth={"sm"}
+      fullWidth
+      maxWidth="sm"
       aria-labelledby="scroll-dialog-help"
     >
-      <AppBarWithinDialog
-        onClickStartIcon={props.toggleHelpDialog}
-        title="Help"
-      />
-      <DialogContent sx={{ padding: "0px 0px 20px 0px" }}>
+      {!props.mobileScreen && (
+        <Stack className="dialog-header" direction="row" spacing={1}>
+          <StyledIconButton className="dialog-header-button left-empty" />
+          <DialogTitle>Help</DialogTitle>
+          <Tooltip title="Close">
+            <StyledIconButton
+              className="dialog-header-button right"
+              onClick={props.toggleHelpDialog}
+            >
+              <Close />
+            </StyledIconButton>
+          </Tooltip>
+        </Stack>
+      )}
+
+      {props.mobileScreen && (
+        <AppBarWithinDialog
+          onClickStartIcon={props.toggleHelpDialog}
+          title="Help"
+        />
+      )}
+      <DialogContent dividers sx={{ padding: "0px 0px 20px 0px" }}>
         <List>
           <ListItem>
             <Typography display="block" sx={{ paddingLeft: "20px" }}>

--- a/asreview/webapp/src/Components/SettingsDialog.js
+++ b/asreview/webapp/src/Components/SettingsDialog.js
@@ -55,7 +55,7 @@ const classes = {
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
   [`& .${classes.content}`]: {
-    height: 688,
+    height: 588,
     padding: "0px 0px 10px 0px",
   },
 }));
@@ -281,7 +281,7 @@ const SettingsDialog = (props) => {
             maxWidth="md"
             sx={{ paddingTop: "10px", paddingBottom: "10px" }}
           >
-            <Card sx={{ height: 500, overflowY: "scroll" }}>
+            <Card sx={{ height: 400, overflowY: "scroll" }}>
               <CardContent>
                 <Typography
                   variant="h5"

--- a/asreview/webapp/src/Components/SettingsDialog.js
+++ b/asreview/webapp/src/Components/SettingsDialog.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useQuery } from "react-query";
 import { connect } from "react-redux";
 import {
   Box,
@@ -21,11 +22,21 @@ import {
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import { AppBarWithinDialog, OpenInNewIconStyled } from "../Components";
+import { BaseAPI } from "../api/index.js";
 import { fontSizeOptions, donateURL } from "../globals.js";
+import { setASReviewVersion } from "../redux/actions";
 
 const mapStateToProps = (state) => {
   return {
     asreview_version: state.asreview_version,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setASReviewVersion: (asreview_version) => {
+      dispatch(setASReviewVersion(asreview_version));
+    },
   };
 };
 
@@ -35,6 +46,15 @@ const SettingsDialog = (props) => {
   // second layer state
   const [fontSizeSetting, setFontSizeSetting] = useState(false);
   const [shortcutSetting, setShortcutSetting] = useState(false);
+
+  const { isError } = useQuery("boot", BaseAPI.boot, {
+    enabled: props.asreview_version === undefined,
+    onSuccess: (data) => {
+      // set the version of asreview
+      props.setASReviewVersion(data.version);
+    },
+    refetchOnWindowFocus: false,
+  });
 
   // second layer toggle
   const toggleFontSizeSetting = () => {
@@ -184,7 +204,9 @@ const SettingsDialog = (props) => {
                     About ASReview LAB <OpenInNewIconStyled />
                   </React.Fragment>
                 }
-                secondary={"Version " + props.asreview_version}
+                secondary={`Version ${
+                  !isError ? props.asreview_version : `N/A`
+                }`}
               />
             </ListItem>
             {donateURL !== undefined && (
@@ -418,4 +440,4 @@ const SettingsDialog = (props) => {
   );
 };
 
-export default connect(mapStateToProps)(SettingsDialog);
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsDialog);

--- a/asreview/webapp/src/Components/SettingsDialog.js
+++ b/asreview/webapp/src/Components/SettingsDialog.js
@@ -406,7 +406,7 @@ const SettingsDialog = (props) => {
               <ListItemIcon>
                 <InfoOutlined />
               </ListItemIcon>
-              <ListItemText secondary="While screening, you can press a key (or a combination of keys) to label a record as relevant or irrelevant, or to return to the previous decision." />
+              <ListItemText secondary="While reviewing, you can press a key (or a combination of keys) to label a record as relevant or irrelevant, to return to the previous decision, or to add a note." />
             </ListItem>
             <ListItem>
               <ListItemIcon></ListItemIcon>
@@ -468,6 +468,26 @@ const SettingsDialog = (props) => {
                       variant="body2"
                     >
                       Return to the previous decision
+                    </Typography>
+                  </Grid>
+                </Grid>
+                <Grid container>
+                  <Grid item style={{ width: 135 }}>
+                    <Typography
+                      color="textSecondary"
+                      display="block"
+                      variant="body2"
+                    >
+                      Press <b>N</b> or <b>Shift + N</b>:
+                    </Typography>
+                  </Grid>
+                  <Grid item>
+                    <Typography
+                      color="textSecondary"
+                      display="block"
+                      variant="body2"
+                    >
+                      Add a note
                     </Typography>
                   </Grid>
                 </Grid>

--- a/asreview/webapp/src/ProjectComponents/ProjectImportDialog.js
+++ b/asreview/webapp/src/ProjectComponents/ProjectImportDialog.js
@@ -7,31 +7,11 @@ import {
   Stack,
   Tooltip,
 } from "@mui/material";
-import { styled } from "@mui/material/styles";
 import { Close, Feedback } from "@mui/icons-material";
 
 import { ImportFromFile } from "../ProjectComponents";
 import { StyledIconButton } from "../StyledComponents/StyledButton.js";
 import { ProjectAPI } from "../api/index.js";
-
-const PREFIX = "ProjectImportDialog";
-
-const classes = {
-  title: `${PREFIX}-title`,
-  titleButton: `${PREFIX}-title-button`,
-};
-
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-  [`& .${classes.title}`]: {
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-
-  [`& .${classes.titleButton}`]: {
-    alignItems: "center",
-    paddingRight: 24,
-  },
-}));
 
 const ProjectImportDialog = (props) => {
   const queryClient = useQueryClient();
@@ -68,7 +48,7 @@ const ProjectImportDialog = (props) => {
   }, [props.open]);
 
   return (
-    <StyledDialog
+    <Dialog
       open={props.open}
       fullScreen={props.mobileScreen}
       fullWidth
@@ -84,9 +64,13 @@ const ProjectImportDialog = (props) => {
           }),
       }}
     >
-      <Stack className={classes.title} direction="row" spacing={1}>
+      <Stack className="dialog-header" direction="row" spacing={1}>
         <DialogTitle>Import project</DialogTitle>
-        <Stack className={classes.titleButton} direction="row" spacing={1}>
+        <Stack
+          className="dialog-header-button right"
+          direction="row"
+          spacing={1}
+        >
           <Tooltip title="Send feedback">
             <StyledIconButton
               component={"a"}
@@ -114,7 +98,7 @@ const ProjectImportDialog = (props) => {
           reset={reset}
         />
       </DialogContent>
-    </StyledDialog>
+    </Dialog>
   );
 };
 

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
@@ -45,24 +45,12 @@ const steps = ["Basic information", "Data", "Model"];
 const PREFIX = "SetupDialog";
 
 const classes = {
-  title: `${PREFIX}-title`,
-  closeButton: `${PREFIX}-close-button`,
   content: `${PREFIX}-content`,
   stepper: `${PREFIX}-stepper`,
   form: `${PREFIX}-form`,
 };
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
-  [`& .${classes.title}`]: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-
-  [`& .${classes.closeButton}`]: {
-    paddingRight: 24,
-  },
-
   [`& .${classes.content}`]: {
     overflowY: "hidden",
     paddingLeft: 0,
@@ -533,13 +521,17 @@ const SetupDialog = (props) => {
     >
       {!addDataset && !addPriorKnowledge && (
         <Fade in={!addDataset}>
-          <Box className={classes.title}>
+          <Stack className="dialog-header" direction="row">
             <DialogTitle>Create a new project</DialogTitle>
             <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
               {props.project_id && (activeStep === 0 || activeStep === 2) && (
                 <SavingStateBox isSaving={isSaving()} />
               )}
-              <Box className={classes.closeButton}>
+              <Stack
+                className="dialog-header-button right"
+                direction="row"
+                spacing={1}
+              >
                 <Tooltip title="Send feedback">
                   <StyledIconButton
                     component={"a"}
@@ -556,16 +548,20 @@ const SetupDialog = (props) => {
                     </StyledIconButton>
                   </Tooltip>
                 )}
-              </Box>
+              </Stack>
             </Stack>
-          </Box>
+          </Stack>
         </Fade>
       )}
       {addDataset && (
         <Fade in={addDataset}>
-          <Box className={classes.title}>
+          <Stack className="dialog-header" direction="row">
             <DialogTitle>Dataset</DialogTitle>
-            <Stack direction="row" spacing={2} className={classes.closeButton}>
+            <Stack
+              direction="row"
+              spacing={1}
+              className="dialog-header-button right"
+            >
               <Button disabled={isAddingDataset} onClick={handleDiscardDataset}>
                 Discard Changes
               </Button>
@@ -578,12 +574,12 @@ const SetupDialog = (props) => {
                 Save
               </LoadingButton>
             </Stack>
-          </Box>
+          </Stack>
         </Fade>
       )}
       {addPriorKnowledge && (
         <Fade in={addPriorKnowledge}>
-          <Box className={classes.title}>
+          <Stack className="dialog-header" direction="row">
             <DialogTitle>Prior knowledge</DialogTitle>
             <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
               {isEnoughPriorKnowledge() && (
@@ -595,7 +591,7 @@ const SetupDialog = (props) => {
               {labeledStats?.n_prior !== 0 && (
                 <SavingStateBox isSaving={isSavingPriorKnowledge()} />
               )}
-              <Box className={classes.closeButton}>
+              <Box className="dialog-header-button right">
                 <Button
                   variant={!isEnoughPriorKnowledge() ? "text" : "contained"}
                   onClick={toggleAddPriorKnowledge}
@@ -604,7 +600,7 @@ const SetupDialog = (props) => {
                 </Button>
               </Box>
             </Stack>
-          </Box>
+          </Stack>
         </Fade>
       )}
       <Divider />

--- a/asreview/webapp/src/api/UtilsAPI.js
+++ b/asreview/webapp/src/api/UtilsAPI.js
@@ -2,10 +2,10 @@ import { axiosErrorHandler } from "./axiosErrorHandler";
 import axios from "axios";
 
 class UtilsAPI {
-  static faq = () => {
+  static fetchFAQ = ({ queryKey }) => {
     const url =
       "https://raw.githubusercontent.com/asreview/asreview/master/asreview/webapp/help.json";
-    return new Promise(function (resolve, reject) {
+    return new Promise((resolve, reject) => {
       axios
         .get(url)
         .then((result) => {


### PR DESCRIPTION
This PR adjusted the interface of the settings and help dialog for version 1. The current interface is retained for the mobile screen.

![image](https://user-images.githubusercontent.com/17449217/158777973-828ab553-c235-4c31-9c59-5904a621839a.png)
![image](https://user-images.githubusercontent.com/17449217/158778018-2a806cef-f4e8-473d-847c-b52a507ac9c6.png)
![image](https://user-images.githubusercontent.com/17449217/158778065-da91bd0f-a932-40e6-ba68-83e7e9da1dd8.png)
![image](https://user-images.githubusercontent.com/17449217/158778116-8e855205-5f7f-4992-96d4-d341a8430764.png)
