### PR TITLE
Fix int overflow bug

### DIFF
--- a/asreview/webapp/run_model.py
+++ b/asreview/webapp/run_model.py
@@ -126,8 +126,9 @@ def train_model(project_id, label_method=None):
                 "Project {project_id} - No new labels since last run.")
             return
 
-        query_record_ids = np.array([x[0] for x in diff_history], dtype=int)
-        inclusions = np.array([x[1] for x in diff_history], dtype=int)
+        query_record_ids = np.array([x[0] for x in diff_history],
+                                    dtype=np.int64)
+        inclusions = np.array([x[1] for x in diff_history], dtype=np.int64)
 
         query_idx = convert_id_to_idx(as_data, query_record_ids)
 


### PR DESCRIPTION
This fixes the int overflow bug (#1064) that occurs on Windows systems if the dataset has a column record_id and the entries are integers that are too large for the Python/Windows 32 bit int. Apparently this is a thing that does not occur on mac: https://stackoverflow.com/questions/38314118/overflowerror-python-int-too-large-to-convert-to-c-long-on-windows-but-not-ma