### PR TITLE
Split overview page in documentation about simulation

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -8,7 +8,7 @@ ASReview LAB is a free (Libre) open-source machine learning tool for screening
 and systematically labeling a large collection of textual data. It's sometimes
 referred to as a tool for title and abstract screening in systematic reviews
 or meta-analyses,  but it can handle any type of textual data that must be
-screened systematically.
+screened systematically, see the paper published in `Nature Machine Intelligence <https://www.nature.com/articles/s42256-020-00287-7>`_. 
 
 ASReview LAB implements three different options:
 
@@ -26,6 +26,7 @@ around the world.
     :width: 320
     :align: center
     :alt: ASReview LAB overview
+
 
 What is active learning?
 ------------------------
@@ -50,22 +51,22 @@ Labeling workflow with ASReview
 Start and finish a systematic labeling process with ASReview LAB by following
 these steps:
 
-1. Create a dataset with potentially relevant records you want to screen systematically. Improve the quality of the data and specify clear reviewing (inclusion/exclusion) criteria
-2. Specify a stopping criterium
+1. Create a dataset with potentially relevant records you want to screen systematically. Improve the `quality of the data <https://www.asreview.ai/blog/the-importance-of-abstracts>`__ and specify clear reviewing (inclusion/exclusion) criteria
+2. Specify a `stopping criterium <https://www.github.com/asreview/asreview/discussions/557>`__
 3. :doc:`start`
 4. :doc:`project_create`
 5. :ref:`Import your dataset <project_create:Add dataset>`
 6. :ref:`project_create:Select Prior Knowledge`
-7. Select the four components of the active learning model (feature extractor, classifier, balancing method, query strategy)
+7. Select the four components of the :ref:`Active learning model <project_create:Model>` (feature extractor, classifier, balancing method, query strategy)
 8. Wait until the warm up of the AI is ready (the software is extracting the features and trains the classifier on the prior knowledge)
-9. Start :doc:`screening` until you reach your stopping criterium
-10. :ref:`progress:Export results` and :ref:`manage:Export project`
+9. Start :doc:`screening` until you reach your `stopping criterium <https://www.github.com/asreview/asreview/discussions/557>`__
+10. At any time you can export the :term:`dataset` the labelling decissions or the entire :term:`project`.
 
 
 Quick start
 -----------
 
-1. Check if Python 3.7 or later is installed (if not, install Python)
+1. Check if Python 3.7 or later is installed (if not, `install Python <https://www.python.org/downloads>`__)
 
 .. code:: bash
 
@@ -83,19 +84,19 @@ Quick start
 
   asreview lab
 
-4. Click Create to create a project.
+4. Click *Create* to create a project
 
 5. Select a mode (Oracle, Exploration, Simulation)
 
-6. Name the project, and if you want, add an author name(s) and type a description.
+6. Name the project, and if you want, add an author name(s) and type a description
 
-7. **Import a dataset** you want to review, or select a benchmark dataset (only available for **Exploration** and **Simulation**).
+7. Import a dataset you want to review, or select a benchmark dataset (only available for the Exploration and Simulation mode)
 
-8. **Add prior knowledge**. Select at least 1 relevant and 1 irrelevant record to warm up the AI. You can search for a specific record or request random records.
+8. Add prior knowledge. Select at least 1 relevant and 1 irrelevant record to warm up the AI. You can search for a specific record or request random records
 
-9. Select the four components of the active learning model, or rely on the default settings that have shown fast and excellent performance in many simulation studies.
+9. Select the four components of the active learning model, or rely on the default settings that have shown fast and excellent performance in many simulation studies
 
-10. ASReview LAB starts extracting the features and runs the classifier with the prior knowledge.
+10. ASReview LAB starts extracting the features and runs the classifier with the prior knowledge
 
 You’re ready to start labeling your data! All your labeling actions are
 automatically saved, so there is no need to click the save button (we don’t
@@ -230,8 +231,23 @@ encounter as you use ASReview LAB.
   Screener
     Replacement term when the context is PRISMA-based reviewing.
 
+
+
+Key principles
+--------------
+
+The use of ASReview LAB comes with `five fundamental principles
+<https://asreview.ai/blog/the-zen-of-elas/>`_:
+
+1. Humans are the oracle;
+2. Code is open & results are transparent;
+3. Decisions are unbiased;
+4. The interface shows an AI is at work;
+5. Users are responsible for importing high quality data.
+
+
 Privacy
 -------
 
 The ASReview LAB software doesn't collect any information about the usage or
-user. Great, isn't it!
+its user. Great, isn't it!

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -1,6 +1,10 @@
 Support
 -------
 
+Questions can be asked on `GitHub Discussions <https://github.com/asreview/asreview/discussions>`__. 
+
+For bug reports and feature requests, please submit an issue on `GitHub <https://github.com/asreview/asreview/issues/new/choose>`__.
+
 Donate
 ~~~~~~
 
@@ -19,8 +23,15 @@ Prof. Dr. Rens van de Schoot <https://www.rensvandeschoot.com/contact/>`_ or sen
 Contribute
 ~~~~~~~~~~
 
-If you discover issues please let us know via `Github
-<https://github.com/asreview/asreview/issues/new/choose>`_. If you have ideas
-to solve your own or other issues, it is highly appreciate to contribute to
-the `development <https://github.com/asreview/asreview/blob/master/CONTRIBUTING.md>`_.
+How do you go from user to contributor? There are many ways to join in, and it might be less complicated than you expect. In a `blogpost <https://asreview.nl/blog/open-source-and-research/>`_ we list some easy examples for first-time contributors, for example sharing your experiences or answering users questions on the `Dicsussion platform <https://github.com/asreview/asreview/discussions>`_. 
+
+Specific instructions for code-contributing are available on `Github <https://github.com/asreview/asreview/blob/master/CONTRIBUTING.md>`_ as well as instructions for `developers <https://github.com/asreview/asreview/blob/master/DEVELOPMENT.md>`_.
+
+
+.. note::
+
+	All contributions, small or large, are very much appreciated!!
+
+
+
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -116,7 +116,7 @@ acceptance in ASReview:
 -  N/A = This format does not exist.
 -  X = Not supported.
 
-.. warning::
+.. tip::
 
     If the export of your search engine is not accepted in ASReview, you can
     also try the following: import the search engine file first into one of
@@ -127,7 +127,7 @@ Systematic Review Software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There are several software packages available for systematic reviewing, see
-for an `overview <https://arxiv.org/abs/2006.12166>`_. Some of them use machine
+for an `overview <https://www.nature.com/articles/s42256-020-00287-7>`_. Some of them use machine
 learning, while other focus on screening and management. The overview below
 shows an overview of alternative software programs and the compatibility with
 ASReview.

--- a/docs/source/data_format.rst
+++ b/docs/source/data_format.rst
@@ -5,26 +5,14 @@ To carry out a systematic review with ASReview on your own dataset, your data
 file needs to adhere to a certain format. ASReview accepts the following
 formats:
 
- - **RIS file format** `(wikipedia) <https://en.wikipedia.org/wiki/RIS_(file_format)>`__ with
-   extensions ``.ris`` or ``.txt``. RIS file formats are used by digital libraries, like
-   IEEE Xplore, Scopus and ScienceDirect. Citation managers Mendeley, RefWorks,
-   Zotero, and EndNote support the RIS file format as well.
 
-For parsing RIS file format, the software uses a Python RIS files parser and
-reader (`rispy <https://pypi.org/project/rispy/>`__). Successful import/export
-depends on a proper data set structure. To validate your data set, the
-complete default mapping can be found on the `rispy GitHub page
-<https://github.com/MrTango/rispy>`_.
+Tabular file format
+-------------------
 
-.. figure:: ../images/asreview_export_to_zotero_labeled.png
-   :alt: Example record with a labeling decision imported to Zotero
-
-.. figure:: ../images/asreview_export_to_endnote_labeled.png
-   :alt: Example record with a labeling decision imported to Endnote
-
-**Tabular datasets** with extensions ``.csv``, ``.tab``, ``.tsv``, or ``.xlsx``.
-   CSV and TAB files are preferably comma, semicolon, or tab-delimited.
-   The preferred file encoding is *UTF-8* or *latin1*.
+Tabular datasets with extensions ``.csv``, ``.tab``, ``.tsv``, or ``.xlsx``
+can be used in ASReview LAB. CSV and TAB files are preferably comma,
+semicolon, or tab-delimited.    The preferred file encoding is *UTF-8* or
+*latin1*.
 
 For tabular data files, the software accepts a set of predetermined column names:
 
@@ -78,8 +66,7 @@ information is available via the API.
 If a Digital Object Identifier ( ``DOI``) is available it will be displayed during the
 screening phase as a clickable hyperlink to the full text document. Note by
 using ASReview you do *not* automatically have access to full-text and if you do
-not have access you might want to read this `blog post
-<https://asreview.ai/blog/tools-that-work-well-with-asreview-google-scholar-button/>`__.
+not have access you might want to read this `blog post <https://asreview.ai/blog/tools-that-work-well-with-asreview-google-scholar-button/>`__.
 
 **Included** A binary variable indicating the existing labeling decisions with
 ``0`` = irrelevant/excluded, and ``1`` = relevant/included. Different column
@@ -99,5 +86,51 @@ names are allowed, see the table. It can be used for:
 
 .. note::
 
-  Files exported with ASReview LAB contain the column ``included`` and can be used for
-  prior knowledge.
+  Files exported with ASReview LAB contain the column ``included``. When
+  re-importing a partly labeled dataset in the the RIS file format, the labels
+  stored in the N1 field are used as prior knowledge. When a completely
+  labeled dataset is re-imported it can be used in the Exploration and
+  Simualtion mode. 
+
+
+RIS file format
+---------------
+
+RIS file formats (with extensions ``.ris`` or ``.txt``) are used by digital
+libraries, like IEEE Xplore, Scopus and ScienceDirect. Citation managers
+Mendeley, RefWorks, Zotero, and EndNote support the RIS file format as well.
+See `(wikipedia) <https://en.wikipedia.org/wiki/RIS_(file_format)>`__  for 
+detailed information about the format. 
+
+For parsing RIS file format, ASReview LAB uses a Python RIS files parser and
+reader (`rispy <https://pypi.org/project/rispy/>`__). Successful import/export
+depends on a proper data set structure. The complete list of accepted fields and 
+default mapping can be found on the `rispy GitHub page <https://github.com/MrTango/rispy>`_.
+
+
+.. tip:: 
+
+  Labeling decissions ``ASReview_relevant``, ``ASReview_irrelevant``, and
+  ``ASReview_not_seen`` are stored with the N1 (Notes) tag. In citation managers
+  Zotero and Endnote the labels can be used for making selections; see the
+  screenshots or watch the `instruction video  <https://www.youtube.be/-Rw291AE20I>`_. 
+
+.. note:: 
+
+  When re-importing a partly labeled dataset in the the RIS file format, the
+  labels stored in the N1 field are used as prior knowledge. When a completely
+  labeled dataset is re-imported it can be used in the Exploration and
+  Simualtion mode.  
+
+
+
+.. figure:: ../images/asreview_export_to_zotero_labeled.png
+   :alt: Example record with a labeling decision imported to Zotero
+
+   Example record with a labeling decision imported to Zotero
+
+
+.. figure:: ../images/asreview_export_to_endnote_labeled.png
+   :alt: Example record with a labeling decision imported to Endnote
+   
+   Example record with a labeling decision imported to Endnote

--- a/docs/source/data_labeled.rst
+++ b/docs/source/data_labeled.rst
@@ -3,46 +3,56 @@ Fully and partially labeled data
 
 Fully and partially labeled datasets serve a special role in the ASReview
 context. These datasets have review decisions for a subset of the records or
-for each record in the dataset. The labels are dichotomous: relevant or
-irrelevant. :ref:`data_labeled:Partially labeled data` is useful in the Oracle
-mode, whereas :ref:`data_labeled:Fully labeled data` is useful in the Simulation
-and Exploration mode. See :ref:`project_create:Project modes` for more
-information.
+for all records in the dataset. 
 
-All datasets exported from ASReview LAB can be imported into ASReview LAB
-again. All labels are recognized by the software. In Oracle mode, all labels
-are directly added as :ref:`Prior Knowledge <project_create:Select Prior
-Knowledge>`.
+.. tip::
 
-Labeled data format
--------------------
+  :ref:`data_labeled:Partially labeled data` is useful in the Oracle
+  mode, whereas :ref:`data_labeled:Fully labeled data` is useful in the Simulation
+  and Exploration mode.
+
+
+
+Label format
+------------
+
 
 For tabular datasets (:doc:`e.g., CSV, XLSX <data_format>`), the dataset
 should contain a column called "included" or "label" (See :ref:`Data format
 <column-names>` for all naming conventions), which is filled with ``1``'s or
-``0``'s for the records that are already screened. The value is left empty for
-the records that you haven't screened yet.
+``0``'s for the records that are already screened, or selected by experts to
+be used for prior knowledge. The value is left empty for the records that you
+haven't screened yet, or which are added to the dataset.
+
+
 
 For the RIS file format, the labels ``ASReview_relevant``,
 ``ASReview_irrelevant``, and ``ASReview_not_seen``) can be stored with the N1
 (Notes) tag. An example of a RIS file with labels in the N1 tag can be found
-in the `ASReview GitHub repository
-<https://github.com/asreview/asreview/blob/master/tests/demo_data/baseline_tag-notes_labels.ris>`_.
-All labels in this example are valid ways to label the data. Exported RIS file
-from ASReview LAB can be imported into ASReview LAB again, and whereafter all
-labels are recognized.
+in the `ASReview GitHub repository <https://github.com/asreview/asreview/blob/master/tests/demo_data/baseline_tag-notes_labels.ris>`_.
+All labels in this example are valid ways to label the data. 
+
+
+.. note::
+
+  Exported files containing labeling decission can be imported into ASReview LAB again,
+  and whereafter all labels are recognized.
+
+
 
 Partially labeled data
 ----------------------
 
-.. note::
+.. tip::
 
 	Useful for Oracle projects. Read more about :ref:`project_create:Project modes`.
 
-Partially labeled datasets are datasets with a review decision for a subset of
-the records in the dataset. A partially labeled dataset can be obtained by
-exporting results from ASReview LAB or other software. It can also be
-constructed given the format described above.
+Partially labeled datasets are datasets with a labeling decision for a subset
+of the records in the dataset and no decission for another subset.  
+
+A partially labeled dataset can be obtained by exporting results from ASReview
+LAB or other software. It can also be constructed given the format described
+above by merging a labeled dataset with new unlabeled records.
 
 Partially labeled datasets are useful as the labels will be recognized by
 ASReview LAB as :ref:`Prior Knowledge <project_create:Select Prior Knowledge>`, and labels are used to
@@ -57,37 +67,36 @@ train the first iteration of the active learning model.
 Fully labeled data
 ------------------
 
-.. note::
+.. tip::
 
 	Useful for Simulation and Exploration projects. Read more about :ref:`project_create:Project modes`.
 
-Fully labeled datasets are datasets with a review decision for each record in
+Fully labeled datasets are datasets with a labeling decision for each record in
 the dataset. Fully labeled datasets are useful for exploration or simulation
 purposes (see also :ref:`simulation_overview:What is a simulation?` and
-:ref:`project_create:Project modes`). See :ref:`data_labeled:Benchmark
-Datasets` for built-in, fully labeled datasets in ASReview LAB.
+:ref:`project_create:Project modes`). 
 
 
-Benchmark Datasets
-~~~~~~~~~~~~~~~~~~
+Benchmark data
+--------------
 
 The `ASReview research project <https://asreview.ai/about/>`_ collects fully
 labeled datasets published open access. The labeled datasets are PRISMA-based
-reviews on various research topics. They can be useful for benchmark projects
-such as testing the performance of new active learning models. The datasets
-and their metadata are available via the `Systematic Review Datasets
-<https://github.com/asreview/systematic-review-datasets>`_ repository. In
+systematic reviews or meta-analyses on various research topics. They can be
+useful for teaching purposes or for testing the performance of (new) active
+learning models. The datasets and their metadata are available via the
+`Systematic Review Datasets <https://github.com/asreview/systematic-review-datasets>`_ repository. In
 ASReview LAB, these datasets are referred to as "Benchmark Datasets".
 
-These Benchmark Datasets are directly available in the software. During the
+The Benchmark Datasets are directly available in the software. During the
 :ref:`project_create:Add Dataset` step of the project setup, there is a panel
 with all the datasets. The datasets can be selected and used directly.
+
 Benchmark datasets are also available via the :doc:`cli`. Use the prefix
 ``benchmark:`` followed by the identifier of the dataset (see `Systematic
 Review Datasets <https://github.com/asreview/systematic-review-datasets>`_
 repository). For example, to use the Van de Schoot et al. (2017) dataset, use
 ``benchmark:van_de_schoot_2017``.
 
-You can donate your dataset to the `Systematic Review Datasets
-<https://github.com/asreview/systematic-review-datasets>`_ collection.
+You can donate your dataset to the `Systematic Review Datasets <https://github.com/asreview/systematic-review-datasets>`_ collection by via a Pull Request, or send an email to asreview@uu.nl.
 

--- a/docs/source/extensions_overview.rst
+++ b/docs/source/extensions_overview.rst
@@ -4,8 +4,7 @@ Extensions
 ASReview has extensive support for extensions. They can extend the
 functionality of ASReview LAB, and the
 :doc:`Command Line Interface <cli>`. There are :ref:`officially
-supported extensions<extensions-official>` and
-:ref:`community<extensions-community>` maintained extensions.
+supported extensions<extensions-official>` and `community maintained extensions <https://github.com/asreview/asreview/discussions/1140>`_.
 
 Looking to develop your own extension? See :ref:`develop-extensions` for
 detailed instructions.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,9 +60,13 @@ feature requests, please submit an issue on `GitHub
 
     simulation_overview
 
+    simulation_webapp
+
     simulation_cli
 
     simulation_api_example
+
+    simulation_results
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,7 +29,7 @@ ASReview LAB, see :doc:`start`.
 
     See :doc:`troubleshooting` for common problems during installation.
 
-.. note::
+.. tip::
 
     For users with Apple M1 computers, if you experience problems, follow the
     `instructions
@@ -121,4 +121,7 @@ access the same folder.
 Build a local image
 ~~~~~~~~~~~~~~~~~~~
 
-For more information, see `ASReview LAB GitHub <https://github.com/asreview/asreview/tree/master/docker>`__.
+If you want to use a specific version of ASReview LAB, not available as
+DockerHub image, you can build your own. To build your own image, create a
+file called Dockerfile (no file extension) and fill it with the following
+code.  For more information, see `ASReview LAB GitHub <https://github.com/asreview/asreview/tree/master/docker/#build-your-own-image>`__.

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -1,9 +1,9 @@
 Progress and results
 ====================
 
-During screening, you might want to keep track of your progress and know when
-to stop. This section provides documentation on useful tools for these
-purposes.
+During screening, you might want to keep track of your progress and to obtain
+information for your stopping criteria. This section provides documentation on
+useful tools for these purposes.
 
 Analytics
 ---------
@@ -36,19 +36,18 @@ The summary statistics are counts of the records in your dataset.
 - Labeled records: the number of records that you labeled as relevant or irrelevant, including those you added as prior knowledge.
 - Relevant records: the number of records that you labeled as relevant, including those you added as prior knowledge.
 - Irrelevant records: the number of records that you labeled as irrelevant, including those you added as prior knowledge.
-- Irrelevant since last relevant: the number of irrelevant records you have seen since the last relevant record. The larger this number (relatively), the more likely you have seen the relevant records.
+- Irrelevant since last relevant: the number of irrelevant records you have seen since the last relevant record. 
+
 
 Charts
 ~~~~~~
 
 The charts on the analytics page can be useful to monitor your progress. There
-is a *Progress* and a *Recall* chart. You will probably see a decline in the
-number of relevant items you find. This helps to decide when to stop. The
-charts do not include prior knowledge and are most relevant after you have
-screened a couple of hundreds of records.
+is a *Progress* and a *Recall* chart. The charts do not include prior
+knowledge and are most relevant after you have screened a couple of records.
+
 
 **Progress chart**
-
 
 The progress chart plots the number of relevant records in the last 10 records
 that you reviewed in ASReview LAB. For example, when you reviewed 100 records,
@@ -57,11 +56,21 @@ you labeled 3 relevant records between the 91st and 100th reviewed records.
 **Recall chart**
 
 The recall chart plots the number of relevant records against the number of
-records that you reviewed in ASReview LAB. Relevant by ASReview LAB refers to
+records that you reviewed in ASReview LAB. *Relevant by ASReview LAB* refers to
 the relevant records that you labeled with the assistance of the active
-learning model. Random relevant refers to the relevant records that you might
-find if you manually reviewed all the records without the assistance of the
+learning model. *Random relevant* refers to the relevant records that you might
+find if you manually reviewed the records so far without the assistance of the
 active learning model.
+
+**Export Figure**
+
+The plots can be exported as a figure:
+
+1. :doc:`start`.
+2. Open or :doc:`project_create`.
+3. Click on Analytics on in the left menu.
+4. Click on the hamburger menu next to the Progress or Recall chart. 
+5. Select *Download SVG* or *PNG* to export a figure, or select *Download CSV* to export the data behind the figure. 
 
 
 Stop screening
@@ -72,6 +81,21 @@ The `blogpost
 `How to stop screening?
 <https://github.com/asreview/asreview/discussions/557>`_ discussion provide
 tips on when to stop with screening.
+
+.. tip::
+
+  The number of irrelevant records since last relevant will increase the longer you screen.
+
+.. tip:: 
+
+  If you selected *Maximum* as the :ref:`project_create:Query Strategy`, you will 
+  see a decline in the number of relevant items in the plots the longer you screen. This may
+  help to decide when to 'stop screening <https://github.com/asreview/asreview/discussions/557>`_. 
+
+.. tip::
+
+  The data behind the recall plot can be used to calculate the `knee-algortitm <https://github.com/asreview/asreview/discussions/1115#discussioncomment-2812003>`_ as a stopping criteria. 
+
 
 Mark project as finished
 ------------------------
@@ -91,8 +115,18 @@ clicking again on *Mark as in review*.
 Export results
 --------------
 
-You can export the results of your screening to a RIS, CSV, TSV or Excel file.
-A file contains all imported data including your decisions. The file is ordered as follows:
+You can export the results of your labeling decissions to a RIS, CSV, TSV or Excel file.
+A file contains all imported data including your decisions. 
+
+The following variables will be added to your dataset:
+
+- The column titled **included** contains the labels as provided by the user:
+  ``0`` = not relevant, ``1`` = relevant and if missing it means the record is
+  not seen during the screening process.
+- The column titled **asreview_ranking** contains an identifier to
+  preserve the rank ordering as described above.
+
+The file is ordered as follows:
 
 1. All relevant records you have seen in the order they were shown during the screening process.
 2. All records not seen during the screening and ordered from most to least relevant according to the last iteration of the model.
@@ -115,12 +149,6 @@ To download your results follow these steps:
 
     A RIS file can only be exported if a RIS file is imported.
 
-The following variables will be added to your dataset:
 
-- The column titled **included** contains the labels as provided by the user:
-  ``0`` = not relevant, ``1`` = relevant and if missing it means the record is
-  not seen during the screening process.
-- The column titled **asreview_ranking** contains an identifier to
-  preserve the rank ordering as described above.
 
 

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -13,29 +13,29 @@ To create a project:
 
 1. :doc:`start`.
 2. Go to the *Projects dashboard* if you are not already there (http://localhost:5000/projects)
-3. Click on the Create on the bottom left
+3. Click on the *Create* button on the bottom left
 
 Project information
 ===================
 
-In this step of the project setup, step 1, you provide all relevant
-information about your project as well as the type of project you want (the
-mode). The sections below provide more information on the input fields. After
-you complete this step, click next.
+In Step 1 you need to provide all relevant information about your project as
+well as the type of project you want (the mode). The sections below provide
+more information on the input fields. After you complete this step, click
+*next*.
 
 Project modes
 -------------
 
-In this step, you have to select a mode. The default is "Oracle". Most users
-are looking for this one. Oracle mode is used to screen an unlabeled dataset
-(it's fine if you already have some labels) with the help of AI. The other two
-modes, Simulation, and Exploration require fully labeled datasets. They are
-useful for experts studying the performance of active learning or
-demonstrating the workings of active learning and ASReview.
+In this step, you have to select a mode. The default is **Oracle**. Oracle mode
+is used to screen an unlabeled dataset with the help of AI (it's fine if you
+already have labels, these will used as prior knowledge). The other
+two modes, Simulation and Exploration, require fully labeled datasets. They
+are useful for teaching purposes or studying the performance of active
+learning in a simulation study.
 
 In short:
 
-- You have an unlabeled dataset (a few labels is fine) -> Oracle
+- You have an Unlabeled, or :ref:`data_labeled:Partially labeled data` -> Oracle
 - You have a :ref:`data_labeled:Fully labeled data` -> Simulation or Exploration.
 
 .. figure:: ../images/setup_project_modes.png
@@ -45,31 +45,28 @@ In short:
 Project details
 ---------------
 
-Provide project details like name of the project, authors (for example, the
-name of the screener), and a description. You can edit these values later in
-the *Details* page.
+Provide project details like name of the project (required), author(s) (for
+example, the name of the screener), and a description. You can edit these
+values later in the *Details* page.
 
 
 Data
 ====
 
-In this step of the project setup, step 1, you import a dataset and select
-prior knowledge. Read :doc:`data` for information about dataset formats. Prior
-knowledge is used to come up with a first sorting of the dataset.
+In Step 2, you import a dataset and select prior knowledge.
 
 Add Dataset
 -----------
 
 Click on *Add* to select a dataset. The data needs to adhere to a
-:doc:`specific format<data>`. You will benefit most from what active learning
-has to offer with :ref:`data:High quality data`.
+:doc:`specific format<data>`.
 
 Depending on the :ref:`Project mode <project_create:Project modes>`, you are
 offered the following options for adding a dataset. Keep in mind that in Oracle
 mode, your dataset is unlabeled or :ref:`data_labeled:Partially labeled data`. For Exploration and Simulation mode, you need :ref:`data_labeled:Fully labeled
 data`.
 
-.. note::
+.. tip::
 
     You will benefit most from what active learning has to offer with :ref:`data:High quality data`.
 
@@ -77,45 +74,53 @@ data`.
 From File
 ~~~~~~~~~
 
-Drag and drop your file or select your file. Click on Save on the top right.
+Drag and drop your file or select your file. Click on *Save* on the top right.
 
 From URL
 ~~~~~~~~
 
 Use a link to a dataset on the Internet. For example, a link from this
 `dataset repository
-<https://github.com/asreview/systematic-review-datasets>`__. Click on Save on
+<https://github.com/asreview/systematic-review-datasets>`__. Click on *Save* on
 the top right.
 
 From Extension
 ~~~~~~~~~~~~~~
 
 Oracle and Exploration only. Select a file available via an extension. Click
-on Save on the top right.
+on *Save* on the top right.
 
 Benchmark Datasets
 ~~~~~~~~~~~~~~~~~~
 
-Simulation and Exploration only. Select one of the
-:ref:`data_labeled:benchmark datasets`. Click
-on Save on the top right.
+For Simulation and Exploration only. Select one of the
+:ref:`data_labeled:benchmark data`. Click
+on *Save* on the top right.
 
 
 Select Prior Knowledge
 ----------------------
 
-The first iteration of the active learning cycle requires prior knowledge to
-work. This knowledge is used to train the first model. In this step, you need
-to provide **at least** one relevant and one irrelevant record in your
-dataset. To facilitate this, it is possible to search within your dataset.
-This is especially useful for finding records that are relevant based on your
-prior knowledge or expertise. You can also let ASReview LAB present you a
-couple of random documents. This can be useful for finding irrelevant records.
+.. note::
+  If you use :ref:`data_labeled:Partially labeled data` you can skip this step. 
+
+The first iteration of the active learning cycle requires traning data,
+referred to as prior knowledge. This knowledge is used by the classifier to
+create an initial ranking of the unseen records. In this step, you need to
+provide a minimum training data set of size two, with **at least** one
+relevant and one irrelevant labeled record.
+
+To facilitate prior selection, it is possible to search within your dataset.
+This is especially useful for finding records that are relevant based on
+previous studies or expert consensus. 
+
+You can also let ASReview LAB present you with random documents. This can be
+useful for finding irrelevant records.
 
 The interface works as follows; on the left, you will see methods to find
 records to use as prior knowledge, on the right, you will see your selected
 prior knowledge. If you have **at least** one relevant and one irrelevant
-record, you can click *Close* and go to the next step.
+record, you can click *Close* and go to the next step. 
 
 .. figure:: ../images/setup_prior.png
    :alt: ASReview prior knowledge selector
@@ -137,11 +142,14 @@ After entering your search terms, press enter to start searching.
 
 
 Click the document you had in mind and answer, "Is this record relevant?".
-Note, don't label all items here. Only the one you are looking for.
+Note, don't label all items here. Only the one you are looking for and want to
+use as training data.
 
 The prior knowledge will now show up on the right. There are no restrictions
-on the number of publications you provide but preferably provide 1-5
-relevant records. If you are done, click *Close*.
+on the number of records and the software already works with 2 labels (1
+relevant and 1 irrelevant). 
+
+If you are done searching prior knowledge, click *Close*.
 
 .. figure:: ../images/setup_prior_search_1rel.png
    :alt: ASReview prior knowledge search 1 relevant
@@ -149,72 +157,132 @@ relevant records. If you are done, click *Close*.
 Random
 ~~~~~~
 
-You also need to provide at least one prior irrelevant document. You can do
-this by searching it, but this can be challenging as you don't know what you
-are looking for. One way to find an irrelevant document is by labeling a set
-of random records from the dataset. Given that the majority of records in the
-dataset are irrelevant (extremely imbalanced data problem), the records
-presented here are likely to be irrelevant for your study. Click on random to
-show a few random records. Indicate for each document whether it is relevant
-or irrelevant.
+.. warning::
+  Do not use the random option to search for the sparse relevant records!
+
+
+You also need to provide at least one prior irrelevant document. One way to
+find an irrelevant document is by labeling a set of random records from the
+dataset. Given that the majority of records in the dataset are irrelevant
+(extremely imbalanced data problem), the records presented here are likely to
+be irrelevant for your study. Click on *random* to show a few random records.
+Indicate for each record you want to use as training data whether it is
+irrelevant (or relevant).
 
 .. figure:: ../images/setup_prior_random_1rel.png
    :alt: ASReview prior knowledge random
 
 The prior knowledge will now show up on the right. Use the buttons to see all
-prior knowledge or irrelevant items. There are no restrictions on the
-number of publications you provide but preferably provide 1-5 relevant
-records. If you are done, click *Close*.
+prior knowledge or irrelevant items. There are no restrictions on the number
+of records you provide, and the software already works with 2 labeled
+records (1 relevant and 1 irrelevant). 
 
-After labeling a couple of randomly selected records, ASReview LAB will ask
-you whether you want to stop. Click on **STOP** and click **Next**.
+After labeling five randomly selected records, ASReview LAB will ask you
+whether you want to stop searching prior knowledge. Click on *STOP* and
+click *Next*.
+
+If you are done, click *Close*.
 
 Model
 =====
 
-In the next step of the setup, you can select a model. The default settings
-(Naïve Bayes, TF-IDF, Max) have fast and excellent performance. Most users can
-skip this step and click *Next*.
+In the next step of the setup, you can select the active learning model. The
+default settings (Naïve Bayes, TF-IDF, Max) have fast and excellent
+performance. Most users can skip this step and click *Next*. More information
+about the active learning proces can be found in the blog post `Active learning explained <https://asreview.nl/blog/active-learning-explained/>`_, 
 
-Select model (advanced)
------------------------
+Select model
+------------
 
 It is possible to change the settings of the Active learning model. There are
-four ingredients that can be changed in the software: the type of classifier,
-the query strategy, balance strategy, and the feature extraction technique.
+four settings that can be changed in the software: 
 
-The classifier is the machine learning model used to compute the relevance
-scores. The available classifiers are Naive Bayes, Support Vector
-Machine, Logistic Regression, and Random Forest. More classifiers can be
-selected via the :doc:`API <reference>`. The default is Naive Bayes,
-though relatively simplistic, it seems to work quite well on a wide range of
-datasets.
 
-The query strategy determines which document is shown after the model has
-computed the relevance scores. The three options are: certainty-based, mixed and
-random. When certainty-based is selected, the documents are shown in the order of
-relevance score. The document most likely to be relevant is shown first. When
-mixed is selected, the next document will be selected certainty-based 95% of the
-time, and randomly chosen otherwise. When random is selected, documents are shown
-in a random order (ignoring the model output completely). **Warning**: selecting
-this option means your review is not going to be accelerated by using ASReview.
+Feature extraction
+~~~~~~~~~~~~~~~~~~
 
 The feature extraction technique determines the method how text is translated
 into a vector that can be used by the classifier. The default is TF-IDF (Term
 Frequency-Inverse Document Frequency) from `SKLearn <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html>`_.
 It works well in combination with Naive Bayes and other fast training models.
-Another option is Doc2Vec provided by the `gensim <https://radimrehurek.com/gensim/>`_
-package which needs to be installed manually.
-To use it, install the gensim package manually:
+
+Another recommended option is Doc2Vec provided by the `gensim <https://radimrehurek.com/gensim/>`_
+package. Before starting ASReview LAB first intall gensim:
 
 .. code:: bash
 
     pip install gensim
 
-It takes relatively long to create a feature matrix with this method. However,
-this only has to be done once per simulation/review. The upside of this method
-is the dimension-reduction that generally takes place, which makes the
-modeling quicker.
+.. note::
+
+  It takes relatively long to create a feature matrix with Doc2Vec, but  this
+  only has to be done once. The upside of this method is that it takes context
+  into accound. Also, a benifit is the dimension-reduction that generally
+  takes place, which makes the modeling quicker.
+
+Several other feature extractors are available in the software (sentence Bert,
+embedding IDF/LSTM) and more classifiers can be selected via the :doc:`API
+<reference>`, or added via an :ref:`extensions_dev:model extensions`. 
+
+Classifier
+~~~~~~~~~~
+
+The classifier is the machine learning model used to compute the relevance
+scores. The default is Naive Bayes, though relatively simplistic, it seems to
+work quite well on a wide range of datasets. Several other classifiers are
+available in the software (logistic regression, random forest, SVM, LSTM,
+neural net) and more classifiers can be selected via the :doc:`API
+<reference>` or added via an :ref:`extensions_dev:model extensions`. 
+
+The neural nets require `tensorflow <https://www.tensorflow.org/>`_, use
+
+.. code:: bash
+
+    pip install tensorflow
+
+
+.. note::
+
+  Neural nets (and LSTM) require a much larger training set (i.e., more prior knowledge) compared to the other classifiers.
+
+
+
+Balancing Strategy
+~~~~~~~~~~~~~~~~~~
+
+To decrease the class imbalance in the training data, the default is to
+rebalance the training set by a technique called dynamic resampling (DR)
+(`Ferdinands et al., 2020 <https://doi.org/10.31219/osf.io/w6qbg>`_).  DR
+undersamples the number of irrelevant records in the training data, whereas
+the number of relevant records are oversampled such that the size of the
+training data remains the same. The ratio between relevant and irrelevant
+records in the rebalanced training data is not fixed, but dynamically updated
+and depends on the number of records in the available training data, the total
+number of records in the dataset, and the ratio between relevant and
+irrelevant records in the available training data. No balancing or
+undersampling are the other options. Other strategies can be selected via the
+:doc:`API <reference>` or added via an :ref:`extensions_dev:model extensions`.
+
+
+Query Strategy
+~~~~~~~~~~~~~~
+
+The query strategy determines which document is shown after the model has
+computed the relevance scores. The options are: maximum (certainty-based),
+uncertainty, random and clustering. When certainty-based is selected, the
+documents are shown in the order of relevance score. The document most likely
+to be relevant is shown first. When mixed is selected, the next document will
+be selected certainty-based 95% of the time, and uncertainty based or randomly
+chosen otherwise. When random is selected, documents are shown in a random
+order (ignoring the model output completely). Other strategies can be selected
+via the :doc:`API <reference>` or added via an :ref:`extensions_dev:model
+extensions`.
+
+.. warning::
+  Selecting random means your review is not going to be accelerated by using ASReview.
+
+Model Swithcing 
+~~~~~~~~~~~~~~~
 
 During the screening phase, it is not possible to change the model. However,
 it is possible to select a first model, screen part of the data, and export
@@ -224,14 +292,21 @@ on the first model will be recognized as prior knowledge. Then, a second model
 can be trained on the partly-labeled data, and the new predictions will be
 based on the second model.
 
+.. tip::
+
+  It is suggested to first screen with a simple active learning model (e.g.,
+  the defaults) untill you reach your stopping criteria, then switch to a
+  different model (e.g., doc2vec plus a neural net) and screen again untill
+  you reach your stopping criteria.
 
 Warm up
 =======
 
-In the last step of the setup, step 4, ASReview LAB trains a model and ranks
-the records in your dataset. Depending on the model and the size of your
-dataset, this can take a couple of minutes (or even longer). After the project
-is successfully initialized, you can start reviewing.
+In the last step of the setup, step 4, ASReview LAB runs the feature extracter
+and trains a model and ranks the records in your dataset. Depending on the
+model and the size of your dataset, this can take a couple of minutes (or even
+longer; you can enjoy the `animation video <https://www.youtube.com/watch?v=k-a2SCq-LtA>`_). After the project is successfully
+initialized, you can start reviewing.
 
 .. note::
 

--- a/docs/source/research.rst
+++ b/docs/source/research.rst
@@ -4,28 +4,43 @@ Research
 The open source ASReview LAB software is one of the products of the `ASReview
 research project <https://asreview.ai/about/>`_. The ASReview research project
 is a fundamental and applied research project studying the application of AI
-in the field of systematic reviews. The research is conducted by the research
-team, partners, and contributors. ASReview LAB is stable and validated by the
-scientific community `(Van de Schoot et al., 2020)
-<https://www.nature.com/articles/s42256-020-00287-7>`_. In short, ASReview LAB
-is written by researchers for researchers.
+in the field of systematically reviewing large amounts of text data. 
 
-The team defined and implements the `five fundamental principles of ASReview
-<https://asreview.ai/blog/the-zen-of-elas/>`_:
+ 
 
-1. Humans are the oracle;
-2. Code is open & results are transparent;
-3. Decisions are unbiased;
-4. The interface shows an AI is at work;
-5. Users are responsible for importing high quality data.
+.. note::
+  
+  The ASReview project is developed by researchers for researchers, and anyone is welcome to join the community!
+
+There are still 1001 scientific papers that can be published using the
+ASReview products. We welcome researchers worldwide to work on papers like
+applying the existing models to new types of datasets (different scientific
+fields, other languages, multilanguage data, text data outside acadmia, ulta
+large datasets, etcetera), adding new models and testing the performance on
+the available benchmark datasets, adding and testing new stopping ruls or
+performance metrics, and so on! 
+
+
+Scientific principles
+---------------------
+
+The scientific team works according to the Open Science principles and invests in an
+inclusive community contributing to the project. In short, research is
+conducted according to the following fundamental principles:
+
+- Research output should be `FAIR <https://www.uu.nl/en/research/open-science>`_ (Finable Accessible Interoperable and Reusable).
+- Research should be conducted with integrity, and we commit ourselves to the `Netherlands Code of Conduct for Research Integrity <https://www.nwo.nl/sites/nwo/files/documents Netherlands%2BCode%2Bof%2BConduct%2Bfor%2BResearch%2BIntegrity_2018_UK.pdf>`_ .
+- Output should be rewarded according to the Declaration on Research Assessment (`DORA <https://sfdora.org/read/>`_).
+
+
+Utrecht University has established `specific regulations <https://www.uu.nl/en/organisation/about-us/codes-of-conduct>`_ governing conduct for its employees. These are based on the key principles of professional and quality academic conduct and ethically-responsible research. Members of the team employed by Utrecht University, commit themselves to these regulations in all their conduct, including all work related to ASReview. Adherence to similar key principles is expected of all researchers involved in all facets of the ASReview project.
 
 Cite
-~~~~
+----
 
-For scientific use, we encourage you to cite both the software and research
-project.
+For scientific use, we encourage users to cite:
 
-- The paper published in `Nature Machine Intelligence <https://www.nature.com/articles/s42256-020-00287-7>`_ can be used to cite the **ASReview project**.
+- The paper published in `Nature Machine Intelligence <https://www.nature.com/articles/s42256-020-00287-7>`_ to cite the **ASReview project**.
 
 - For citing the software **ASReview LAB**, refer to the `specific release
   <https://doi.org/10.5281/zenodo.3345592>`_ of the software. The menu on the
@@ -33,5 +48,4 @@ project.
 
 - For citing the documentation (or to download the pdf) go to `Zenodo <https://doi.org/10.5281/zenodo.4287119>`_.
 
-- More studies related to the project can be found on the
-  `asreview.ai/research <https://asreview.ai/research/>`_.
+- More studies related to the project can be found on `asreview.ai/research <https://asreview.ai/research/>`_.

--- a/docs/source/research.rst
+++ b/docs/source/research.rst
@@ -29,7 +29,7 @@ inclusive community contributing to the project. In short, research is
 conducted according to the following fundamental principles:
 
 - Research output should be `FAIR <https://www.uu.nl/en/research/open-science>`_ (Finable Accessible Interoperable and Reusable).
-- Research should be conducted with integrity, and we commit ourselves to the `Netherlands Code of Conduct for Research Integrity <https://www.nwo.nl/sites/nwo/files/documents Netherlands%2BCode%2Bof%2BConduct%2Bfor%2BResearch%2BIntegrity_2018_UK.pdf>`_ .
+- Research should be conducted with integrity, and we commit ourselves to the `Netherlands Code of Conduct for Research Integrity <https://www.nwo.nl/en/netherlands-code-conduct-research-integrity>`_ .
 - Output should be rewarded according to the Declaration on Research Assessment (`DORA <https://sfdora.org/read/>`_).
 
 

--- a/docs/source/screening.rst
+++ b/docs/source/screening.rst
@@ -18,26 +18,50 @@ You are asked to make a decision: relevant or irrelevant?
 .. figure:: ../images/project_screening.png
    :alt: ASReview Screening
 
-Click on the decision of choice. A new record is presented to you. While you
-review the records, ASReview LAB continuously improves its understanding of
-your decisions, constantly updating the underlying ordering of the records.
+
+Screening in Oracle mode
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the Oracle mode, unlabeled records are presented to you. Depending on the
+selected strategy it is the most likely relevant record (default
+setting) or based on anothter :ref:project_create:Query Strategy.  
+
+Click on the decision of your choice, and new record is presented to you. While
+you review the next record, a new model is being trained. ASReview LAB
+continuously improves its understanding of your decisions, constantly updating
+the underlying ordering of the records.
+
+Each labeling decision of the user starts the training  of a new model given
+there is no model being trained at that time. When this new model is trained,
+the unseen records' rank order is updated. Training and labeling occur
+asynchronous. With fast models, a new ranking will probably be available
+before the user finished reading the text. With slower models, training
+continues until a new model is trained, and the user can continue screening
+the next record in line (2nd, 3rd, etc.). Therefore, the record shown to the
+user can be the one with the highest relevance score of the second last model
+or the highest-ranked as resulted from the latest model until a new model is
+trained. 
 
 As you keep reviewing documents and providing labels, you will probably see
 fewer relevant records. When to stop screening is left to you. See
 :doc:`progress` for more information on progress monitoring and information on
 when to stop.
 
-.. note::
+.. tip::
 
   If you are in doubt about your decision, take your time as you are the
-  oracle. Based on your input, a new model will be trained in the background.
+  oracle. Based on your input, a new model will be trained, and you do not
+  want to confuse the prediction mode. For the model it may be better to
+  consult others, read the full-text (in case of reviewing abstracts of
+  scientific papers)
 
 Screening in Exploration mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-In Exploration mode, a blue bar is displayed on top of the record. The blue
-bar indicates whether the record is relevant or irrelevant.
+The Exploration mode is usefull for teaching purposes, because a blue bar is
+displayed on top of the record indicating whether the record has been labeled
+relevant or irrelevant in the dataset. You can make the same labeling
+decission without the need of being the oracle. 
 
 .. figure:: ../images/project_screening_exploration.png
    :alt: ASReview Screening
@@ -45,8 +69,9 @@ bar indicates whether the record is relevant or irrelevant.
 Autosave
 --------
 
-Your decisions are saved automatically into your ASReview project file. There
-is no need to press any buttons to save your work anywhere in ASReview LAB.
+Your decisions (and notes) are saved automatically into your ASReview project
+file. There is no need to press any buttons to save your work anywhere in
+ASReview LAB (in fact, there is not even a *save* button).
 
 Change decisions
 ----------------
@@ -57,17 +82,17 @@ interface of ASReview LAB offers two options to change your decision.
 Undo last decision
 ~~~~~~~~~~~~~~~~~~
 
-You can return to your previous decision during screening. You can disable
-this option in the Settings menu.
-
+You can return to your previous decision during screening. 
 
 1. :doc:`start`.
 2. Open or :doc:`project_create`.
 3. Label the record displayed in the screen as relevant or irrelevant.
-4. Click on **Undo** (At the bottom right)
-5. Click on **Keep (ir)relevant** or **Convert to (ir)relevant**
+4. Click on *Undo* (At the bottom right)
+5. Click on *Keep (ir)relevant* or *Convert to (ir)relevant*.
 6. Continue screening.
 
+You can disable
+this option in the Settings menu.
 
 Screening history
 ~~~~~~~~~~~~~~~~~
@@ -107,10 +132,6 @@ Keyboard shortcuts
 ASReview LAB supports the use of keyboard shortcuts during screening. The
 table below lists the available keyboard shortcuts.
 
-.. note::
-
-  Keyboard shortcuts are only available when the **Undo** feature has been
-  enabled in the Settings (bottom left).
 
 You can press a key (or a combination of keys) to label a record as relevant
 or irrelevant, or to return to the previous decision during screening.
@@ -125,6 +146,12 @@ By default, keyboard shortcuts are disabled.
 +-----------------------------+------------------------+
 | Return to previous decision | **u** or **Shift + u** |
 +-----------------------------+------------------------+
+
+
+.. note::
+
+  Keyboard shortcuts are only available when the **Undo** feature has been
+  enabled in the Settings (bottom left).
 
 
 Display

--- a/docs/source/simulation_overview.rst
+++ b/docs/source/simulation_overview.rst
@@ -5,9 +5,9 @@ What is a simulation?
 ---------------------
 
 A simulation involves mimicking the screening process with a certain model. As
-it is already known which records are labeled relevant, the software can
+it is already known which records are labeled as relevant, the software can
 automatically reenact the screening process as if a human was labeling the
-records.
+records in interaction with the Aclive Learning model.
 
 Why run a simulation?
 ---------------------
@@ -36,7 +36,7 @@ Datasets for simulation
 
 Simulations require :ref:`fully labeled datasets <data_labeled:fully labeled data>` (labels: ``0`` = irrelevant, ``1`` = relevant). Such a dataset can be the result of an earlier study. ASReview offers also fully labeled datasets via the `benchmark platform <https://github.com/asreview/systematic-review-datasets>`_. These datasets are available via the user interface in the *Data* step of the setup and in the command line with the prefix `benchmark:` (e.g. `benchmark:van_de_schoot_2017`).
 
-.. warning::
+.. tip::
 
     When you import your data, make sure to remove duplicates and to retrieve
     as many abstracts as possible (`See Importance-of-abstracts blog for help
@@ -47,11 +47,11 @@ Simulations require :ref:`fully labeled datasets <data_labeled:fully labeled dat
 Simulating with ASReview LAB
 ----------------------------
 
-ASReview LAB offers three different solutions to run simulations:
+ASReview LAB offers three different solutions to run simulations with the:
 
-- With the :ref:`webapp (the frontend) <simulation_overview:simulate with webapp>`
-- With the :doc:`command line interface <simulation_cli>`
-- With the :doc:`Python API <simulation_api_example>`
+- :ref:`Webapp (the frontend) <simulation_overview:simulate with webapp>`
+- :doc:`Command line interface <simulation_cli>`
+- :doc:`Python API <simulation_api_example>`
 
 Simulate with webapp
 --------------------
@@ -69,19 +69,16 @@ mode (see figure below).
 In the step *Data*, import a :ref:`fully labeled dataset <data_labeled:fully labeled data>`
 or use one of the benchmark datasets.
 
-.. figure:: ../images/setup_datasets_simulate_benchmark.png
-   :alt: ASReview LAB benchmark datasets
-
 Selecting prior knowledge is relatively easy. In case you know relevant
 records to start with, use the search function. In case you don't, use the
 *Random* option. Toggle the button "Relevant" on top to see some random
 irrelevant records. Label some relevant and some irrelevant records.
 
-.. figure:: ../images/setup_datasets_simulate_benchmark.png
-   :alt: ASReview LAB benchmark datasets
+.. figure:: ../images/setup_prior_knowledge_random_simulate.png
+   :alt: ASReview LAB Prior selection for simulation study
 
 The step *Warm up* is differs slightly from the Oracle and Exploration mode.
-This step start the simulation, after some seconds, it will return "Got it".
+This step starts the simulation, after some seconds, it will return "Got it".
 This means, the simulation runs further in the background. You are returned to
 the Analytics page.
 
@@ -100,9 +97,10 @@ Analyzing results
 
 After a simulation, the results are stored in the ASReview project file
 (extension `.asreview`). This file contains a large number of variables and
-logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. An easier solution would be to use one of the extensions. ASReview Insights is a useful example.
+logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. 
 
-The extension `ASReview Insights <https://github.com/asreview/asreview-insights>`_ offers useful tools, like plotting functions and metrics, to analyze results of a simulation.
+An easier solution would be to use the extension `ASReview Insights <https://github.com/asreview/asreview-insights>`_, which offers useful tools,
+like plotting functions and metrics, to analyze results of a simulation.
 
 Install ASReview Insights directly from PyPi:
 
@@ -111,10 +109,4 @@ Install ASReview Insights directly from PyPi:
 	pip install asreview-insights
 
 Detailed documention can found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>`_ page.
-
-The following command returns the recall at any moment during the simulation:
-
-.. code-block:: bash
-
-	asreview plot recall MY_SIMULATION.asreview
 

--- a/docs/source/simulation_overview.rst
+++ b/docs/source/simulation_overview.rst
@@ -1,6 +1,13 @@
 Overview
 ========
 
+ASReview LAB offers three different solutions to run simulations with the:
+
+- :ref:`Webapp (the frontend) <simulation_webapp:simulate via the webapp>`
+- :doc:`Command line interface <simulation_cli>`
+- :doc:`Python API <simulation_api_example>`
+
+
 What is a simulation?
 ---------------------
 
@@ -13,7 +20,7 @@ Why run a simulation?
 ---------------------
 
 Simulating with ASReview LAB has multiple purposes. First, the performance of
-one or multiple models can be measured by different metrics (see :ref:`Analyzing results <simulation_overview:Analyzing results>`). A convenient one
+one or multiple models can be measured by different metrics (see :ref:`Analyzing results <simulation_results:Analyzing results>`). A convenient one
 is that you can investigate the amount of work you could have saved by using
 active learning compared to your manual screening process.
 
@@ -44,69 +51,4 @@ Simulations require :ref:`fully labeled datasets <data_labeled:fully labeled dat
     benefit most from what :doc:`active learning <about>`
     has to offer.
 
-Simulating with ASReview LAB
-----------------------------
-
-ASReview LAB offers three different solutions to run simulations with the:
-
-- :ref:`Webapp (the frontend) <simulation_overview:simulate with webapp>`
-- :doc:`Command line interface <simulation_cli>`
-- :doc:`Python API <simulation_api_example>`
-
-Simulate with webapp
---------------------
-
-To run a simulation in the ASReview webapp, create a project as described in
-:doc:`project_create`. Most of the steps of the setup are identical or
-straightworward. In this section, some of the differences are highlighted.
-
-In the step on *Project Information*, select the "Simulation"
-mode (see figure below).
-
-.. figure:: ../images/setup_project_info_simulate.png
-   :alt: ASReview LAB simulate option
-
-In the step *Data*, import a :ref:`fully labeled dataset <data_labeled:fully labeled data>`
-or use one of the benchmark datasets.
-
-Selecting prior knowledge is relatively easy. In case you know relevant
-records to start with, use the search function. In case you don't, use the
-*Random* option. Toggle the button "Relevant" on top to see some random
-irrelevant records. Label some relevant and some irrelevant records.
-
-.. figure:: ../images/setup_prior_knowledge_random_simulate.png
-   :alt: ASReview LAB Prior selection for simulation study
-
-The step *Warm up* is differs slightly from the Oracle and Exploration mode.
-This step starts the simulation, after some seconds, it will return "Got it".
-This means, the simulation runs further in the background. You are returned to
-the Analytics page.
-
-.. figure:: ../images/setup_warmup_simulate_background.png
-   :alt: ASReview LAB simulation runs in background
-
-This page now has a refresh button on the top right. If the simulation is not
-finished yet, you can refresh the page or use the refresh button to follow the
-progress. After a while, the Elas mascotte on the left will hold a sign with
-"finished". Your simulation is now finished and you can study the results in
-the analytics page.
-
-
-Analyzing results
------------------
-
-After a simulation, the results are stored in the ASReview project file
-(extension `.asreview`). This file contains a large number of variables and
-logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. 
-
-An easier solution would be to use the extension `ASReview Insights <https://github.com/asreview/asreview-insights>`_, which offers useful tools,
-like plotting functions and metrics, to analyze results of a simulation.
-
-Install ASReview Insights directly from PyPi:
-
-.. code-block:: bash
-
-	pip install asreview-insights
-
-Detailed documention can found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>`_ page.
 

--- a/docs/source/simulation_results.rst
+++ b/docs/source/simulation_results.rst
@@ -1,0 +1,17 @@
+Analyzing results
+=================
+
+After a simulation, the results are stored in the ASReview project file
+(extension `.asreview`). This file contains a large number of variables and
+logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. 
+
+An easier solution would be to use the extension `ASReview Insights <https://github.com/asreview/asreview-insights>`_, which offers useful tools, like plotting functions and metrics, to analyze results of a simulation.
+
+Install ASReview Insights directly from PyPi:
+
+.. code-block:: bash
+
+	pip install asreview-insights
+
+Detailed documention can found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>`_ page.
+

--- a/docs/source/simulation_webapp.rst
+++ b/docs/source/simulation_webapp.rst
@@ -1,0 +1,37 @@
+Simulate via the webapp
+=======================
+
+To run a simulation in the ASReview webapp, create a project as described in
+:doc:`project_create`. Most of the steps of the setup are identical or
+straightworward. In this section, some of the differences are highlighted.
+
+In the step on *Project Information*, select the "Simulation"
+mode (see figure below).
+
+.. figure:: ../images/setup_project_info_simulate.png
+   :alt: ASReview LAB simulate option
+
+In the step *Data*, import a :ref:`fully labeled dataset <data_labeled:fully labeled data>`
+or use one of the benchmark datasets.
+
+Selecting prior knowledge is relatively easy. In case you know relevant
+records to start with, use the search function. In case you don't, use the
+*Random* option. Toggle the button "Relevant" on top to see some random
+irrelevant records. Label some relevant and some irrelevant records.
+
+.. figure:: ../images/setup_prior_knowledge_random_simulate.png
+   :alt: ASReview LAB Prior selection for simulation study
+
+The step *Warm up* is differs slightly from the Oracle and Exploration mode.
+This step starts the simulation, after some seconds, it will return "Got it".
+This means, the simulation runs further in the background. You are returned to
+the Analytics page.
+
+.. figure:: ../images/setup_warmup_simulate_background.png
+   :alt: ASReview LAB simulation runs in background
+
+This page now has a refresh button on the top right. If the simulation is not
+finished yet, you can refresh the page or use the refresh button to follow the
+progress. After a while, the Elas mascotte on the left will hold a sign with
+"finished". Your simulation is now finished and you can study the results in
+the analytics page.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,6 +1,9 @@
 Start ASReview LAB
 ==================
 
+Start via CLI
+-------------
+
 After you install ASReview LAB, start the program via the command line to
 start using it.
 
@@ -14,8 +17,8 @@ MacOS or Linux, you can open `Terminal` and run the command.
 The information in the sections below is more advanced and not needed for the
 majority of the ASReview LAB users.
 
-Command line arguments for starting ASReview LAB
-------------------------------------------------
+Command line arguments
+----------------------
 
 ASReview LAB provides a powerful command line interface for running ASReview
 LAB with other options or even run tasks like simulations. For a list of
@@ -78,14 +81,25 @@ available commands in ASReview LAB, type :code:`asreview lab --help`.
 	techniques, and query strategies). Use an integer between 0 and 2^32 - 1.
 
 
+Set environment variables
+-------------------------
+
 The following evironment variables are available.
 
 .. option:: ASREVIEW_PATH
 
-	The path to the folder with project. Default `~/.asreview`.
+	The path to the folder with project. Default `~/.asreview`, or search the location in Windows with 
 
-Set environment variables
-~~~~~~~~~~~~~~~~~~~~~~~~~
+  .. code:: bash
+
+  dir "\.asreview"/ s
+
+  In MacOS or Linux operating systems use
+
+  .. code:: bash
+
+  find / -type d -name ".asreview"
+
 
 How you set environment variables depends on the operating system and the
 environment in which you deploy ASReview LAB.
@@ -116,8 +130,8 @@ Or the following on Windows operating systems:
 	echo %ASREVIEW_PATH%
 
 
-Run ASReview LAB on localhost with a different port
----------------------------------------------------
+Run on a different port
+-----------------------
 
 By default, ASReview LAB runs on port 5000. If that port is already in use or
 if you want to specify a different port, start ASReview LAB with the following


### PR DESCRIPTION
This PR proposes to split the overview file about the simulation and adds a separate chapter on running the simulation in the webapp (no text is changed). Same for the results. 

This PR assumes https://github.com/asreview/asreview/pull/1170, only one commit is new:  https://github.com/asreview/asreview/pull/1172/commits/277c95ea846c6b20d995eb0dd13ec0603fb4a358.