### PR TITLE
Add , "--model_seed" as argument for the seed selection

### DIFF
--- a/asreview/entry_points/base.py
+++ b/asreview/entry_points/base.py
@@ -93,7 +93,7 @@ def _base_parser(prog=None, description=None):
              "and parameter values."
     )
     parser.add_argument(
-        "--seed",
+        "--seed", "--model_seed",
         default=None,
         type=int,
         help="Seed for the model (classifiers, balance "


### PR DESCRIPTION
This PR adds `--model_seed` as an alternative to `--seed` as there also exists an `--init_seed` argument, making the original name of the seed ambiguous. `--seed` remains for backward compatibility.