### PR TITLE
Fix actionable options for project with error status

### DIFF
--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
@@ -436,7 +436,10 @@ const ProjectTable = (props) => {
                   const showAnalyticsButton = () => {
                     return (
                       row["reviews"][0] !== undefined &&
-                      row["reviews"][0]["status"] !== projectStatuses.SETUP
+                      !(
+                        row["reviews"][0]["status"] === projectStatuses.SETUP ||
+                        row["reviews"][0]["status"] === projectStatuses.ERROR
+                      )
                     );
                   };
 
@@ -452,7 +455,8 @@ const ProjectTable = (props) => {
                       row["projectNeedsUpgrade"] ||
                       row["mode"] === projectModes.SIMULATION ||
                       row["reviews"][0] === undefined ||
-                      row["reviews"][0]["status"] === projectStatuses.SETUP
+                      row["reviews"][0]["status"] === projectStatuses.SETUP ||
+                      row["reviews"][0]["status"] === projectStatuses.ERROR
                     );
                   };
 


### PR DESCRIPTION
This PR fixed the direct export of the project in setup status. This issue was accidentally introduced in #1052 