### PR TITLE
Fix min simulate option and make it default

### DIFF
--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -350,11 +350,10 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
     parser.add_argument(
         "--n_queries",
         type=type_n_queries,
-        default=None,
-        help="The number of queries. Alternatively, entering 'min' will stop "
-        "the simulation when all relevant records have been found. By "
-        "default, the program stops after all records are reviewed or is "
-        "interrupted by the user.")
+        default="min",
+        help="The number of label actions to simulate. Default, 'min' "
+        "will stop simulating when all relevant records are found. Use -1 "
+        "to simulate all labels actions.")
     parser.add_argument(
         "-n",
         "--n_papers",

--- a/asreview/review/base.py
+++ b/asreview/review/base.py
@@ -171,6 +171,9 @@ class BaseReview(ABC):
 
             # Label the records.
             self._label(record_ids)
+        else:
+            # write to state when stopped
+            self._write_to_state()
 
     def _label_priors(self):
         """Make sure the prior records are labeled."""

--- a/asreview/review/simulate.py
+++ b/asreview/review/simulate.py
@@ -216,29 +216,25 @@ class ReviewSimulate(BaseReview):
     def _stop_review(self):
         """In simulation mode, the stop review function should get the labeled
         records list from the reviewer attribute."""
-        stop = False
 
         # if the pool is empty, always stop
         if self.pool.empty:
-            stop = True
+            return True
 
         # If we are exceeding the number of papers, stop.
         if self.n_papers is not None and len(self.labeled) >= self.n_papers:
-            stop = True
+            return True
 
         # If n_queries is set to min, stop when all papers in the pool are
         # irrelevant.
         if self.n_queries == 'min' and (self.data_labels[self.pool] == 0).all():
-            stop = True
-        # Otherwise, stop when reaching n_queries (if provided)
-        elif self.n_queries is not None:
-            if self.total_queries >= self.n_queries:
-                stop = True
+            return True
 
-        if stop:
-            self._write_to_state()
+        # Stop when reaching n_queries (if provided)
+        if isinstance(self.n_queries, int) and self.total_queries >= self.n_queries:
+            return True
 
-        return stop
+        return False
 
     def train(self):
         """Train a new model on the labeled data."""

--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -355,6 +355,23 @@ class SQLiteState(BaseState):
                 "'settings' should be an ASReviewSettings object.")
 
     @property
+    def n_records(self):
+        """Number of records in the loop.
+
+        Returns
+        -------
+        int
+            Number of records.
+        """
+        con = self._connect_to_sql()
+        cur = con.cursor()
+        cur.execute("SELECT COUNT (*) FROM record_table")
+        n = cur.fetchone()[0]
+        con.close()
+
+        return n
+
+    @property
     def n_records_labeled(self):
         """Number labeled records.
 

--- a/asreview/types.py
+++ b/asreview/types.py
@@ -29,6 +29,12 @@ def type_n_queries(value):
         return value
     else:
         try:
-            return int(value)
+            value_i = int(value)
+
+            # convert -1 to None
+            if value_i == -1:
+                return None
+
+            return value_i
         except ValueError:
             raise ValueError("Value for n_queries is not 'min' or a valid integer")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -175,6 +175,23 @@ def test_number_records_found(tmpdir):
         assert s.get_labels().sum() == 28
 
 
+def test_n_queries_min(tmpdir):
+    dataset = 'benchmark:van_de_Schoot_2017'
+    asreview_fp = Path(tmpdir, 'test.asreview')
+    n_queries = "min"
+    priors = [284, 285]
+    seed = 101
+
+    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+           f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
+    entry_point = SimulateEntryPoint()
+    entry_point.execute(argv)
+
+    with open_state(asreview_fp) as s:
+        assert s.get_labels().sum() == 43
+        assert len(s.get_labels()) == 515
+
+
 def test_write_interval(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -208,6 +208,7 @@ def test_n_queries_all(tmpdir):
         assert s.get_labels().sum() == 43
         assert len(s.get_labels()) == 6189
 
+
 def test_write_interval(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -192,6 +192,22 @@ def test_n_queries_min(tmpdir):
         assert len(s.get_labels()) == 515
 
 
+def test_n_queries_all(tmpdir):
+    dataset = 'benchmark:van_de_Schoot_2017'
+    asreview_fp = Path(tmpdir, 'test.asreview')
+    n_queries = -1
+    priors = [284, 285]
+    seed = 101
+
+    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+           f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
+    entry_point = SimulateEntryPoint()
+    entry_point.execute(argv)
+
+    with open_state(asreview_fp) as s:
+        assert s.get_labels().sum() == 43
+        assert len(s.get_labels()) == 6189
+
 def test_write_interval(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -131,6 +131,7 @@ def test_settings_state():
 
 def test_n_records_labeled():
     with open_state(TEST_STATE_FP) as state:
+        assert state.n_records == len(TEST_LABELS)
         assert state.n_records_labeled == len(TEST_LABELS)
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -131,7 +131,6 @@ def test_settings_state():
 
 def test_n_records_labeled():
     with open_state(TEST_STATE_FP) as state:
-        assert state.n_records == len(TEST_LABELS)
         assert state.n_records_labeled == len(TEST_LABELS)
 
 


### PR DESCRIPTION
This PR re-implements the `--n_query min` option in the simulation interface. It fixes various bugs and sets the default to `min`. 

The options are now:

```
min => stop after last relevant record is found
1,2,3,... => any int to indicate to stop after that number of iterations
-1 => simulate till the very very end
```

- Also added tests to cover future problems. 
- Changed the insights package as well to work well with this feature. 
