### PR TITLE
URL extension checks

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -15,6 +15,7 @@
 import hashlib
 from pathlib import Path
 from urllib.parse import urlparse
+from urllib.request import urlopen
 
 import numpy as np
 import pandas as pd
@@ -179,6 +180,16 @@ class ASReviewData():
             if path.endswith(suffix):
                 if best_suffix is None or len(suffix) > len(best_suffix):
                     best_suffix = suffix
+
+        if best_suffix is None and is_url(fp):
+            try:
+                url_filename = urlopen(fp).info().get_filename()
+                for suffix, entry in entry_points.items():
+                    if url_filename.endswith(suffix):
+                        if best_suffix is None or len(suffix) > len(best_suffix):
+                            best_suffix = suffix
+            except:
+                pass
 
         if best_suffix is None:
             raise BadFileFormatError(f"Error importing file {fp}, no capabilities "

--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -182,14 +182,11 @@ class ASReviewData():
                     best_suffix = suffix
 
         if best_suffix is None and is_url(fp):
-            try:
-                url_filename = urlopen(fp).info().get_filename()
-                for suffix, entry in entry_points.items():
-                    if url_filename.endswith(suffix):
-                        if best_suffix is None or len(suffix) > len(best_suffix):
-                            best_suffix = suffix
-            except:
-                pass
+            url_filename = urlopen(fp).info().get_filename()
+            for suffix, entry in entry_points.items():
+                if url_filename.endswith(suffix):
+                    if best_suffix is None or len(suffix) > len(best_suffix):
+                        best_suffix = suffix
 
         if best_suffix is None:
             raise BadFileFormatError(f"Error importing file {fp}, no capabilities "

--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -125,10 +125,11 @@ class RISReader:
         encodings = ["utf-8", "utf-8-sig", "ISO-8859-1"]
         entries = None
         if entries is None:
+            if is_url(fp):
+                url_input = urlopen(fp)
             for encoding in encodings:
                 if is_url(fp):
                     try:
-                        url_input = urlopen(fp)
                         bibliography_file = io.StringIO(
                             url_input.read().decode(encoding)
                         )
@@ -137,6 +138,7 @@ class RISReader:
                             rispy.load(bibliography_file, skip_unknown_tags=True)
                         )
                         bibliography_file.close()
+                        break
                     except UnicodeDecodeError:
                         pass
                 else:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -18,9 +18,7 @@ from asreview.utils import is_url
                    ("pubmed_zotero.ris", 6, []), ("pubmed_endnote.txt", 6, []),
                    ("scopus.ris", 6, []), ("ovid_zotero.ris", 6, []),
                    ("proquest.ris", 6, []),
-                   ("https://raw.githubusercontent.com/asreview/systematic-"
-                    "review-datasets/master/datasets/van_de_Schoot_2017/raw/"
-                    "schoot-lgmm-ptsd-included-3.ris", 8, [])])
+                   ("https://osf.io/download/fg93a/", 38, [])])
 def test_reader(test_file, n_lines, ignore_col):
     if is_url(test_file):
         fp = test_file


### PR DESCRIPTION
Enable ASReviewData to handle URLs without file extensions as mentioned in #1233 

Also updates the test for URL without extension containing RIS dataset.