### PR TITLE
Submit prior knowledge search query on pressing Enter

### DIFF
--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorSearch.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/PriorSearch.js
@@ -90,6 +90,12 @@ const PriorSearch = (props) => {
     setKeyword(event.target.value);
   };
 
+  const onKeyDown = (event) => {
+    if (event.key === "Enter") {
+      onClickSearch();
+    }
+  };
+
   return (
     <Root>
       <Fade in>
@@ -109,6 +115,7 @@ const PriorSearch = (props) => {
               autoFocus
               fullWidth
               onChange={onChangeKeyword}
+              onKeyDown={onKeyDown}
               placeholder="Keyword in title, abstract, or author"
               sx={{ ml: 1 }}
             />


### PR DESCRIPTION
This PR makes it possible to submit a prior knowledge search query when pressing Enter on the keyboard.