### PR TITLE
Improve text to explain Analytics charts

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
@@ -336,8 +336,8 @@ export default function ProgressDensityChart(props) {
                                 Presence of relevant records
                               </Typography>
                               <Typography variant="body2">
-                                More relevant records may appear. Continue
-                                reviewing to discover more.
+                                Relevant records appear. Continue reviewing to
+                                discover more.
                               </Typography>
                             </Box>
                           </Stack>
@@ -354,9 +354,9 @@ export default function ProgressDensityChart(props) {
                                 Persistent irrelevant records
                               </Typography>
                               <Typography variant="body2">
-                                More relevant records might not appear. Refer to
-                                your stopping rules to decide if you want to
-                                continue reviewing.
+                                Relevant records do not appear. Refer to your
+                                stopping rules to decide if you want to continue
+                                reviewing.
                               </Typography>
                             </Box>
                           </Stack>

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
@@ -335,7 +335,10 @@ export default function ProgressDensityChart(props) {
                               <Typography variant="subtitle2">
                                 Presence of relevant records
                               </Typography>
-                              <Typography variant="body2">
+                              <Typography
+                                variant="body2"
+                                sx={{ color: "text.secondary" }}
+                              >
                                 Relevant records appear. Continue reviewing to
                                 discover more.
                               </Typography>
@@ -353,7 +356,10 @@ export default function ProgressDensityChart(props) {
                               <Typography variant="subtitle2">
                                 Persistent irrelevant records
                               </Typography>
-                              <Typography variant="body2">
+                              <Typography
+                                variant="body2"
+                                sx={{ color: "text.secondary" }}
+                              >
                                 Relevant records do not appear. Refer to your
                                 stopping rules to decide if you want to continue
                                 reviewing.

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
@@ -124,7 +124,7 @@ const customTooltip = ({ series, seriesIndex, dataPointIndex, w }) => {
     "</span>" +
     "</div>" +
     `<p class="tooltip-label-text-secondary ProgressRecallChart-tooltip-label-text-secondary-color">` +
-    "Relevant records you may find so far if you manually review all the records" +
+    "Relevant records you may have found so far if you manually review all the records" +
     "</p>" +
     "</div>" +
     `<h6 class="tooltip-label-number ProgressRecallChart-tooltip-label-random-number">` +


### PR DESCRIPTION
This PR improved the text to explain the charts on the Analytics page.

![image](https://user-images.githubusercontent.com/17449217/166217281-f495853a-ca65-43f2-bca0-6f729f7b5553.png)

![image](https://user-images.githubusercontent.com/17449217/166216873-288566e7-6685-478f-ae24-359449fc9ece.png)
