### PR TITLE
Add informative error when feature extractor is poorly designed

### DIFF
--- a/asreview/review/base.py
+++ b/asreview/review/base.py
@@ -110,6 +110,15 @@ class BaseReview(ABC):
                     as_data.bodies,
                     as_data.keywords
                 )
+
+                # check if the number of records after the transform equals
+                # the number of in the dataset
+                if self.X.shape[0] != len(as_data):
+                    raise ValueError(
+                        "Dataset has {} records while feature "
+                        "extractor returns {} records"
+                        .format(len(as_data), self.X.shape[0]))
+
                 state.add_feature_matrix(self.X)
 
             # Check if the number or records in the feature matrix matches the


### PR DESCRIPTION
Check number of records after feature extraction. This should be equal to the number of records in the dataset. This improved error might help developers to debug errors with the feature extraction. 