### PR TITLE
Refactor prior knowledge screen in project setup

### DIFF
--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabeledRecordCard.js
@@ -184,7 +184,7 @@ const LabeledRecordCard = (props) => {
                     <Typography variant="h6">
                       {value.title ? value.title : "No title available"}
                     </Typography>
-                    {(value.doi || value.url) && (
+                    {!props.is_prior && (value.doi || value.url) && (
                       <Stack direction="row" spacing={1}>
                         {/* Show DOI if available */}
                         {value.doi && (

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddPriorKnowledge.js
@@ -1,7 +1,11 @@
 import * as React from "react";
+import { useQueryClient } from "react-query";
 import {
+  Box,
+  Button,
   Card,
   DialogContent,
+  DialogTitle,
   Fade,
   Link,
   List,
@@ -15,7 +19,8 @@ import {
 import { styled } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 
-import { InfoCard } from "../../SetupComponents";
+import { AppBarWithinDialog } from "../../../Components";
+import { InfoCard, SavingStateBox } from "../../SetupComponents";
 import { PriorLabeled, PriorRandom, PriorSearch } from "../DataComponents";
 import { useToggle } from "../../../hooks/useToggle";
 
@@ -65,11 +70,57 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 const AddPriorKnowledge = (props) => {
+  const queryClient = useQueryClient();
+
   const [search, toggleSearch] = useToggle();
   const [random, toggleRandom] = useToggle();
 
+  const isEnoughPriorKnowledge = () => {
+    return props.n_prior_exclusions > 4 && props.n_prior_inclusions > 4;
+  };
+
+  const isSavingPriorKnowledge = () => {
+    return (
+      queryClient.isMutating({ mutationKey: "mutatePriorKnowledge" }) ||
+      queryClient.isMutating({ mutationKey: "mutateLabeledPriorKnowledge" })
+    );
+  };
+
   return (
     <Root>
+      {props.mobileScreen && (
+        <AppBarWithinDialog
+          onClickStartIcon={props.toggleAddPriorKnowledge}
+          startIconIsClose={false}
+          title="Prior knowledge"
+        />
+      )}
+      {!props.mobileScreen && (
+        <Fade in>
+          <Stack className="dialog-header" direction="row">
+            <DialogTitle>Prior knowledge</DialogTitle>
+            <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+              {isEnoughPriorKnowledge() && (
+                <Typography variant="body2" sx={{ color: "secondary.main" }}>
+                  Enough prior knowledge. Click CLOSE to move on to the next
+                  step.
+                </Typography>
+              )}
+              {props.n_prior !== 0 && (
+                <SavingStateBox isSaving={isSavingPriorKnowledge()} />
+              )}
+              <Box className="dialog-header-button right">
+                <Button
+                  variant={!isEnoughPriorKnowledge() ? "text" : "contained"}
+                  onClick={props.toggleAddPriorKnowledge}
+                >
+                  Close
+                </Button>
+              </Box>
+            </Stack>
+          </Stack>
+        </Fade>
+      )}
       <Fade in>
         <DialogContent className={classes.form}>
           <Stack className={classes.layout}>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/EntryPointDataset.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/EntryPointDataset.js
@@ -97,10 +97,7 @@ const EntryPointDataset = (props) => {
         </Stack>
       </AccordionDetails>
       <AccordionActions>
-        <LoadingButton
-          loading={props.isAddingDataset}
-          onClick={handleAdd}
-        >
+        <LoadingButton loading={props.isAddingDataset} onClick={handleAdd}>
           Add
         </LoadingButton>
       </AccordionActions>

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
@@ -16,7 +16,6 @@ import {
   StepLabel,
   Stepper,
   Tooltip,
-  Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Close } from "@mui/icons-material";

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
@@ -280,13 +280,6 @@ const SetupDialog = (props) => {
     }
   );
 
-  const isEnoughPriorKnowledge = () => {
-    return (
-      labeledStats?.n_prior_exclusions > 4 &&
-      labeledStats?.n_prior_inclusions > 4
-    );
-  };
-
   /**
    * Step3: Model
    */
@@ -459,13 +452,6 @@ const SetupDialog = (props) => {
     return isInitiatingProject || isMutatingInfo || isMutatingModelConfig;
   };
 
-  const isSavingPriorKnowledge = () => {
-    return (
-      queryClient.isMutating({ mutationKey: "mutatePriorKnowledge" }) ||
-      queryClient.isMutating({ mutationKey: "mutateLabeledPriorKnowledge" })
-    );
-  };
-
   React.useEffect(() => {
     if (activeStep === 1 && (isInitError || isMutateInfoError)) {
       handleBack();
@@ -522,39 +508,6 @@ const SetupDialog = (props) => {
                   </Tooltip>
                 )}
               </Stack>
-            </Stack>
-          </Stack>
-        </Fade>
-      )}
-      {props.mobileScreen && addPriorKnowledge && (
-        <AppBarWithinDialog
-          onClickStartIcon={toggleAddPriorKnowledge}
-          startIconIsClose={false}
-          title="Prior knowledge"
-        />
-      )}
-      {!props.mobileScreen && addPriorKnowledge && (
-        <Fade in={addPriorKnowledge}>
-          <Stack className="dialog-header" direction="row">
-            <DialogTitle>Prior knowledge</DialogTitle>
-            <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-              {isEnoughPriorKnowledge() && (
-                <Typography variant="body2" sx={{ color: "secondary.main" }}>
-                  Enough prior knowledge. Click CLOSE to move on to the next
-                  step.
-                </Typography>
-              )}
-              {labeledStats?.n_prior !== 0 && (
-                <SavingStateBox isSaving={isSavingPriorKnowledge()} />
-              )}
-              <Box className="dialog-header-button right">
-                <Button
-                  variant={!isEnoughPriorKnowledge() ? "text" : "contained"}
-                  onClick={toggleAddPriorKnowledge}
-                >
-                  Close
-                </Button>
-              </Box>
             </Stack>
           </Stack>
         </Fade>
@@ -647,6 +600,7 @@ const SetupDialog = (props) => {
           n_prior={labeledStats?.n_prior}
           n_prior_exclusions={labeledStats?.n_prior_exclusions}
           n_prior_inclusions={labeledStats?.n_prior_inclusions}
+          toggleAddPriorKnowledge={toggleAddPriorKnowledge}
         />
       )}
       {!addDataset && !addPriorKnowledge && activeStep !== 3 && (


### PR DESCRIPTION
Changes proposed in this pull request:

- Move around single-use functions and components in the prior knowledge screen
- Hide DOI/URL of labeled records in the prior knowledge screen (unintentionally caused by #1176)
- Format code

*No visual changes*