### PR TITLE
Read RIS file from URL: performance boost and fix

### DIFF
--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -170,10 +170,3 @@ class RISReader():
             # Return the standardised dataframe
             return _standardize_dataframe(df)
 
-
-if __name__ == '__main__':
-    from asreview import ASReviewData
-    ris_url = "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/datasets" \
-              "/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris"
-    d = ASReviewData.from_file(ris_url)
-    print(d.df)

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -15,7 +15,6 @@
 import io
 import logging
 import re
-import tempfile
 
 import pandas
 import requests

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -19,6 +19,7 @@ import re
 import pandas
 import requests
 import rispy
+from urllib.request import urlopen
 
 from asreview.io.utils import _standardize_dataframe
 from asreview.utils import is_url
@@ -128,10 +129,9 @@ class RISReader:
             for encoding in encodings:
                 if is_url(fp):
                     try:
-                        url_input = requests.get(fp)
-                        bibliography_file = io.StringIO(
-                            url_input.content.decode(encoding)
-                        )
+                        url_input = urlopen(fp)
+                        bibliography_file = io.StringIO(url_input.read().decode(encoding))
+
                         entries = list(
                             rispy.load(bibliography_file, skip_unknown_tags=True)
                         )
@@ -169,3 +169,8 @@ class RISReader:
         else:
             # Return the standardised dataframe
             return _standardize_dataframe(df)
+
+if __name__ == '__main__':
+    from asreview import ASReviewData
+    d = ASReviewData.from_file("https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/datasets/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris")
+    print(d.df)

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -15,11 +15,10 @@
 import io
 import logging
 import re
+from urllib.request import urlopen
 
 import pandas
-import requests
 import rispy
-from urllib.request import urlopen
 
 from asreview.io.utils import _standardize_dataframe
 from asreview.utils import is_url
@@ -130,7 +129,9 @@ class RISReader:
                 if is_url(fp):
                     try:
                         url_input = urlopen(fp)
-                        bibliography_file = io.StringIO(url_input.read().decode(encoding))
+                        bibliography_file = io.StringIO(
+                            url_input.read().decode(encoding)
+                        )
 
                         entries = list(
                             rispy.load(bibliography_file, skip_unknown_tags=True)
@@ -169,8 +170,3 @@ class RISReader:
         else:
             # Return the standardised dataframe
             return _standardize_dataframe(df)
-
-if __name__ == '__main__':
-    from asreview import ASReviewData
-    d = ASReviewData.from_file("https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/datasets/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris")
-    print(d.df)

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -125,10 +125,11 @@ class RISReader:
         encodings = ["utf-8", "utf-8-sig", "ISO-8859-1"]
         entries = None
         if entries is None:
+            if is_url(fp):
+                url_input = urlopen(fp)
             for encoding in encodings:
                 if is_url(fp):
                     try:
-                        url_input = urlopen(fp)
                         bibliography_file = io.StringIO(
                             url_input.read().decode(encoding)
                         )
@@ -137,6 +138,7 @@ class RISReader:
                             rispy.load(bibliography_file, skip_unknown_tags=True)
                         )
                         bibliography_file.close()
+                        break
                     except UnicodeDecodeError:
                         pass
                 else:

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,8 @@ setup(
         'openpyxl',
         'gevent',
         'jsonschema',
-        'filelock'
+        'filelock',
+        'requests'
     ],
     extras_require=DEPS,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         'openpyxl',
         'gevent',
         'jsonschema',
-        'filelock',
+        'filelock'
     ],
     extras_require=DEPS,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ setup(
         'gevent',
         'jsonschema',
         'filelock',
-        'requests'
     ],
     extras_require=DEPS,
     entry_points={

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -16,7 +16,9 @@ from asreview import ASReviewData
                    ("generic_tab.tsv", 2, []), ("generic_labels.csv", 6, []),
                    ("pubmed_zotero.ris", 6, []), ("pubmed_endnote.txt", 6, []),
                    ("scopus.ris", 6, []), ("ovid_zotero.ris", 6, []),
-                   ("proquest.ris", 6, [])])
+                   ("proquest.ris", 6, []),
+                   ("https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/"
+                    "datasets/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris", 8, [])])
 def test_reader(test_file, n_lines, ignore_col):
     fp = Path("tests", "demo_data", test_file)
     as_data = ASReviewData.from_file(fp)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -17,8 +17,9 @@ from asreview import ASReviewData
                    ("pubmed_zotero.ris", 6, []), ("pubmed_endnote.txt", 6, []),
                    ("scopus.ris", 6, []), ("ovid_zotero.ris", 6, []),
                    ("proquest.ris", 6, []),
-                   ("https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/"
-                    "datasets/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris", 8, [])])
+                   ("https://raw.githubusercontent.com/asreview/systematic-"
+                    "review-datasets/master/datasets/van_de_Schoot_2017/raw/"
+                    "schoot-lgmm-ptsd-included-3.ris", 8, [])])
 def test_reader(test_file, n_lines, ignore_col):
     fp = Path("tests", "demo_data", test_file)
     as_data = ASReviewData.from_file(fp)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,28 +1,43 @@
 from pathlib import Path
 
-from pytest import mark
 import rispy
+from pytest import mark
 
 from asreview import ASReviewData
 
 
-@mark.parametrize("test_file,n_lines,ignore_col",
-                  [("_baseline.ris", 100, []),
-                   ("embase.csv", 6, ["keywords"]),
-                   ("embase_newpage.csv", 6, ["keywords"]),
-                   ("embase.ris", 6, []), ("generic.csv", 2, []),
-                   ("generic_semicolon.csv", 2, []),
-                   ("generic_tab.csv", 2, []), ("generic_tab.tab", 2, []),
-                   ("generic_tab.tsv", 2, []), ("generic_labels.csv", 6, []),
-                   ("pubmed_zotero.ris", 6, []), ("pubmed_endnote.txt", 6, []),
-                   ("scopus.ris", 6, []), ("ovid_zotero.ris", 6, []),
-                   ("proquest.ris", 6, [])])
+@mark.parametrize(
+    "test_file,n_lines,ignore_col",
+    [
+        ("_baseline.ris", 100, []),
+        ("embase.csv", 6, ["keywords"]),
+        ("embase_newpage.csv", 6, ["keywords"]),
+        ("embase.ris", 6, []),
+        ("generic.csv", 2, []),
+        ("generic_semicolon.csv", 2, []),
+        ("generic_tab.csv", 2, []),
+        ("generic_tab.tab", 2, []),
+        ("generic_tab.tsv", 2, []),
+        ("generic_labels.csv", 6, []),
+        ("pubmed_zotero.ris", 6, []),
+        ("pubmed_endnote.txt", 6, []),
+        ("scopus.ris", 6, []),
+        ("ovid_zotero.ris", 6, []),
+        ("proquest.ris", 6, []),
+        (
+            "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/datasets"
+            "/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris",
+            8,
+            [],
+        ),
+    ],
+)
 def test_reader(test_file, n_lines, ignore_col):
     fp = Path("tests", "demo_data", test_file)
     as_data = ASReviewData.from_file(fp)
     assert len(as_data) == n_lines
 
-    cols = ['title', 'abstract', 'authors', 'keywords']
+    cols = ["title", "abstract", "authors", "keywords"]
     cols = [col for col in cols if col not in ignore_col]
     # if labels is not None:
     #     cols.append('included')
@@ -78,8 +93,9 @@ def test_reader(test_file, n_lines, ignore_col):
         (29, 0),
         (30, -1),
         # No notes tag present
-        (31, -1)
-    ])
+        (31, -1),
+    ],
+)
 def test_asreview_labels_ris(record_i, included):
     fp = Path("tests", "demo_data", "baseline_tag-notes_labels.ris")
     as_data = ASReviewData.from_file(fp)
@@ -88,9 +104,8 @@ def test_asreview_labels_ris(record_i, included):
 
 def test_multiline_tags_ris():
 
-    fp = Path("tests", "demo_data",
-              "baseline_tag_and_field_definitions_lists.ris")
-    entries = rispy.load(fp, encoding='utf-8')
+    fp = Path("tests", "demo_data", "baseline_tag_and_field_definitions_lists.ris")
+    entries = rispy.load(fp, encoding="utf-8")
     assert entries[0]["notes"] == ["Notes 1", "Notes 2"]
 
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,43 +1,28 @@
 from pathlib import Path
 
-import rispy
 from pytest import mark
+import rispy
 
 from asreview import ASReviewData
 
 
-@mark.parametrize(
-    "test_file,n_lines,ignore_col",
-    [
-        ("_baseline.ris", 100, []),
-        ("embase.csv", 6, ["keywords"]),
-        ("embase_newpage.csv", 6, ["keywords"]),
-        ("embase.ris", 6, []),
-        ("generic.csv", 2, []),
-        ("generic_semicolon.csv", 2, []),
-        ("generic_tab.csv", 2, []),
-        ("generic_tab.tab", 2, []),
-        ("generic_tab.tsv", 2, []),
-        ("generic_labels.csv", 6, []),
-        ("pubmed_zotero.ris", 6, []),
-        ("pubmed_endnote.txt", 6, []),
-        ("scopus.ris", 6, []),
-        ("ovid_zotero.ris", 6, []),
-        ("proquest.ris", 6, []),
-        (
-            "https://raw.githubusercontent.com/asreview/systematic-review-datasets/master/datasets"
-            "/van_de_Schoot_2017/raw/schoot-lgmm-ptsd-included-3.ris",
-            8,
-            [],
-        ),
-    ],
-)
+@mark.parametrize("test_file,n_lines,ignore_col",
+                  [("_baseline.ris", 100, []),
+                   ("embase.csv", 6, ["keywords"]),
+                   ("embase_newpage.csv", 6, ["keywords"]),
+                   ("embase.ris", 6, []), ("generic.csv", 2, []),
+                   ("generic_semicolon.csv", 2, []),
+                   ("generic_tab.csv", 2, []), ("generic_tab.tab", 2, []),
+                   ("generic_tab.tsv", 2, []), ("generic_labels.csv", 6, []),
+                   ("pubmed_zotero.ris", 6, []), ("pubmed_endnote.txt", 6, []),
+                   ("scopus.ris", 6, []), ("ovid_zotero.ris", 6, []),
+                   ("proquest.ris", 6, [])])
 def test_reader(test_file, n_lines, ignore_col):
     fp = Path("tests", "demo_data", test_file)
     as_data = ASReviewData.from_file(fp)
     assert len(as_data) == n_lines
 
-    cols = ["title", "abstract", "authors", "keywords"]
+    cols = ['title', 'abstract', 'authors', 'keywords']
     cols = [col for col in cols if col not in ignore_col]
     # if labels is not None:
     #     cols.append('included')
@@ -93,9 +78,8 @@ def test_reader(test_file, n_lines, ignore_col):
         (29, 0),
         (30, -1),
         # No notes tag present
-        (31, -1),
-    ],
-)
+        (31, -1)
+    ])
 def test_asreview_labels_ris(record_i, included):
     fp = Path("tests", "demo_data", "baseline_tag-notes_labels.ris")
     as_data = ASReviewData.from_file(fp)
@@ -104,8 +88,9 @@ def test_asreview_labels_ris(record_i, included):
 
 def test_multiline_tags_ris():
 
-    fp = Path("tests", "demo_data", "baseline_tag_and_field_definitions_lists.ris")
-    entries = rispy.load(fp, encoding="utf-8")
+    fp = Path("tests", "demo_data",
+              "baseline_tag_and_field_definitions_lists.ris")
+    entries = rispy.load(fp, encoding='utf-8')
     assert entries[0]["notes"] == ["Notes 1", "Notes 2"]
 
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -4,6 +4,7 @@ from pytest import mark
 import rispy
 
 from asreview import ASReviewData
+from asreview.utils import is_url
 
 
 @mark.parametrize("test_file,n_lines,ignore_col",
@@ -21,7 +22,11 @@ from asreview import ASReviewData
                     "review-datasets/master/datasets/van_de_Schoot_2017/raw/"
                     "schoot-lgmm-ptsd-included-3.ris", 8, [])])
 def test_reader(test_file, n_lines, ignore_col):
-    fp = Path("tests", "demo_data", test_file)
+    if is_url(test_file):
+        fp = test_file
+    else:
+        fp = Path("tests", "demo_data", test_file)
+
     as_data = ASReviewData.from_file(fp)
     assert len(as_data) == n_lines
 


### PR DESCRIPTION
Changed 2 things:
- The code was missing a break statement, it should break if right decoding is found
- Always load URL once, instead of equivalent to the number of encodings that is tried (max 3)