### PR TITLE
Fix hidden project table navigation on some screens

### DIFF
--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
@@ -52,6 +52,7 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
   [`&.${classes.root}`]: {
     width: "100%",
     borderRadius: 16,
+    marginBottom: 64,
   },
 
   [`& .${classes.error}`]: {


### PR DESCRIPTION
## Before

<img width="336" alt="Screenshot 2022-03-30 at 12 27 42" src="https://user-images.githubusercontent.com/12981139/160811795-e8177268-9d9d-4745-bf37-290157778930.png">

## After

<img width="423" alt="Screenshot 2022-03-30 at 12 29 52" src="https://user-images.githubusercontent.com/12981139/160811806-f4c08230-207a-447f-8c4f-3d77d12e4ccc.png">
