### PR TITLE
Improve statistics card on projects dashboard

### DIFF
--- a/asreview/webapp/src/HomeComponents/DashboardComponents/NumberCard.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/NumberCard.js
@@ -75,7 +75,9 @@ export default function NumberCard(props) {
                   className={`${classes.text} number-card-content-text`}
                   variant={!props.mobileScreen ? "subtitle1" : "subtitle2"}
                 >
-                  Projects in Review
+                  {data?.n_in_review < 2
+                    ? "Project in Review"
+                    : "Projects in Review"}
                 </Typography>
               </Stack>
             </CardContent>
@@ -110,7 +112,9 @@ export default function NumberCard(props) {
                   className={`${classes.text} number-card-content-text`}
                   variant={!props.mobileScreen ? "subtitle1" : "subtitle2"}
                 >
-                  Projects Finished
+                  {data?.n_finished < 2
+                    ? "Project Finished"
+                    : "Projects Finished"}
                 </Typography>
               </Stack>
             </CardContent>

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectTable.js
@@ -250,6 +250,7 @@ const ProjectTable = (props) => {
       });
     },
     onSuccess: (data, variables) => {
+      queryClient.invalidateQueries("fetchDashboardStats");
       // update cached data
       queryClient.setQueryData("fetchProjects", (prev) => {
         return {


### PR DESCRIPTION
This PR corrected a grammatical error (`0 or 1 projects in review/finished`) and re-fetched the statistics after a project status change.

![image](https://user-images.githubusercontent.com/17449217/170998080-06d09152-7489-4608-b355-4e6ccdce0c97.png)
