### PR TITLE
Read RIS file from URL: performance boost and fix 

### DIFF
--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -125,10 +125,11 @@ class RISReader:
         encodings = ["utf-8", "utf-8-sig", "ISO-8859-1"]
         entries = None
         if entries is None:
+            if is_url(fp):
+                url_input = urlopen(fp)
             for encoding in encodings:
                 if is_url(fp):
                     try:
-                        url_input = urlopen(fp)
                         bibliography_file = io.StringIO(
                             url_input.read().decode(encoding)
                         )
@@ -137,6 +138,7 @@ class RISReader:
                             rispy.load(bibliography_file, skip_unknown_tags=True)
                         )
                         bibliography_file.close()
+                        break
                     except UnicodeDecodeError:
                         pass
                 else:


### PR DESCRIPTION
Changed 2 things:
- The code was missing a break statement, it should break if right decoding is found
- Always load URL once, instead of equivalent to the number of encodings that is tried (max 3)