### PR TITLE
Update documentation on deduplication

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -453,7 +453,8 @@ class ASReviewData():
     def duplicated(self, pid='doi'):
         """Return boolean Series denoting duplicate rows.
 
-        Based on persistent identifier (PID) and titles/abstracts.
+        Drop duplicates based on titles and abstracts and if available,
+        on a persistent identifier (PID) such as DOI.
 
         Arguments
         ---------
@@ -497,8 +498,8 @@ class ASReviewData():
     def drop_duplicates(self, pid='doi', inplace=False, reset_index=True):
         """Drop duplicate records.
 
-        Drop duplicates based on persistent
-        identifier (PID) and titles/abstracts.
+        Drop duplicates based on titles and abstracts and if available,
+        on a persistent identifier (PID) such as DOI.
 
         Arguments
         ---------

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -499,7 +499,7 @@ class ASReviewData():
         """Drop duplicate records.
 
         Drop duplicates based on titles and abstracts and if available,
-        on a persistent identifier (PID) such as DOI.
+        on a persistent identifier (PID) such the Digital Object Identifier (`DOI <https://www.doi.org/>`_).
 
         Arguments
         ---------

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -454,7 +454,7 @@ class ASReviewData():
         """Return boolean Series denoting duplicate rows.
 
         Identify duplicates based on titles and abstracts and if available,
-        on a persistent identifier (PID) such as DOI.
+        on a persistent identifier (PID) such as the Digital Object Identifier (`DOI <https://www.doi.org/>`_).
 
         Arguments
         ---------

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -454,7 +454,8 @@ class ASReviewData():
         """Return boolean Series denoting duplicate rows.
 
         Identify duplicates based on titles and abstracts and if available,
-        on a persistent identifier (PID) such as the Digital Object Identifier (`DOI <https://www.doi.org/>`_).
+        on a persistent identifier (PID) such as the Digital Object Identifier
+        (`DOI <https://www.doi.org/>`_).
 
         Arguments
         ---------
@@ -499,7 +500,8 @@ class ASReviewData():
         """Drop duplicate records.
 
         Drop duplicates based on titles and abstracts and if available,
-        on a persistent identifier (PID) such the Digital Object Identifier (`DOI <https://www.doi.org/>`_).
+        on a persistent identifier (PID) such the Digital Object Identifier
+        (`DOI <https://www.doi.org/>`_).
 
         Arguments
         ---------

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -453,7 +453,7 @@ class ASReviewData():
     def duplicated(self, pid='doi'):
         """Return boolean Series denoting duplicate rows.
 
-        Drop duplicates based on titles and abstracts and if available,
+        Identify duplicates based on titles and abstracts and if available,
         on a persistent identifier (PID) such as DOI.
 
         Arguments

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -100,7 +100,7 @@ on *Save* on the top right.
 .. note::
     After adding your dataset, ASReview LAB shows the approximate number of duplicates.
     This number is based on duplicate titles and abstracts and if available, on DOIs.
-    Removing duplicates can be done via the `ASReview Datatools <https://github.com/asreview/asreview-datatools>`_,
+    Removing duplicates can be done via `ASReview Datatools <https://github.com/asreview/asreview-datatools>`_,
     which also allows using a persistent identifier (PID) other than DOI for
     identifying and removing duplicates.
 

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -101,7 +101,7 @@ on *Save* on the top right.
     After adding your dataset, ASReview LAB prints the approximate number of duplicates.
     This number is based on duplicate titles and abstracts and if available, on DOIs.
     Removing duplicates can be done via the :doc:`API <reference>`, which also allows using a custom
-    persistent identifier (PID) other than DOI for identifying duplicates.
+    persistent identifier (PID) other than DOI for identifying and removing duplicates.
 
 
 Select Prior Knowledge

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -99,7 +99,7 @@ on *Save* on the top right.
 
 .. note::
     After adding your dataset, ASReview LAB shows the approximate number of duplicates.
-    This number is based on duplicate titles and abstracts and if available, on DOIs.
+    This number is based on duplicate titles and abstracts and if available, on the Digital Object Identifier (`DOI <https://www.doi.org/>`_).
     Removing duplicates can be done via `ASReview Datatools <https://github.com/asreview/asreview-datatools>`_,
     which also allows using a persistent identifier (PID) other than DOI for
     identifying and removing duplicates.

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -97,6 +97,12 @@ For Simulation and Exploration only. Select one of the
 :ref:`data_labeled:benchmark datasets`. Click
 on *Save* on the top right.
 
+.. note::
+    After adding your dataset, ASReview LAB prints the approximate number of duplicates.
+    This number is based on duplicate titles and abstracts and if available, on DOIs.
+    Removing duplicates can be done via the :doc:`API <reference>`, which also allows using a custom
+    persistent identifier (PID) other than DOI for identifying duplicates.
+
 
 Select Prior Knowledge
 ----------------------

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -98,10 +98,11 @@ For Simulation and Exploration only. Select one of the
 on *Save* on the top right.
 
 .. note::
-    After adding your dataset, ASReview LAB prints the approximate number of duplicates.
+    After adding your dataset, ASReview LAB shows the approximate number of duplicates.
     This number is based on duplicate titles and abstracts and if available, on DOIs.
-    Removing duplicates can be done via the :doc:`API <reference>`, which also allows using a custom
-    persistent identifier (PID) other than DOI for identifying and removing duplicates.
+    Removing duplicates can be done via the `ASReview Datatools <https://github.com/asreview/asreview-datatools>`_,
+    which also allows using a persistent identifier (PID) other than DOI for
+    identifying and removing duplicates.
 
 
 Select Prior Knowledge


### PR DESCRIPTION
update docstring on deduplication to explicitly state that a PID such as DOI will only be used if available