### PR TITLE
Fix page not found due to trailing slash in URL

### DIFF
--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -127,9 +127,9 @@ def create_app(**kwargs):
         return jsonify(message=str(e.original_exception)), 500
 
     @app.route('/', methods=['GET'])
-    @app.route('/projects', methods=['GET'])
-    @app.route('/projects/<project_id>', methods=['GET'])
-    @app.route('/projects/<project_id>/<tab>', methods=['GET'])
+    @app.route('/projects/', methods=['GET'])
+    @app.route('/projects/<project_id>/', methods=['GET'])
+    @app.route('/projects/<project_id>/<tab>/', methods=['GET'])
     def index(**kwargs):
 
         return render_template("index.html")


### PR DESCRIPTION
This PR fixed page not found due to trailing slash in URL.