### PR TITLE
Customize retrieval of random prior candidates

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -759,7 +759,7 @@ def api_random_prior_papers(project):  # noqa: F401
                     "_debug_label": 1,
                 }
             )
-        
+
     elif subset in ["irrelevant", "excluded"]:
         irrel_indices = as_data.df[
             as_data.df["debug_label"] == 0].index.values
@@ -773,7 +773,7 @@ def api_random_prior_papers(project):  # noqa: F401
         else:
             rand_pool_irrelevant = np.random.choice(
                 irrel_indices_pool, n, replace=False)
-        
+
         try:
             irrelevant_records = as_data.record(rand_pool_irrelevant)
         except Exception as err:

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -707,78 +707,92 @@ def api_get_labeled_stats(project):  # noqa: F401
 @bp.route('/projects/<project_id>/prior_random', methods=["GET"])
 @project_from_id
 def api_random_prior_papers(project):  # noqa: F401
-    """Get a selection of random papers to find exclusions.
+    """Get a selection of random records.
 
-    This set of papers is extracted from the pool, but without
+    This set of records is extracted from the pool, but without
     the already labeled items.
     """
 
-    # For Exploration and Simulation modes.
-    # If returned random record needs to show debug label
-    # from both relevant and irrelevant subsets.
-    subset = request.args.get("subset", default=False, type=bool)
+    # get the number of records to return
     n = request.args.get("n", default=5, type=int)
-    n_relevant = request.args.get("n_relevant", default=5, type=int)
-    n_irrelevant = request.args.get("n_irrelevant", default=5, type=int)
+    # get the subset of records to return (for exploration and simulation mode)
+    subset = request.args.get("subset", default=None, type=str)
 
     with open_state(project.project_path) as state:
         pool = state.get_pool().values
 
-    # load data (ASReviewData object)
     as_data = read_data(project.project_path)
 
     payload = {"result": []}
 
-    if subset:
-
+    if subset in ["relevant", "included"]:
         rel_indices = as_data.df[
             as_data.df["debug_label"] == 1].index.values
-        irrel_indices = as_data.df[
-            as_data.df["debug_label"] == 0].index.values
-
         rel_indices_pool = np.intersect1d(pool, rel_indices)
-        irrel_indices_pool = np.intersect1d(pool, irrel_indices)
 
-        try:
+        if len(rel_indices_pool) == 0:
+            return jsonify(payload)
+        elif n > len(rel_indices_pool):
             rand_pool_relevant = np.random.choice(
-                rel_indices_pool, n_relevant, replace=False)
-            rand_pool_irrelevant = np.random.choice(
-                irrel_indices_pool, n_irrelevant, replace=False)
-        except Exception:
-            raise ValueError("Not enough random indices to sample from.")
+                rel_indices_pool, len(rel_indices_pool), replace=False)
+        else:
+            rand_pool = np.random.choice(pool, n, replace=False)
+            rand_pool_relevant = np.random.choice(
+                rel_indices_pool, n, replace=False)
 
         try:
             relevant_records = as_data.record(rand_pool_relevant)
-            irrelevant_records = as_data.record(rand_pool_irrelevant)
-
-            for rr in relevant_records:
-                payload["result"].append(
-                    {
-                        "id": int(rr.record_id),
-                        "title": rr.title,
-                        "abstract": rr.abstract,
-                        "authors": rr.authors,
-                        "keywords": rr.keywords,
-                        "included": None,
-                        "_debug_label": 1,
-                    }
-                )
-            for ir in irrelevant_records:
-                payload["result"].append(
-                    {
-                        "id": int(ir.record_id),
-                        "title": ir.title,
-                        "abstract": ir.abstract,
-                        "authors": ir.authors,
-                        "keywords": ir.keywords,
-                        "included": None,
-                        "_debug_label": 0,
-                    }
-                )
         except Exception as err:
             logging.error(err)
             return jsonify(
                 message=f"Failed to load random records. {err}"), 500
+
+        for rr in relevant_records:
+            payload["result"].append(
+                {
+                    "id": int(rr.record_id),
+                    "title": rr.title,
+                    "abstract": rr.abstract,
+                    "authors": rr.authors,
+                    "keywords": rr.keywords,
+                    "included": None,
+                    "_debug_label": 1,
+                }
+            )
+        
+    elif subset in ["irrelevant", "excluded"]:
+        irrel_indices = as_data.df[
+            as_data.df["debug_label"] == 0].index.values
+        irrel_indices_pool = np.intersect1d(pool, irrel_indices)
+
+        if len(irrel_indices_pool) == 0:
+            return jsonify(payload)
+        elif n > len(irrel_indices_pool):
+            rand_pool_irrelevant = np.random.choice(
+                irrel_indices_pool, len(irrel_indices_pool), replace=False)
+        else:
+            rand_pool_irrelevant = np.random.choice(
+                irrel_indices_pool, n, replace=False)
+        
+        try:
+            irrelevant_records = as_data.record(rand_pool_irrelevant)
+        except Exception as err:
+            logging.error(err)
+            return jsonify(
+                message=f"Failed to load random records. {err}"), 500
+
+        for ir in irrelevant_records:
+            payload["result"].append(
+                {
+                    "id": int(ir.record_id),
+                    "title": ir.title,
+                    "abstract": ir.abstract,
+                    "authors": ir.authors,
+                    "keywords": ir.keywords,
+                    "included": None,
+                    "_debug_label": 0,
+                }
+            )
 
     else:
         if len(pool) == 0:

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/HistoryPage.js
@@ -8,11 +8,12 @@ import { Filter, LabelChip, LabeledRecord } from "../HistoryComponents";
 const PREFIX = "HistoryPage";
 
 const classes = {
-  bodyMobile: `${PREFIX}-body-mobile`,
+  cardWrapper: `${PREFIX}-card-wrapper`,
 };
 
 const Root = styled("div")(({ theme }) => ({
-  [`& .${classes.bodyMobile}`]: {
+  [`& .${classes.cardWrapper}`]: {
+    paddingTop: 32,
     [theme.breakpoints.down("md")]: {
       paddingLeft: 0,
       paddingRight: 0,
@@ -44,7 +45,7 @@ const HistoryPage = (props) => {
             <Divider />
           </Box>
           <Box className="main-page-body-wrapper">
-            <Box className={`${classes.bodyMobile} main-page-body`}>
+            <Box className={`${classes.cardWrapper} main-page-body`}>
               <LabeledRecord
                 label={props.label}
                 filterQuery={props.filterQuery}

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecord.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecord.js
@@ -9,6 +9,7 @@ import {
   ButtonBase,
   CircularProgress,
   Fade,
+  Stack,
   Typography,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
@@ -37,7 +38,7 @@ const Root = styled("div")(({ theme }) => ({
   [`& .${classes.priorRecordCard}`]: {
     height: "calc(100vh - 208px)",
     overflowY: "scroll",
-    padding: "16px 24px",
+    padding: "32px 24px",
   },
 
   [`& .${classes.loadMoreInView}`]: {
@@ -125,11 +126,12 @@ const LabeledRecord = (props) => {
         !(isLoading || !mounted.current) &&
         isFetched && (
           <Fade in={!isError && !(isLoading || !mounted.current) && isFetched}>
-            <Box
+            <Stack
               className={clsx({
                 [classes.priorRecordCard]: props.is_prior,
               })}
               aria-label="labeled record card"
+              spacing={3}
             >
               {isFetched &&
                 data.pages.map((page, index) => (
@@ -162,7 +164,7 @@ const LabeledRecord = (props) => {
                   </Typography>
                 </ButtonBase>
               </InView>
-            </Box>
+            </Stack>
           </Fade>
         )}
     </Root>

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
@@ -10,6 +10,7 @@ import {
   CardContent,
   IconButton,
   Link,
+  Stack,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -39,8 +40,6 @@ const classes = {
 const Root = styled("div")(({ theme }) => ({
   [`& .${classes.root}`]: {
     borderRadius: 16,
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
     [theme.breakpoints.down("md")]: {
       borderRadius: 0,
     },
@@ -185,153 +184,157 @@ const LabeledRecordCard = (props) => {
 
   return (
     <Root>
-      {isError && (
-        <Box sx={{ pt: 8, pb: 16 }}>
-          <InlineErrorHandler
-            message={error["message"]}
-            refetch={reset}
-            button={true}
-          />
-        </Box>
-      )}
-      {!isError &&
-        props.page.result
-          .filter((value) => value.included !== -1)
-          .map((value) => (
-            <Card elevation={3} className={classes.root} key={value.id}>
-              <CardContent className="record-card-content">
-                <Typography gutterBottom variant="h6">
-                  {value.title ? value.title : "No title available"}
-                </Typography>
-                <TruncateMarkup
-                  lines={value.id === recordReadMore ? Infinity : 6}
-                  ellipsis={
-                    <span>
-                      ...{" "}
-                      <Link
-                        component="button"
-                        underline="none"
-                        onClick={() => setRecordReadMore(value.id)}
-                      >
-                        read more
-                      </Link>
-                    </span>
-                  }
-                >
-                  <Typography color="textSecondary">
-                    {value.abstract ? value.abstract : "No abstract available"}
+      <Stack spacing={3}>
+        {isError && (
+          <Box sx={{ pt: 8, pb: 16 }}>
+            <InlineErrorHandler
+              message={error["message"]}
+              refetch={reset}
+              button={true}
+            />
+          </Box>
+        )}
+        {!isError &&
+          props.page.result
+            .filter((value) => value.included !== -1)
+            .map((value) => (
+              <Card elevation={3} className={classes.root} key={value.id}>
+                <CardContent className="record-card-content">
+                  <Typography gutterBottom variant="h6">
+                    {value.title ? value.title : "No title available"}
                   </Typography>
-                </TruncateMarkup>
-              </CardContent>
-              <CardActions className={classes.cardActions}>
-                <Tooltip
-                  title={
-                    !isSimulationProject()
-                      ? disableConvertPrior(value.prior)
-                        ? "Prior knowledge cannot be converted"
-                        : note.editing !== value.id
-                        ? value.included === 1
-                          ? "Convert to irrelevant"
-                          : "Convert to relevant"
-                        : "Save note before converting"
-                      : "Cannot be converted in simulation mode"
-                  }
-                >
-                  <span>
-                    <IconButton
-                      disabled={
-                        isSimulationProject() ||
-                        disableConvertPrior(value.prior) ||
-                        isLoading ||
-                        note.editing === value.id
-                      }
-                      onClick={() => {
-                        handleClickLabelConvert(value);
-                      }}
-                    >
-                      {value.included === 1 ? (
-                        <Favorite
-                          color="error"
-                          fontSize={!props.mobileScreen ? "medium" : "small"}
-                        />
-                      ) : (
-                        <FavoriteBorder
-                          fontSize={!props.mobileScreen ? "medium" : "small"}
-                        />
-                      )}
-                    </IconButton>
-                  </span>
-                </Tooltip>
-                {props.is_prior && (
-                  <Tooltip
-                    title={`Remove ${
-                      value.included !== 1 ? "irrelevant" : "relevant"
-                    } label`}
+                  <TruncateMarkup
+                    lines={value.id === recordReadMore ? Infinity : 6}
+                    ellipsis={
+                      <span>
+                        ...{" "}
+                        <Link
+                          component="button"
+                          underline="none"
+                          onClick={() => setRecordReadMore(value.id)}
+                        >
+                          read more
+                        </Link>
+                      </span>
+                    }
                   >
-                    <span>
-                      <IconButton
-                        disabled={isLoading}
-                        onClick={() => {
-                          handleClickRemoveLabel(value);
-                        }}
-                      >
-                        <Delete
-                          fontSize={!props.mobileScreen ? "medium" : "small"}
-                        />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                )}
-                {!props.is_prior && !value.note && value.id !== note.editing && (
+                    <Typography color="textSecondary">
+                      {value.abstract
+                        ? value.abstract
+                        : "No abstract available"}
+                    </Typography>
+                  </TruncateMarkup>
+                </CardContent>
+                <CardActions className={classes.cardActions}>
                   <Tooltip
                     title={
-                      !props.isSimulating
-                        ? !disableAddNoteButton(value.id)
-                          ? "Add note"
-                          : "Save another note before adding"
-                        : "Add note after simulation is finished"
+                      !isSimulationProject()
+                        ? disableConvertPrior(value.prior)
+                          ? "Prior knowledge cannot be converted"
+                          : note.editing !== value.id
+                          ? value.included === 1
+                            ? "Convert to irrelevant"
+                            : "Convert to relevant"
+                          : "Save note before converting"
+                        : "Cannot be converted in simulation mode"
                     }
                   >
                     <span>
                       <IconButton
                         disabled={
-                          props.isSimulating || disableAddNoteButton(value.id)
+                          isSimulationProject() ||
+                          disableConvertPrior(value.prior) ||
+                          isLoading ||
+                          note.editing === value.id
                         }
-                        onClick={() => handleClickAddNote(value.id)}
+                        onClick={() => {
+                          handleClickLabelConvert(value);
+                        }}
                       >
-                        <NoteAddOutlined
-                          fontSize={!props.mobileScreen ? "medium" : "small"}
-                        />
+                        {value.included === 1 ? (
+                          <Favorite
+                            color="error"
+                            fontSize={!props.mobileScreen ? "medium" : "small"}
+                          />
+                        ) : (
+                          <FavoriteBorder
+                            fontSize={!props.mobileScreen ? "medium" : "small"}
+                          />
+                        )}
                       </IconButton>
                     </span>
                   </Tooltip>
-                )}
-                {!props.is_prior && value.id === note.editing && (
-                  <Tooltip title="Remove note">
-                    <span>
-                      <IconButton
-                        disabled={isLoading}
-                        onClick={() => handleClickRemoveNote(value)}
-                      >
-                        <KeyboardArrowUp
-                          fontSize={!props.mobileScreen ? "medium" : "small"}
-                        />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                )}
-              </CardActions>
-              <RecordCardNote
-                isLoading={isLoading}
-                record={value}
-                mobileScreen={props.mobileScreen}
-                mutate={mutate}
-                note={note}
-                setNote={setNote}
-                is_prior={props.is_prior}
-              />
-            </Card>
-          ))}
+                  {props.is_prior && (
+                    <Tooltip
+                      title={`Remove ${
+                        value.included !== 1 ? "irrelevant" : "relevant"
+                      } label`}
+                    >
+                      <span>
+                        <IconButton
+                          disabled={isLoading}
+                          onClick={() => {
+                            handleClickRemoveLabel(value);
+                          }}
+                        >
+                          <Delete
+                            fontSize={!props.mobileScreen ? "medium" : "small"}
+                          />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
+                  {!props.is_prior && !value.note && value.id !== note.editing && (
+                    <Tooltip
+                      title={
+                        !props.isSimulating
+                          ? !disableAddNoteButton(value.id)
+                            ? "Add note"
+                            : "Save another note before adding"
+                          : "Add note after simulation is finished"
+                      }
+                    >
+                      <span>
+                        <IconButton
+                          disabled={
+                            props.isSimulating || disableAddNoteButton(value.id)
+                          }
+                          onClick={() => handleClickAddNote(value.id)}
+                        >
+                          <NoteAddOutlined
+                            fontSize={!props.mobileScreen ? "medium" : "small"}
+                          />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
+                  {!props.is_prior && value.id === note.editing && (
+                    <Tooltip title="Remove note">
+                      <span>
+                        <IconButton
+                          disabled={isLoading}
+                          onClick={() => handleClickRemoveNote(value)}
+                        >
+                          <KeyboardArrowUp
+                            fontSize={!props.mobileScreen ? "medium" : "small"}
+                          />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
+                </CardActions>
+                <RecordCardNote
+                  isLoading={isLoading}
+                  record={value}
+                  mobileScreen={props.mobileScreen}
+                  mutate={mutate}
+                  note={note}
+                  setNote={setNote}
+                  is_prior={props.is_prior}
+                />
+              </Card>
+            ))}
+      </Stack>
     </Root>
   );
 };

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
@@ -58,7 +58,7 @@ const AddPriorKnowledge = (props) => {
                   </Tooltip>
                 </ListItem>
                 <ListItem disablePadding divider>
-                  <Tooltip title="Get a random record from added dataset">
+                  <Tooltip title="Get random records from added dataset">
                     <ListItemButton onClick={toggleRandom}>
                       <ListItemText primary="Random" />
                       <AddIcon color="primary" />

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/EnoughPriorBanner.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/EnoughPriorBanner.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { Banner } from "material-ui-banner";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+
+const EnoughPriorBanner = (props) => {
+  return (
+    <div>
+      <Banner
+        open={props.reminder}
+        onClose={props.toggleReminder}
+        label={`${props.n_prior_exclusions} records were labeled as irrelevant. You have found enough irrelevant records as prior knowledge. Try to search for relevant records?`}
+        icon={<InfoOutlinedIcon sx={{ color: "text.secondary" }} />}
+        iconProps={{
+          sx: { bgcolor: "transparent" },
+        }}
+        buttonLabel="Search"
+        buttonOnClick={props.onClickPriorSearch}
+        buttonProps={{
+          sx: { color: "text.secondary" },
+        }}
+        dismissButtonLabel="Show more"
+        dismissButtonProps={{
+          sx: { color: "text.secondary" },
+        }}
+        paperProps={{
+          sx: {
+            bgcolor: (theme) =>
+              theme.palette.mode === "dark" ? "grey.900" : "grey.50",
+          },
+        }}
+        cardProps={{
+          sx: {
+            bgcolor: (theme) =>
+              theme.palette.mode === "dark" ? "grey.900" : "grey.50",
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default EnoughPriorBanner;

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -154,6 +154,10 @@ const PriorRandom = (props) => {
               <Typography sx={{ color: "text.secondary" }}>Show</Typography>
               <FormControl variant="standard" sx={{ width: "48px" }}>
                 <Select value={nRecords} onChange={handleNRecordsChange}>
+                  <MenuItem value={1}>1</MenuItem>
+                  <MenuItem value={2}>2</MenuItem>
+                  <MenuItem value={3}>3</MenuItem>
+                  <MenuItem value={4}>4</MenuItem>
                   <MenuItem value={5}>5</MenuItem>
                   <MenuItem value={6}>6</MenuItem>
                   <MenuItem value={7}>7</MenuItem>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -127,10 +127,14 @@ const PriorRandom = (props) => {
   };
 
   React.useEffect(() => {
-    if (props.n_prior_exclusions !== 0 && props.n_prior_exclusions % 5 === 0) {
+    if (
+      props.mode === projectModes.ORACLE &&
+      props.n_prior_exclusions !== 0 &&
+      props.n_prior_exclusions % 5 === 0
+    ) {
       toggleReminder();
     }
-  }, [props.n_prior_exclusions, toggleReminder]);
+  }, [props.mode, props.n_prior_exclusions, toggleReminder]);
 
   React.useEffect(() => {
     if (

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -86,6 +86,7 @@ const PriorRandom = (props) => {
   const [reminder, toggleReminder] = useToggle();
   const [refresh, setRefresh] = React.useState(true);
   const [nRecords, setNRecords] = React.useState(5);
+  const [subset, setSubset] = React.useState("relevant");
 
   const { data, error, isError, isFetched, isFetching, isSuccess } = useQuery(
     [
@@ -93,7 +94,7 @@ const PriorRandom = (props) => {
       {
         project_id: props.project_id,
         n: nRecords,
-        subset: props.mode !== projectModes.ORACLE ? true : null,
+        subset: props.mode !== projectModes.ORACLE ? subset : null,
       },
     ],
     ProjectAPI.fetchPriorRandom,
@@ -108,6 +109,11 @@ const PriorRandom = (props) => {
 
   const handleNRecordsChange = (event) => {
     setNRecords(event.target.value);
+    setRefresh(true);
+  };
+
+  const handleSubsetChange = (event) => {
+    setSubset(event.target.value);
     setRefresh(true);
   };
 
@@ -163,8 +169,27 @@ const PriorRandom = (props) => {
                 </Select>
               </FormControl>
               <Typography sx={{ color: "text.secondary" }}>
-                random records
+                {props.mode === projectModes.ORACLE
+                  ? "random records"
+                  : "random"}
               </Typography>
+              {props.mode !== projectModes.ORACLE && (
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ alignItems: "center" }}
+                >
+                  <FormControl variant="standard" sx={{ width: "96px" }}>
+                    <Select value={subset} onChange={handleSubsetChange}>
+                      <MenuItem value="relevant">relevant</MenuItem>
+                      <MenuItem value="irrelevant">irrelevant</MenuItem>
+                    </Select>
+                  </FormControl>
+                  <Typography sx={{ color: "text.secondary" }}>
+                    records
+                  </Typography>
+                </Stack>
+              )}
             </Stack>
           </Stack>
           <Divider />
@@ -196,10 +221,9 @@ const PriorRandom = (props) => {
                   .filter((record) => record?.included === null)
                   .map((record, index) => (
                     <PriorUnlabeled
-                      mode={props.mode}
                       record={record}
-                      n_prior={props.n_prior}
                       nRecords={nRecords}
+                      subset={subset}
                       key={`result-page-${index}`}
                     />
                   ))}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -3,10 +3,7 @@ import { useQuery, useQueryClient } from "react-query";
 import { connect } from "react-redux";
 import {
   Box,
-  Button,
   Card,
-  CardActions,
-  CardContent,
   CircularProgress,
   Divider,
   Fade,
@@ -22,7 +19,7 @@ import { styled } from "@mui/material/styles";
 import { ArrowBack } from "@mui/icons-material";
 
 import { InlineErrorHandler } from "../../../Components";
-import { PriorUnlabeled } from "../DataComponents";
+import { EnoughPriorBanner, PriorUnlabeled } from "../DataComponents";
 import { ProjectAPI } from "../../../api/index.js";
 import { mapStateToProps, projectModes } from "../../../globals.js";
 import { useToggle } from "../../../hooks/useToggle";
@@ -34,7 +31,6 @@ const classes = {
   icon: `${PREFIX}-icon`,
   empty: `${PREFIX}-empty`,
   loading: `${PREFIX}-loading`,
-  reminder: `${PREFIX}-reminder`,
   select: `${PREFIX}-select`,
 };
 
@@ -66,12 +62,6 @@ const Root = styled("div")(({ theme }) => ({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-  },
-
-  [`& .${classes.reminder}`]: {
-    borderRadius: 16,
-    margin: "32px 24px",
-    maxWidth: 960,
   },
 
   [`& .${classes.select}`]: {
@@ -211,6 +201,12 @@ const PriorRandom = (props) => {
               />
             </Box>
           )}
+          <EnoughPriorBanner
+            n_prior_exclusions={props.n_prior_exclusions}
+            onClickPriorSearch={onClickPriorSearch}
+            reminder={reminder}
+            toggleReminder={toggleReminder}
+          />
           {!reminder &&
             !isError &&
             isFetched &&
@@ -245,29 +241,6 @@ const PriorRandom = (props) => {
                 </Typography>
               </Box>
             )}
-          {reminder && (
-            <Card elevation={3} className={classes.reminder}>
-              <CardContent>
-                <Typography gutterBottom variant="h6">
-                  Enough irrelevant records found
-                </Typography>
-                <Typography sx={{ color: "text.secondary" }}>
-                  {props.n_prior_exclusions} records were labeled as irrelevant.
-                  You have found enough irrelevant records as prior knowledge.
-                  Try to search for relevant records?
-                </Typography>
-              </CardContent>
-              <Divider />
-              <CardActions sx={{ justifyContent: "flex-end" }}>
-                <Button size="small" onClick={toggleReminder}>
-                  Show More Random
-                </Button>
-                <Button size="small" onClick={onClickPriorSearch}>
-                  Search
-                </Button>
-              </CardActions>
-            </Card>
-          )}
         </Card>
       </Fade>
     </Root>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -222,6 +222,7 @@ const PriorRandom = (props) => {
                   .map((record, index) => (
                     <PriorUnlabeled
                       record={record}
+                      mode={props.mode}
                       nRecords={nRecords}
                       subset={subset}
                       key={`result-page-${index}`}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorRandom.js
@@ -42,12 +42,10 @@ const Root = styled("div")(({ theme }) => ({
   width: "50%",
   [`& .${classes.recordCard}`]: {
     alignItems: "center",
-    display: "flex",
-    flexDirection: "column",
     height: "calc(100vh - 208px)",
     width: "100%",
     overflowY: "scroll",
-    padding: "16px 24px",
+    padding: "32px 24px",
   },
   [`& .${classes.icon}`]: {
     color: theme.palette.text.secondary,
@@ -189,9 +187,10 @@ const PriorRandom = (props) => {
             isFetched &&
             isSuccess &&
             data?.result.length !== 0 && (
-              <Box
+              <Stack
                 className={classes.recordCard}
                 aria-label="unlabeled record card"
+                spacing={3}
               >
                 {data?.result
                   .filter((record) => record?.included === null)
@@ -204,7 +203,7 @@ const PriorRandom = (props) => {
                       key={`result-page-${index}`}
                     />
                   ))}
-              </Box>
+              </Stack>
             )}
           {!reminder &&
             !isError &&

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorSearch.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorSearch.js
@@ -36,12 +36,10 @@ const Root = styled("div")(({ theme }) => ({
   width: "50%",
   [`& .${classes.recordCard}`]: {
     alignItems: "center",
-    display: "flex",
-    flexDirection: "column",
     height: "calc(100vh - 208px)",
     width: "100%",
     overflowY: "scroll",
-    padding: "16px 24px",
+    padding: "32px 24px",
   },
   [`& .${classes.icon}`]: {
     color: theme.palette.text.secondary,
@@ -149,9 +147,10 @@ const PriorSearch = (props) => {
               </Box>
             )}
           {!isError && isFetched && isSuccess && (
-            <Box
+            <Stack
               className={classes.recordCard}
               aria-label="unlabeled record card"
+              spacing={3}
             >
               {data?.result
                 .filter((record) => record?.included === -1)
@@ -163,7 +162,7 @@ const PriorSearch = (props) => {
                     key={`result-page-${index}`}
                   />
                 ))}
-            </Box>
+            </Stack>
           )}
         </Card>
       </Fade>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -28,11 +28,10 @@ const classes = {
 };
 
 const Root = styled("div")(({ theme }) => ({
+  maxWidth: 400,
+  width: "100%",
   [`& .${classes.root}`]: {
     borderRadius: 16,
-    marginTop: theme.spacing(3),
-    // marginBottom: theme.spacing(3),
-    maxWidth: 960,
   },
 
   [`& .${classes.icon}`]: {

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -97,7 +97,7 @@ const PriorUnlabeled = (props) => {
               {
                 project_id: props.project_id,
                 n: props.nRecords,
-                subset: props.mode !== projectModes.ORACLE ? true : null,
+                subset: props.subset,
               },
             ],
             (prev) => {

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -97,7 +97,8 @@ const PriorUnlabeled = (props) => {
               {
                 project_id: props.project_id,
                 n: props.nRecords,
-                subset: props.subset,
+                subset:
+                  props.mode !== projectModes.ORACLE ? props.subset : null,
               },
             ],
             (prev) => {

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorUnlabeled.js
@@ -97,6 +97,7 @@ const PriorUnlabeled = (props) => {
               "fetchPriorRandom",
               {
                 project_id: props.project_id,
+                n: props.nRecords,
                 subset: props.mode !== projectModes.ORACLE ? true : null,
               },
             ],

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/index.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/index.js
@@ -4,6 +4,7 @@ export { default as DataForm } from "./DataForm";
 export { default as DataFormCard } from "./DataFormCard";
 export { default as DatasetFromEntryPoint } from "./DatasetFromEntryPoint";
 export { default as DatasetFromURL } from "./DatasetFromURL";
+export { default as EnoughPriorBanner } from "./EnoughPriorBanner";
 export { default as EntryPointDataset } from "./EntryPointDataset";
 export { default as PriorLabeled } from "./PriorLabeled";
 export { default as PriorRandom } from "./PriorRandom";

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -202,11 +202,11 @@ class ProjectAPI {
   }
 
   static fetchPriorRandom({ queryKey }) {
-    const { project_id, subset } = queryKey[1];
+    const { project_id, n, subset } = queryKey[1];
     const url = api_url + `projects/${project_id}/prior_random`;
     return new Promise((resolve, reject) => {
       axios
-        .get(url, { params: { subset: subset } })
+        .get(url, { params: { n: n, subset: subset } })
         .then((result) => {
           resolve(result["data"]);
         })


### PR DESCRIPTION
This PR implements custom options for getting random records when adding prior knowledge. Users can specify the number of records to be shown (5 to 10) and whether to show relevant or irrelevant records (in Exploration and Simulation modes).

The reminder after labeling 5 consecutive irrelevant records is replaced by a banner and is only used in Oracle mode (to be discussed).

**In Oracle mode:**
![image](https://user-images.githubusercontent.com/17449217/169060322-f5e7ebc0-ef6e-4365-985b-bd3ea492bc4a.png)
![image](https://user-images.githubusercontent.com/17449217/169060257-a8867271-14ad-412d-8c7e-af660f8dbd9d.png)

**In Exploration or Simulation mode:**
![image](https://user-images.githubusercontent.com/17449217/169060824-f9e2db18-7610-42e1-a05f-2bebd21ed5ac.png)

**When there are no unlabeled records (not likely to see):**
![image](https://user-images.githubusercontent.com/17449217/169061119-ec5f8325-cf76-4403-96e5-55213c1efa4b.png)

