### PR TITLE
Display project check box when clicking Export of project created in <1.0 version

### DIFF
--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
@@ -431,18 +431,7 @@ const ProjectTable = (props) => {
                   };
 
                   const onClickProjectExport = () => {
-                    if (
-                      row["reviews"][0] === undefined ||
-                      row["reviews"][0]["status"] === projectStatuses.SETUP ||
-                      row["projectNeedsUpgrade"]
-                    ) {
-                      queryClient.prefetchQuery(
-                        ["fetchExportProject", { project_id: row.id }],
-                        ProjectAPI.fetchExportProject
-                      );
-                    } else {
-                      openProject(row, "export");
-                    }
+                    openProject(row, "export");
                   };
 
                   const onClickProjectDetails = () => {


### PR DESCRIPTION
This PR displayed the project check dialog when the Export button of the project created in the <1.0 version is clicked, rather than directly exporting the `.asreview` file, to be consistent with clicking other quick buttons and to avoid unexpected exporting behavior. However, it is still not possible to export the dataset before upgrading the project.