### PR TITLE
Choose deduplication strategies

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -486,6 +486,8 @@ class ASReviewData():
         if len(dedup) == 2:
             s_dups_2 = dict_dedup[dedup[1]]
             s_dups = s_dups | s_dups_2
+        if len(dedup) > 2:
+            raise ValueError("Too many deduplication methods passed with dedup parameter.")
 
         return s_dups
 
@@ -574,3 +576,4 @@ class ASReviewData():
             self.df = df
             return
         return df
+

--- a/asreview/data/statistics.py
+++ b/asreview/data/statistics.py
@@ -203,7 +203,7 @@ def n_keywords(data):
     return np.average([len(keywords) for keywords in data.keywords])
 
 
-def n_duplicates(data, pid='doi'):
+def n_duplicates(data, pid='doi', dedup='pt'):
     """Number of duplicates.
 
     Duplicate detection can be a very challenging task. Multiple
@@ -216,10 +216,14 @@ def n_duplicates(data, pid='doi'):
     pid: string
         Which persistent identifier (PID) to use for deduplication.
         Default is 'doi'.
+    dedup: string, default 'pt'
+        Which deduplication strategies to use:
+        'p' for persistent identifier
+        't' for text
 
     Return
     ------
     int:
         Number of duplicates
     """
-    return int(data.duplicated(pid).sum())
+    return int(data.duplicated(pid, dedup).sum())

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -57,16 +57,30 @@ def test_duplicate_count():
     d = ASReviewData.from_file(Path("tests", "demo_data", "duplicate_records.csv"))
 
     assert n_duplicates(d) == 2
+    assert n_duplicates(d, dedup='p') == 1
+    assert n_duplicates(d, dedup='t') == 1
 
 
 def test_deduplication():
     d_dups = ASReviewData.from_file(Path("tests", "demo_data", "duplicate_records.csv"))
 
+    # test boolean series returned by .duplicated() based on text
+    s_dups_bool = pd.Series([False, True, False, False, False, False, False,
+                             False, False, False, False, False, False, False])
+    pd.testing.assert_series_equal(d_dups.duplicated(dedup='t'), s_dups_bool,
+                                   check_names=False, check_index=False)
+
+    # test boolean series returned by .duplicated() based on pid
+    s_dups_bool = pd.Series([False, False, False, True, False, False, False,
+                             False, False, False, False, False, False, False])
+    pd.testing.assert_series_equal(d_dups.duplicated(dedup='p'), s_dups_bool,
+                                   check_names=False, check_index=False)
+
+    # test boolean series returned by .duplicated() based on text and pid
     s_dups_bool = pd.Series([False, True, False, True, False, False, False,
                              False, False, False, False, False, False, False])
-
-    # test whether .duplicated() provides correct boolean series for duplicates
-    pd.testing.assert_series_equal(d_dups.duplicated(), s_dups_bool, check_index=False)
+    pd.testing.assert_series_equal(d_dups.duplicated(dedup='pt'), s_dups_bool,
+                                   check_names=False, check_index=False)
 
     d_nodups = ASReviewData(
         pd.DataFrame({


### PR DESCRIPTION
This PR adds the possibility to specify what deduplication method can be used. By default deduplication is based on persistent identifiers and text. This PR adds possibility to choose only one of the two and makes it easier to implement extra options in the future.

Also added extra tests for this.