### PR TITLE
Display simulation progress in circular gauge chart

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
@@ -140,7 +140,9 @@ const AnalyticsPage = (props) => {
                   <Grid container spacing={3}>
                     <Grid item xs={12} sm={5}>
                       <ProgressChart
+                        isSimulating={props.isSimulating}
                         mobileScreen={props.mobileScreen}
+                        mode={props.mode}
                         progressQuery={progressQuery}
                       />
                     </Grid>

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
@@ -3,6 +3,8 @@ import Chart from "react-apexcharts";
 import { Card, CardContent } from "@mui/material";
 import { styled, useTheme } from "@mui/material/styles";
 
+import { projectModes } from "../../globals";
+
 const PREFIX = "ProgressChart";
 
 const classes = {
@@ -35,8 +37,14 @@ export default function ProgressChart(props) {
     : null;
 
   const formattedTotal = React.useCallback(() => {
-    return n_papers ? n_papers.toLocaleString("en-US") : 0;
-  }, [n_papers]);
+    if (props.mode !== projectModes.SIMULATION || !props.isSimulating) {
+      return n_papers ? n_papers.toLocaleString("en-US") : 0;
+    } else {
+      return (
+        Math.round(((n_included + n_excluded) / n_papers) * 10000) / 100 + "%"
+      );
+    }
+  }, [props.isSimulating, props.mode, n_included, n_excluded, n_papers]);
 
   /**
    * Chart data array
@@ -86,7 +94,10 @@ export default function ProgressChart(props) {
             },
             total: {
               show: true,
-              label: "Total records",
+              label:
+                props.mode !== projectModes.SIMULATION || !props.isSimulating
+                  ? "Total records"
+                  : "Simulation progress",
               fontSize: !props.mobileScreen
                 ? theme.typography.subtitle1.fontSize
                 : theme.typography.subtitle2.fontSize,
@@ -154,7 +165,13 @@ export default function ProgressChart(props) {
         mode: theme.palette.mode,
       },
     };
-  }, [theme, formattedTotal, props.mobileScreen]);
+  }, [
+    theme,
+    formattedTotal,
+    props.mobileScreen,
+    props.mode,
+    props.isSimulating,
+  ]);
 
   const [series, setSeries] = React.useState(seriesArray());
   const [options, setOptions] = React.useState({});


### PR DESCRIPTION
This PR aims to display the simulation progress (percentage of labeled papers to the total) by default when the simulation is running. When the simulation is finished, the number of total records displays as usual.

![localhost_3000_projects_test-simulate_](https://user-images.githubusercontent.com/17449217/167433885-ca1734ea-2398-4dae-b47a-2808720412dd.png)

![localhost_3000_projects_test-simulate_ (1)](https://user-images.githubusercontent.com/17449217/167434103-2e2484c8-3863-4cc1-8eba-eae094c6f1cf.png)
