### PR TITLE
Confirm label is saved explicitly during the review

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/ReviewPage.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/ReviewPage.js
@@ -125,7 +125,7 @@ const ReviewPage = (props) => {
   const showUndoBarIfNeeded = (label, initial) => {
     if (props.undoEnabled) {
       const mark = label === 0 ? "irrelevant" : "relevant";
-      const message = initial ? `Labeled as ${mark}` : "Changes saved";
+      const message = initial ? `Label saved as ${mark}` : "Changes saved";
       showUndoBar(message);
     }
   };


### PR DESCRIPTION
This PR changed the text of the decision undo bar to explicitly confirm the label is saved.

![image](https://user-images.githubusercontent.com/17449217/171864556-b583790e-5bf7-4387-9813-f46687faa8d5.png)
