### PR TITLE
Fix serialization of mixed query strategies

### DIFF
--- a/asreview/models/query/mixed.py
+++ b/asreview/models/query/mixed.py
@@ -73,7 +73,7 @@ class MixedQuery(BaseQueryStrategy):
         self.strategy_2 = strategy_2
 
         self.mix_ratio = mix_ratio
-        self.random_state = get_random_state(random_state)
+        self._random_state = get_random_state(random_state)
 
         self.kwargs_1 = _parse_mixed_kwargs(kwargs, strategy_1)
         self.kwargs_2 = _parse_mixed_kwargs(kwargs, strategy_2)
@@ -81,12 +81,12 @@ class MixedQuery(BaseQueryStrategy):
         self.query_model1 = get_query_model(strategy_1, **self.kwargs_1)
         if "random_state" in self.query_model1.default_param:
             self.query_model1 = get_query_model(
-                strategy_1, random_state=self.random_state, **self.kwargs_1)
+                strategy_1, random_state=self._random_state, **self.kwargs_1)
 
         self.query_model2 = get_query_model(strategy_2, **self.kwargs_2)
         if "random_state" in self.query_model2.default_param:
             self.query_model2 = get_query_model(
-                strategy_2, random_state=self.random_state, **self.kwargs_2)
+                strategy_2, random_state=self._random_state, **self.kwargs_2)
 
     def query(self, X, classifier, n_instances=None, **kwargs):
 
@@ -124,7 +124,7 @@ class MixedQuery(BaseQueryStrategy):
 
         while i < len(query_idx_1) and j < len(query_idx_2):
 
-            if self.random_state.rand() < self.mix_ratio:
+            if self._random_state.rand() < self.mix_ratio:
                 query_idx_mix.append(query_idx_1[i])
                 i = i + 1
             else:


### PR DESCRIPTION
This does not resolve the issue with the results being random at the moment. 

Example code
```

asreview simulate benchmark:van_de_schoot_2017 -q max_random --seed 535 --init_seed 535 -s vds_max_random.asreview
asreview plot recall vds_max_random.asreview -o vds_max_random_recall.png

asreview simulate benchmark:van_de_schoot_2017 -q max_uncertainty --seed 535 --init_seed 535 -s vds_max_uncertainty.asreview
asreview plot recall vds_max_uncertainty.asreview -o vds_max_uncertainty_recall.png
```