### PR TITLE
Display relevant/irrelevant random prior candidates

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -730,8 +730,10 @@ def api_random_prior_papers(project):  # noqa: F401
 
     if subset:
 
-        rel_indices = as_data.df[as_data.df["debug_label"] == 1].index.values
-        irrel_indices = as_data.df[as_data.df["debug_label"] == 0].index.values
+        rel_indices = as_data.df[
+            as_data.df["debug_label"] == 1].index.values
+        irrel_indices = as_data.df[
+            as_data.df["debug_label"] == 0].index.values
 
         rel_indices_pool = np.intersect1d(pool, rel_indices)
         irrel_indices_pool = np.intersect1d(pool, irrel_indices)
@@ -760,7 +762,7 @@ def api_random_prior_papers(project):  # noqa: F401
                         "_debug_label": 1,
                     }
                 )
-            for ir in relevant_records:
+            for ir in irrelevant_records:
                 payload["result"].append(
                     {
                         "id": int(ir.record_id),
@@ -774,7 +776,8 @@ def api_random_prior_papers(project):  # noqa: F401
                 )
         except Exception as err:
             logging.error(err)
-            return jsonify(message=f"Failed to load random records. {err}"), 500
+            return jsonify(
+                message=f"Failed to load random records. {err}"), 500
 
     else:
         try:

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -720,30 +720,7 @@ def api_random_prior_papers(project):  # noqa: F401
 
     payload = {"result": []}
 
-    if not subset:
-        try:
-            pool_random = np.random.choice(pool, 1, replace=False)
-        except Exception:
-            raise ValueError("Not enough random indices to sample from.")
-
-        try:
-            record = read_data(project.project_path).record(pool_random)[0]
-            debug_label = record.extra_fields.get("debug_label", None)
-            debug_label = int(debug_label) if pd.notnull(debug_label) else None
-
-            payload["result"].append({
-                "id": int(record.record_id),
-                "title": record.title,
-                "abstract": record.abstract,
-                "authors": record.authors,
-                "keywords": record.keywords,
-                "included": None,
-                "_debug_label": debug_label
-            })
-        except Exception as err:
-            logging.error(err)
-            return jsonify(message=f"Failed to load random records. {err}"), 500
-    else:
+    if subset:
         data = pd.DataFrame(columns=["record_id", "debug_label"])
 
         for record in read_data(project.project_path).record(pool):
@@ -807,6 +784,29 @@ def api_random_prior_papers(project):  # noqa: F401
                     "_debug_label": irrelevant_debug_label,
                 }
             )
+        except Exception as err:
+            logging.error(err)
+            return jsonify(message=f"Failed to load random records. {err}"), 500
+    else:
+        try:
+            pool_random = np.random.choice(pool, 1, replace=False)
+        except Exception:
+            raise ValueError("Not enough random indices to sample from.")
+
+        try:
+            record = read_data(project.project_path).record(pool_random)[0]
+            debug_label = record.extra_fields.get("debug_label", None)
+            debug_label = int(debug_label) if pd.notnull(debug_label) else None
+
+            payload["result"].append({
+                "id": int(record.record_id),
+                "title": record.title,
+                "abstract": record.abstract,
+                "authors": record.authors,
+                "keywords": record.keywords,
+                "included": None,
+                "_debug_label": debug_label
+            })
         except Exception as err:
             logging.error(err)
             return jsonify(message=f"Failed to load random records. {err}"), 500

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -754,41 +754,59 @@ def api_random_prior_papers(project):  # noqa: F401
                 "record_id": int(record.record_id),
                 "debug_label": debug_label
             }, ignore_index=True)
-        
+
         try:
-            pool_relevant = np.random.choice(data[data["debug_label"] == 1]["record_id"].tolist(), 1, replace=False)
-            pool_irrelevant = np.random.choice(data[data["debug_label"] == 0]["record_id"].tolist(), 1, replace=False)
+            pool_relevant = np.random.choice(
+                data[data["debug_label"] == 1]["record_id"].tolist(), 1, replace=False
+            )
+            pool_irrelevant = np.random.choice(
+                data[data["debug_label"] == 0]["record_id"].tolist(), 1, replace=False
+            )
         except Exception:
             raise ValueError("Not enough random indices to sample from.")
-        
+
         try:
             # get relevant records
             relevant_record = read_data(project.project_path).record(pool_relevant)
-            relevant_debug_label = relevant_record[0].extra_fields.get("debug_label", None)
-            relevant_debug_label = int(relevant_debug_label) if pd.notnull(relevant_debug_label) else None
+            relevant_debug_label = relevant_record[0].extra_fields.get(
+                "debug_label", None
+            )
+            relevant_debug_label = (
+                int(relevant_debug_label) if pd.notnull(relevant_debug_label) else None
+            )
             # get irrelevant records
             irrelevant_record = read_data(project.project_path).record(pool_irrelevant)
-            irrelevant_debug_label = irrelevant_record[0].extra_fields.get("debug_label", None)
-            irrelevant_debug_label = int(irrelevant_debug_label) if pd.notnull(irrelevant_debug_label) else None
+            irrelevant_debug_label = irrelevant_record[0].extra_fields.get(
+                "debug_label", None
+            )
+            irrelevant_debug_label = (
+                int(irrelevant_debug_label)
+                if pd.notnull(irrelevant_debug_label)
+                else None
+            )
 
-            payload["result"].append({
-                "id": int(relevant_record[0].record_id),
-                "title": relevant_record[0].title,
-                "abstract": relevant_record[0].abstract,
-                "authors": relevant_record[0].authors,
-                "keywords": relevant_record[0].keywords,
-                "included": None,
-                "_debug_label": relevant_debug_label
-            })
-            payload["result"].append({
-                "id": int(irrelevant_record[0].record_id),
-                "title": irrelevant_record[0].title,
-                "abstract": irrelevant_record[0].abstract,
-                "authors": irrelevant_record[0].authors,
-                "keywords": irrelevant_record[0].keywords,
-                "included": None,
-                "_debug_label": irrelevant_debug_label
-            })
+            payload["result"].append(
+                {
+                    "id": int(relevant_record[0].record_id),
+                    "title": relevant_record[0].title,
+                    "abstract": relevant_record[0].abstract,
+                    "authors": relevant_record[0].authors,
+                    "keywords": relevant_record[0].keywords,
+                    "included": None,
+                    "_debug_label": relevant_debug_label,
+                }
+            )
+            payload["result"].append(
+                {
+                    "id": int(irrelevant_record[0].record_id),
+                    "title": irrelevant_record[0].title,
+                    "abstract": irrelevant_record[0].abstract,
+                    "authors": irrelevant_record[0].authors,
+                    "keywords": irrelevant_record[0].keywords,
+                    "included": None,
+                    "_debug_label": irrelevant_debug_label,
+                }
+            )
         except Exception as err:
             logging.error(err)
             return jsonify(message=f"Failed to load random records. {err}"), 500

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -713,6 +713,9 @@ def api_random_prior_papers(project):  # noqa: F401
     the already labeled items.
     """
 
+    # For Exploration and Simulation modes.
+    # If returned random record needs to show debug label
+    # from both relevant and irrelevant subsets.
     subset = request.args.get("subset", default=False, type=bool)
 
     with open_state(project.project_path) as state:

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
@@ -74,6 +74,7 @@ const AddPriorKnowledge = (props) => {
         )}
         {!search && random && (
           <PriorRandom
+            mode={props.mode}
             n_prior={props.n_prior}
             n_prior_exclusions={props.n_prior_exclusions}
             toggleRandom={toggleRandom}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -21,7 +21,7 @@ import { ArrowBack } from "@mui/icons-material";
 import { InlineErrorHandler } from "../../../Components";
 import { PriorUnlabeled } from "../DataComponents";
 import { ProjectAPI } from "../../../api/index.js";
-import { mapStateToProps } from "../../../globals.js";
+import { mapStateToProps, projectModes } from "../../../globals.js";
 import { useToggle } from "../../../hooks/useToggle";
 
 const PREFIX = "PriorRandom";
@@ -76,9 +76,15 @@ const Root = styled("div")(({ theme }) => ({
 const PriorRandom = (props) => {
   const queryClient = useQueryClient();
   const [reminder, toggleReminder] = useToggle();
-
+  console.log(props.mode !== projectModes.ORACLE);
   const { data, error, isError, isFetched, isFetching, isSuccess } = useQuery(
-    ["fetchPriorRandom", { project_id: props.project_id }],
+    [
+      "fetchPriorRandom",
+      {
+        project_id: props.project_id,
+        subset: props.mode !== projectModes.ORACLE ? true : null,
+      },
+    ],
     ProjectAPI.fetchPriorRandom,
     {
       enabled: true,

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -76,7 +76,8 @@ const Root = styled("div")(({ theme }) => ({
 const PriorRandom = (props) => {
   const queryClient = useQueryClient();
   const [reminder, toggleReminder] = useToggle();
-  console.log(props.mode !== projectModes.ORACLE);
+  const [refresh, setRefresh] = React.useState(true);
+
   const { data, error, isError, isFetched, isFetching, isSuccess } = useQuery(
     [
       "fetchPriorRandom",
@@ -87,7 +88,10 @@ const PriorRandom = (props) => {
     ],
     ProjectAPI.fetchPriorRandom,
     {
-      enabled: true,
+      enabled: refresh,
+      onSuccess: () => {
+        setRefresh(false);
+      },
       refetchOnWindowFocus: false,
     }
   );
@@ -106,6 +110,12 @@ const PriorRandom = (props) => {
       toggleReminder();
     }
   }, [props.n_prior_exclusions, toggleReminder]);
+
+  React.useEffect(() => {
+    if (!data?.result.filter((record) => record?.included === null).length) {
+      setRefresh(true);
+    }
+  }, [data?.result]);
 
   return (
     <Root>
@@ -143,13 +153,16 @@ const PriorRandom = (props) => {
               className={classes.recordCard}
               aria-label="unlabeled record card"
             >
-              {data?.result.map((record, index) => (
-                <PriorUnlabeled
-                  record={record}
-                  n_prior={props.n_prior}
-                  key={`result-page-${index}`}
-                />
-              ))}
+              {data?.result
+                .filter((record) => record?.included === null)
+                .map((record, index) => (
+                  <PriorUnlabeled
+                    mode={props.mode}
+                    record={record}
+                    n_prior={props.n_prior}
+                    key={`result-page-${index}`}
+                  />
+                ))}
             </Box>
           )}
           {reminder && (

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -17,7 +17,7 @@ import { styled } from "@mui/material/styles";
 import { InlineErrorHandler } from "../../../Components";
 import { ExplorationModeRecordAlert } from "../../../StyledComponents/StyledAlert.js";
 import { ProjectAPI } from "../../../api/index.js";
-import { mapStateToProps } from "../../../globals.js";
+import { mapStateToProps, projectModes } from "../../../globals.js";
 import "../../../App.css";
 
 const PREFIX = "PriorUnlabeled";
@@ -91,7 +91,30 @@ const PriorUnlabeled = (props) => {
             }
           );
         } else {
-          queryClient.invalidateQueries("fetchPriorRandom");
+          // update cached data
+          queryClient.setQueryData(
+            [
+              "fetchPriorRandom",
+              {
+                project_id: props.project_id,
+                subset: props.mode !== projectModes.ORACLE ? true : null,
+              },
+            ],
+            (prev) => {
+              return {
+                ...prev,
+                result: prev.result.map((record) => {
+                  return {
+                    ...record,
+                    included:
+                      record.id === variables.doc_id
+                        ? variables.label
+                        : record.included,
+                  };
+                }),
+              };
+            }
+          );
         }
       },
     }

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
@@ -766,6 +766,7 @@ const SetupDialog = (props) => {
 
       {addPriorKnowledge && (
         <AddPriorKnowledge
+          mode={info["mode"]}
           n_prior={labeledStats?.n_prior}
           n_prior_exclusions={labeledStats?.n_prior_exclusions}
           n_prior_inclusions={labeledStats?.n_prior_inclusions}

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -202,11 +202,11 @@ class ProjectAPI {
   }
 
   static fetchPriorRandom({ queryKey }) {
-    const { project_id } = queryKey[1];
+    const { project_id, subset } = queryKey[1];
     const url = api_url + `projects/${project_id}/prior_random`;
     return new Promise((resolve, reject) => {
       axios
-        .get(url)
+        .get(url, { params: { subset: subset } })
         .then((result) => {
           resolve(result["data"]);
         })


### PR DESCRIPTION
This PR aims to display both relevant and irrelevant random records when adding prior knowledge in Exploration and Simulation modes. Improvements are still needed on the back end to improve efficiency.

![image](https://user-images.githubusercontent.com/17449217/167942980-347bdaaf-2603-4e01-a693-ea347431b79a.png)
