### PR TITLE
Rename n_queries into stop_if

### DIFF
--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -171,7 +171,7 @@ class SimulateEntryPoint(BaseEntryPoint):
             settings = ASReviewSettings(
                 model=args.model,
                 n_instances=args.n_instances,
-                n_queries=args.n_queries,
+                stop_if=args.stop_if,
                 n_prior_included=args.n_prior_included,
                 n_prior_excluded=args.n_prior_excluded,
                 query_strategy=args.query_strategy,
@@ -229,7 +229,7 @@ class SimulateEntryPoint(BaseEntryPoint):
                                   feature_model=feature_model,
                                   n_papers=args.n_papers,
                                   n_instances=args.n_instances,
-                                  n_queries=args.n_queries,
+                                  stop_if=args.stop_if,
                                   prior_indices=prior_idx,
                                   n_prior_included=args.n_prior_included,
                                   n_prior_excluded=args.n_prior_excluded,
@@ -349,6 +349,11 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         "--n_queries",
         type=type_n_queries,
         default="min",
+        help="Deprecated, use 'stop_if' instead.")
+    parser.add_argument(
+        "--stop_if",
+        type=type_n_queries,
+        default="min",
         help="The number of label actions to simulate. Default, 'min' "
         "will stop simulating when all relevant records are found. Use -1 "
         "to simulate all labels actions.")
@@ -357,7 +362,7 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         "--n_papers",
         type=int,
         default=None,
-        help="Deprecated, use 'n_queries' instead.")
+        help="Deprecated, use 'stop_if' instead.")
     parser.add_argument("--verbose",
                         "-v",
                         default=0,

--- a/asreview/review/base.py
+++ b/asreview/review/base.py
@@ -40,7 +40,7 @@ class BaseReview(ABC):
     n_instances: int
         Number of papers to query at each step in the active learning
         process.
-    n_queries: int
+    stop_if: int
         Number of steps/queries to perform. Set to None for no limit.
     start_idx: numpy.ndarray
         Start the simulation/review with these indices. They are assumed to
@@ -59,7 +59,7 @@ class BaseReview(ABC):
         feature_model=Tfidf(),
         n_papers=None,
         n_instances=DEFAULT_N_INSTANCES,
-        n_queries=None,
+        stop_if=None,
         start_idx=[],
     ):
         """Initialize the reviewer base class, so that everything is ready to
@@ -76,7 +76,7 @@ class BaseReview(ABC):
         self.as_data = as_data
         self.project = project
         self.n_instances = n_instances
-        self.n_queries = n_queries
+        self.stop_if = stop_if
         self.prior_indices = start_idx
 
         if n_papers is not None:
@@ -146,7 +146,7 @@ class BaseReview(ABC):
                                 balance_strategy=self.balance_model.name,
                                 feature_extraction=self.feature_extraction.name,
                                 n_instances=self.n_instances,
-                                n_queries=self.n_queries,
+                                stop_if=self.stop_if,
                                 model_param=self.classifier.param,
                                 query_param=self.query_strategy.param,
                                 balance_param=self.balance_model.param,
@@ -202,18 +202,18 @@ class BaseReview(ABC):
         if pool.empty:
             stop = True
 
-        # If n_queries is set to min, stop when all papers in the pool are
+        # If stop_if is set to min, stop when all papers in the pool are
         # irrelevant.
-        if self.n_queries == 'min' and (self.data_labels[pool] == 0).all():
+        if self.stop_if == 'min' and (self.data_labels[pool] == 0).all():
             stop = True
-        # Otherwise, stop when reaching n_queries (if provided)
-        elif self.n_queries is not None:
+        # Otherwise, stop when reaching stop_if (if provided)
+        elif self.stop_if is not None:
             with open_state(self.project) as state:
                 training_sets = state.get_training_sets()
                 # There is one query per trained model. We subtract 1
                 # for the priors.
-                n_queries = len(set(training_sets)) - 1
-            if n_queries >= self.n_queries:
+                stop_if = len(set(training_sets)) - 1
+            if stop_if >= self.stop_if:
                 stop = True
 
         return stop

--- a/asreview/review/simulate.py
+++ b/asreview/review/simulate.py
@@ -105,7 +105,7 @@ class ReviewSimulate(BaseReview):
     n_instances: int
         Number of papers to query at each step in the active learning
         process.
-    n_queries: int
+    stop_if: int
         Number of steps/queries to perform. Set to None for no limit.
     start_idx: numpy.ndarray
         Start the simulation/review with these indices. They are assumed to
@@ -217,13 +217,13 @@ class ReviewSimulate(BaseReview):
         if self.pool.empty:
             return True
 
-        # If n_queries is set to min, stop when all papers in the pool are
+        # If stop_if is set to min, stop when all papers in the pool are
         # irrelevant.
-        if self.n_queries == 'min' and (self.data_labels[self.pool] == 0).all():
+        if self.stop_if == 'min' and (self.data_labels[self.pool] == 0).all():
             return True
 
-        # Stop when reaching n_queries (if provided)
-        if isinstance(self.n_queries, int) and self.total_queries >= self.n_queries:
+        # Stop when reaching stop_if (if provided)
+        if isinstance(self.stop_if, int) and self.total_queries >= self.stop_if:
             return True
 
         return False

--- a/asreview/settings.py
+++ b/asreview/settings.py
@@ -30,7 +30,7 @@ SETTINGS_TYPE_DICT = {
     "balance_strategy": str,
     "feature_extraction": str,
     "n_instances": int,
-    "n_queries": type_n_queries,
+    "stop_if": type_n_queries,
     "n_prior_included": int,
     "n_prior_excluded": int,
     "mode": str,
@@ -85,7 +85,7 @@ class ASReviewSettings(object):
                  balance_strategy,
                  feature_extraction,
                  n_instances=DEFAULT_N_INSTANCES,
-                 n_queries=None,
+                 stop_if=None,
                  n_prior_included=None,
                  n_prior_excluded=None,
                  abstract_only=False,
@@ -95,6 +95,7 @@ class ASReviewSettings(object):
                  balance_param={},
                  feature_param={},
                  data_fp=None,
+                 n_queries=None,
                  n_papers=None,  # deprecated
                  data_name=None  # deprecated
                  ):
@@ -105,7 +106,7 @@ class ASReviewSettings(object):
         self.balance_strategy = balance_strategy
         self.feature_extraction = feature_extraction
         self.n_instances = n_instances
-        self.n_queries = n_queries
+        self.stop_if = stop_if
         self.n_prior_included = n_prior_included
         self.n_prior_excluded = n_prior_excluded
         self.abstract_only = abstract_only

--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -304,7 +304,7 @@ class SQLiteState(BaseState):
             balance_strategy  : triple
             feature_extraction: tfidf
             n_instances       : 1
-            n_queries         : 1
+            stop_if           : min
             n_prior_included  : 10
             n_prior_excluded  : 10
             mode              : simulate

--- a/asreview/types.py
+++ b/asreview/types.py
@@ -37,4 +37,4 @@ def type_n_queries(value):
 
             return value_i
         except ValueError:
-            raise ValueError("Value for n_queries is not 'min' or a valid integer")
+            raise ValueError("Expected 'min' or a valid integer")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -179,11 +179,11 @@ def test_non_tf_models(tmpdir):
 def test_number_records_found(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')
-    n_queries = 100
+    stop_if = 100
     priors = [284, 285]
     seed = 101
 
-    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+    argv = f'{dataset} -s {asreview_fp} --stop_if {stop_if} ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
@@ -192,14 +192,14 @@ def test_number_records_found(tmpdir):
         assert s.get_labels().sum() == 28
 
 
-def test_n_queries_min(tmpdir):
+def test_stop_if_min(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')
-    n_queries = "min"
+    stop_if = "min"
     priors = [284, 285]
     seed = 101
 
-    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+    argv = f'{dataset} -s {asreview_fp} --stop_if {stop_if} ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
@@ -209,14 +209,14 @@ def test_n_queries_min(tmpdir):
         assert len(s.get_labels()) == 515
 
 
-def test_n_queries_all(tmpdir):
+def test_stop_if_all(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')
-    n_queries = -1
+    stop_if = -1
     priors = [284, 285]
     seed = 101
 
-    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+    argv = f'{dataset} -s {asreview_fp} --stop_if {stop_if} ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
@@ -229,12 +229,12 @@ def test_n_queries_all(tmpdir):
 def test_write_interval(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')
-    n_queries = 100
+    stop_if = 100
     priors = [284, 285]
     seed = 101
     write_interval = 20
 
-    argv = f'{dataset} -s {asreview_fp} --n_queries {n_queries} ' \
+    argv = f'{dataset} -s {asreview_fp} --stop_if {stop_if} ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed} ' \
            f'--write_interval {write_interval}'.split()
     entry_point = SimulateEntryPoint()
@@ -249,13 +249,13 @@ def test_write_interval(tmpdir):
 def test_project_already_exists_error(tmpdir):
     asreview_fp1 = Path(tmpdir, 'test1.asreview')
 
-    argv = f'benchmark:van_de_Schoot_2017 -s {asreview_fp1} --n_queries 100' \
+    argv = f'benchmark:van_de_Schoot_2017 -s {asreview_fp1} --stop_if 100' \
            f' --seed 535'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
 
     # Simulate 100 queries in two steps of 50.
-    argv = f'benchmark:van_de_Schoot_2017 -s {asreview_fp1} --n_queries 50' \
+    argv = f'benchmark:van_de_Schoot_2017 -s {asreview_fp1} --stop_if 50' \
            f' --seed 535'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
@@ -271,18 +271,18 @@ def test_partial_simulation(tmpdir):
     seed = 101
 
     # Simulate 100 queries in one go.
-    argv = f'{dataset} -s {asreview_fp1} --n_queries 100 ' \
+    argv = f'{dataset} -s {asreview_fp1} --stop_if 100 ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
 
     # Simulate 100 queries in two steps of 50.
-    argv = f'{dataset} -s {asreview_fp2} --n_queries 50 ' \
+    argv = f'{dataset} -s {asreview_fp2} --stop_if 50 ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
 
-    argv = f'{dataset} -s {asreview_fp2} --n_queries 100 ' \
+    argv = f'{dataset} -s {asreview_fp2} --stop_if 100 ' \
            f'--prior_idx {priors[0]} {priors[1]} --seed {seed}'.split()
     entry_point = SimulateEntryPoint()
     entry_point.execute(argv)
@@ -314,7 +314,7 @@ def test_is_partial_simulation(tmpdir):
     dataset = 'benchmark:van_de_Schoot_2017'
     asreview_fp = Path(tmpdir, 'test.asreview')
 
-    argv = f'{dataset} -s {asreview_fp} --n_queries 50'.split()
+    argv = f'{dataset} -s {asreview_fp} --stop_if 50'.split()
     parser = _simulate_parser()
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
This PR proposes to fix the naming issues/confusion. This PR also provides informative warnings if n_queries is used. 

The 2 relevant options are now:

```
  --n_instances N_INSTANCES
                        Number of papers queried each query.Default 1.
  --stop_if STOP_IF     The number of label actions to simulate. Default, 'min' will stop simulating when all relevant records are found. Use -1 to simulate all labels actions.


  --n_queries N_QUERIES
                        Deprecated, use 'stop_if' instead.
  -n N_PAPERS, --n_papers N_PAPERS
                        Deprecated, use 'stop_if' instead.
```