### PR TITLE
Update deduplication

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -486,7 +486,7 @@ class ASReviewData():
             .str.lower().str.strip().replace("", None)
 
         # save boolean series for duplicates based on titles/abstracts
-        s_dups_text = ((s.duplicated(keep=keep)) & (s.notnull()))
+        s_dups_text = ((s.duplicated()) & (s.notnull()))
 
         # final boolean series for all duplicates
         if s_dups_pid is not None:

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -480,13 +480,13 @@ class ASReviewData():
         else:
             s_dups_pid = None
 
-        # get the texts and clean them
+        # get the texts, clean them and replace empty strings with None
         s = pd.Series(self.texts) \
             .str.replace("[^A-Za-z0-9]", "", regex=True) \
-            .str.lower()
+            .str.lower().str.strip().replace("", None)
 
         # save boolean series for duplicates based on titles/abstracts
-        s_dups_text = s.duplicated()
+        s_dups_text = ((s.duplicated(keep=keep)) & (s.notnull()))
 
         # final boolean series for all duplicates
         if s_dups_pid is not None:

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -240,7 +240,7 @@ class ASReviewData():
             return self.title
 
         cur_texts = np.array([
-            self.title[i] + self.abstract[i] for i in range(len(self))
+            self.title[i] + " " + self.abstract[i] for i in range(len(self))
         ], dtype=object)
         return cur_texts
 

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -240,7 +240,7 @@ class ASReviewData():
             return self.title
 
         cur_texts = np.array([
-            self.title[i] + " " + self.abstract[i] for i in range(len(self))
+            self.title[i] + self.abstract[i] for i in range(len(self))
         ], dtype=object)
         return cur_texts
 

--- a/tests/demo_data/duplicate_records.csv
+++ b/tests/demo_data/duplicate_records.csv
@@ -1,0 +1,15 @@
+title;abstract;doi;some_column
+a;lorem;10.1;lorem
+a;lorem;;lorem
+b;lorem;10.3;lorem
+c;lorem;10.3;lorem
+d;lorem;;lorem
+e;lorem;;lorem
+f;lorem;   ;lorem
+g;lorem;   ;lorem
+h;lorem;;lorem
+i;lorem;;lorem
+;;10.4;lorem
+;;10.5;lorem
+   ;   ;10.6;lorem
+   ;   ;10.7;lorem

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -55,42 +55,42 @@ def test_datasets(data_name):
 
 
 def test_duplicate_count():
-    d = asreview.ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi
-a;lorem;10.1
-a;lorem;
-b;lorem;10.3
-c;lorem;10.3
-d;lorem;
-e;lorem;
-f;lorem;   
-g;lorem;   
-h;lorem;
-i;lorem;
-;;10.4
-;;10.5
-   ;   ;10.6
-   ;   ;10.7
+    d = asreview.ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi;some_column
+a;lorem;10.1;lorem
+a;lorem;;lorem
+b;lorem;10.3;lorem
+c;lorem;10.3;lorem
+d;lorem;;lorem
+e;lorem;;lorem
+f;lorem;   ;lorem
+g;lorem;   ;lorem
+h;lorem;;lorem
+i;lorem;;lorem
+;;10.4;lorem
+;;10.5;lorem
+   ;   ;10.6;lorem
+   ;   ;10.7;lorem
 """), sep=';'))
 
     assert n_duplicates(d) == 2
 
 
 def test_deduplication():
-    d_dups = ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi
-a;lorem;10.1
-a;lorem;
-b;lorem;10.3
-c;lorem;10.3
-d;lorem;
-e;lorem;
-f;lorem;   
-g;lorem;   
-h;lorem;
-i;lorem;
-;;10.4
-;;10.5
-   ;   ;10.6
-   ;   ;10.7
+    d_dups = ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi;some_column
+a;lorem;10.1;lorem
+a;lorem;;lorem
+b;lorem;10.3;lorem
+c;lorem;10.3;lorem
+d;lorem;;lorem
+e;lorem;;lorem
+f;lorem;   ;lorem
+g;lorem;   ;lorem
+h;lorem;;lorem
+i;lorem;;lorem
+;;10.4;lorem
+;;10.5;lorem
+   ;   ;10.6;lorem
+   ;   ;10.7;lorem
 """), sep=';'))
 
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,3 @@
-import io
 import urllib
 from pathlib import Path
 
@@ -77,8 +76,8 @@ def test_deduplication():
                          "lorem", "lorem", "lorem", "", "", "   ", "   "],
             "doi": ["10.1", "10.3", None, None, "   ", "   ", None,
                     None, "10.4", "10.5", "10.6", "10.7"],
-            "some_column": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem", "lorem"]
+            "some_column": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
+                            "lorem", "lorem", "lorem", "lorem", "lorem", "lorem"]
         })
     )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -54,13 +54,13 @@ def test_datasets(data_name):
 
 
 def test_duplicate_count():
-    d = ASReviewData.from_file(Path("demo_data", "duplicate_records.csv"))
+    d = ASReviewData.from_file(Path("tests", "demo_data", "duplicate_records.csv"))
 
     assert n_duplicates(d) == 2
 
 
 def test_deduplication():
-    d_dups = ASReviewData.from_file(Path("demo_data", "duplicate_records.csv"))
+    d_dups = ASReviewData.from_file(Path("tests", "demo_data", "duplicate_records.csv"))
 
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,
                              False, False, False, False, False, False, False])

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,3 +1,4 @@
+import io
 import urllib
 from pathlib import Path
 
@@ -54,31 +55,43 @@ def test_datasets(data_name):
 
 
 def test_duplicate_count():
-    d = asreview.ASReviewData(
-        pd.DataFrame({
-            "title": ["a", "a", "b", "c", "d", "e", "f",
-                      "g", "h", "i", "", "", "   ", "   "],
-            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem", "", "", "   ", "   "],
-            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ",
-                    None, None, "10.4", "10.5", "10.6", "10.7"]
-        })
-    )
+    d = asreview.ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi
+a;lorem;10.1
+a;lorem;
+b;lorem;10.3
+c;lorem;10.3
+d;lorem;
+e;lorem;
+f;lorem;   
+g;lorem;   
+h;lorem;
+i;lorem;
+;;10.4
+;;10.5
+   ;   ;10.6
+   ;   ;10.7
+"""), sep=';'))
 
     assert n_duplicates(d) == 2
 
 
 def test_deduplication():
-    d_dups = ASReviewData(
-        pd.DataFrame({
-            "title": ["a", "a", "b", "c", "d", "e", "f", "g",
-                      "h", "i", "", "", "   ", "   "],
-            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem", "", "", "   ", "   "],
-            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ",
-                    None, None, "10.4", "10.5", "10.6", "10.7"]
-        })
-    )
+    d_dups = ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi
+a;lorem;10.1
+a;lorem;
+b;lorem;10.3
+c;lorem;10.3
+d;lorem;
+e;lorem;
+f;lorem;   
+g;lorem;   
+h;lorem;
+i;lorem;
+;;10.4
+;;10.5
+;   ;10.6
+;   ;10.7
+"""), sep=';'))
 
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,
                              False, False, False, False, False, False, False])
@@ -89,10 +102,10 @@ def test_deduplication():
     d_nodups = ASReviewData(
         pd.DataFrame({
             "title": ["a", "b", "d", "e", "f", "g", "h", "i",
-                      "", "", "   ", "   "],
+                      None, None, "   ", "   "],
             "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "", "", "   ", "   "],
-            "doi": ["10.1", "10.3", "", "", "   ", "   ", None,
+                         "lorem", "lorem", "lorem", None, None, "   ", "   "],
+            "doi": ["10.1", "10.3", None, None, "   ", "   ", None,
                     None, "10.4", "10.5", "10.6", "10.7"]
         })
     )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -89,8 +89,8 @@ h;lorem;
 i;lorem;
 ;;10.4
 ;;10.5
-;   ;10.6
-;   ;10.7
+   ;   ;10.6
+   ;   ;10.7
 """), sep=';'))
 
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,42 +53,47 @@ def test_datasets(data_name):
     assert exists(data.filepath)
 
 
-def test_data_statistics():
+def test_duplicate_count():
     d = asreview.ASReviewData(
         pd.DataFrame({
-            "title": ["a", "a", "b", "c", "d", "e", "f", "g", "h", "i"],
-            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem", "lorem"],
-            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ", None, None]
+            "title": ["a", "a", "b", "c", "d", "e", "f",
+                      "g", "h", "i", "", "", "   ", "   "],
+            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
+                         "lorem", "lorem", "lorem", "lorem", "", "", "   ", "   "],
+            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ",
+                    None, None, "10.4", "10.5", "10.6", "10.7"]
         })
     )
 
     assert n_duplicates(d) == 2
 
 
-def test_data_base():
+def test_deduplication():
     d_dups = ASReviewData(
         pd.DataFrame({
             "title": ["a", "a", "b", "c", "d", "e", "f", "g",
-                      "h", "i"],
-            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem", "lorem"],
-            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ", None, None]
+                      "h", "i", "", "", "   ", "   "],
+            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
+                         "lorem", "lorem", "lorem", "lorem", "", "", "   ", "   "],
+            "doi": ["10.1", "", "10.3", "10.3", "", "", "   ", "   ",
+                    None, None, "10.4", "10.5", "10.6", "10.7"]
         })
     )
 
-    s_dups_bool = pd.Series([False, True, False, True, False,
-                             False, False, False, False, False])
+    s_dups_bool = pd.Series([False, True, False, True, False, False, False,
+                             False, False, False, False, False, False, False])
 
     # test whether .duplicated() provides correct boolean series for duplicates
     pd.testing.assert_series_equal(d_dups.duplicated(), s_dups_bool)
 
     d_nodups = ASReviewData(
         pd.DataFrame({
-            "title": ["a", "b", "d", "e", "f", "g", "h", "i"],
-            "abstract": ["lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", "lorem"],
-            "doi": ["10.1", "10.3", "", "", "   ", "   ", None, None]
+            "title": ["a", "b", "d", "e", "f", "g", "h", "i",
+                      "", "", "   ", "   "],
+            "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem",
+                         "lorem", "lorem", "lorem", "", "", "   ", "   "],
+            "doi": ["10.1", "10.3", "", "", "   ", "   ", None,
+                    None, "10.4", "10.5", "10.6", "10.7"]
         })
     )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -55,58 +55,30 @@ def test_datasets(data_name):
 
 
 def test_duplicate_count():
-    d = asreview.ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi;some_column
-a;lorem;10.1;lorem
-a;lorem;;lorem
-b;lorem;10.3;lorem
-c;lorem;10.3;lorem
-d;lorem;;lorem
-e;lorem;;lorem
-f;lorem;   ;lorem
-g;lorem;   ;lorem
-h;lorem;;lorem
-i;lorem;;lorem
-;;10.4;lorem
-;;10.5;lorem
-   ;   ;10.6;lorem
-   ;   ;10.7;lorem
-"""), sep=';'))
+    d = ASReviewData.from_file(Path("demo_data", "duplicate_records.csv"))
 
     assert n_duplicates(d) == 2
 
 
 def test_deduplication():
-    d_dups = ASReviewData(pd.read_csv(io.StringIO("""title;abstract;doi;some_column
-a;lorem;10.1;lorem
-a;lorem;;lorem
-b;lorem;10.3;lorem
-c;lorem;10.3;lorem
-d;lorem;;lorem
-e;lorem;;lorem
-f;lorem;   ;lorem
-g;lorem;   ;lorem
-h;lorem;;lorem
-i;lorem;;lorem
-;;10.4;lorem
-;;10.5;lorem
-   ;   ;10.6;lorem
-   ;   ;10.7;lorem
-"""), sep=';'))
+    d_dups = ASReviewData.from_file(Path("demo_data", "duplicate_records.csv"))
 
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,
                              False, False, False, False, False, False, False])
 
     # test whether .duplicated() provides correct boolean series for duplicates
-    pd.testing.assert_series_equal(d_dups.duplicated(), s_dups_bool)
+    pd.testing.assert_series_equal(d_dups.duplicated(), s_dups_bool, check_index=False)
 
     d_nodups = ASReviewData(
         pd.DataFrame({
             "title": ["a", "b", "d", "e", "f", "g", "h", "i",
-                      None, None, "   ", "   "],
+                      "", "", "   ", "   "],
             "abstract": ["lorem", "lorem", "lorem", "lorem", "lorem",
-                         "lorem", "lorem", "lorem", None, None, "   ", "   "],
+                         "lorem", "lorem", "lorem", "", "", "   ", "   "],
             "doi": ["10.1", "10.3", None, None, "   ", "   ", None,
-                    None, "10.4", "10.5", "10.6", "10.7"]
+                    None, "10.4", "10.5", "10.6", "10.7"],
+            "some_column": ["lorem", "lorem", "lorem", "lorem", "lorem", "lorem", "lorem",
+                         "lorem", "lorem", "lorem", "lorem", "lorem"]
         })
     )
 


### PR DESCRIPTION
We left this out at first with the assumption that data never has both title and abstract missing. However, after some testing this turns out to be quite a common problem. Take the following data:

| DOI    | Title | Abstract |
|--------|-------|----------|
| 10.100 |       |          |
| 10.200 |       |          |

Now it will still remove the second entry, this PR prevents that from happening.