### PR TITLE
Update simulation_results.rst

### DIFF
--- a/docs/source/simulation_results.rst
+++ b/docs/source/simulation_results.rst
@@ -14,4 +14,4 @@ Install ASReview Insights directly from PyPi:
 
 	pip install asreview-insights
 
-Detailed documention on the extension can be found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>` page.
+Detailed documentation on the extension can be found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>`_ page.

--- a/docs/source/simulation_results.rst
+++ b/docs/source/simulation_results.rst
@@ -6,7 +6,7 @@ After a simulation, the results are stored in the ASReview project file
 (extension `.asreview`). This file contains a large number of variables and
 logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. 
 
-One readily available extension for analysing the results of a simulation is `ASReview Insights <https://github.com/asreview/asreview-insights>`_. This extension offers useful tools for plotting and extracting the statistical results of several performance metrics, such as the Work Saved over Sampling (WSS), the proportion of Relevant Record Found (RRF), the Extra Relevant records Found (ERF) and the Average Time to Discover (ATD).
+One readily available extension for analyzing the results of a simulation is `ASReview Insights <https://github.com/asreview/asreview-insights>`_. This extension offers valuable tools for plotting the recall and extracting the statistical results of several performance metrics, such as the Work Saved over Sampling (WSS), the proportion of Relevant Record Found (RRF), the Extra Relevant records Found (ERF), and the Average Time to Discover (ATD).
 
 Install ASReview Insights directly from PyPi:
 

--- a/docs/source/simulation_results.rst
+++ b/docs/source/simulation_results.rst
@@ -6,8 +6,7 @@ After a simulation, the results are stored in the ASReview project file
 (extension `.asreview`). This file contains a large number of variables and
 logs on the simulation. The data can be extracted from the project file via the API or with one of the available extensions. See :doc:`these examples on the Project API <example_api_asreview_file>` for more information about opening the project file. 
 
-An easier solution would be to use the extension `ASReview Insights <https://github.com/asreview/asreview-insights>`_, which offers useful tools,
-like plotting functions and metrics, to analyze results of a simulation.
+One readily available extension for analysing the results of a simulation is `ASReview Insights <https://github.com/asreview/asreview-insights>`_. This extension offers useful tools for plotting and extracting the statistical results of several performance metrics, such as the Work Saved over Sampling (WSS), the proportion of Relevant Record Found (RRF), the Extra Relevant records Found (ERF) and the Average Time to Discover (ATD).
 
 Install ASReview Insights directly from PyPi:
 
@@ -15,5 +14,4 @@ Install ASReview Insights directly from PyPi:
 
 	pip install asreview-insights
 
-Detailed documention can found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>`_ page.
-
+Detailed documention on the extension can be found on the `ASReview Insights GitHub <https://github.com/asreview/asreview-insights>` page.


### PR DESCRIPTION
I would suggest to add a mention of the performance metrics that the ASReview Insights package provides in the ReadtheDocs of the ASReview software, so that users are immediately pointed to the ASReview Insights page when looking for these metrics on the RTD page. 

Motivation: I was looking for the documentation on performance metrics on the RTD page and couldn't find it, because it's a separate package that's not part of the core ASReview code. Simply adding in the search terms in the "Analyzing Results" page on simulations via CLI will help direct users to the right location more easily, as they will turn up as results when using the search bar.