### PR TITLE
Add active learning info

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -44,6 +44,12 @@ Intelligence, has shown the benefits of active learning, `reducing up to 95%
 <https://www.nature.com/articles/s42256-020-00287-7>`_ of the required
 screening time.
 
+.. raw:: html
+
+    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+        <iframe src="https://www.youtube.com/embed/k-a2SCq-LtA" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+    </div>
+
 
 Labeling workflow with ASReview
 -------------------------------

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -38,7 +38,12 @@ of screening large amounts of textual data is screening prioritization through
 `Active Learning <https://asreview.ai/blog/active-learning-explained/>`_: a constant
 interaction between a human who labels records and a machine learning model
 which selects the most likely relevant record based on a minimum training
-dataset. It allows the screening of large amounts of text in an intelligent
+dataset. The active learning cycle is repeated until the annotator has seen all
+relevant records. Thus, the machine learning model is responsible for ranking the
+records and the human provides the labels, this is called
+`Researcher-In-The-Loop (RITL) <https://asreview.ai/blog/active-learning-explained/>`_.
+
+It allows the screening of large amounts of text in an intelligent
 and time-efficient manner. ASReview LAB, published in Nature Machine
 Intelligence, has shown the benefits of active learning, `reducing up to 95%
 <https://www.nature.com/articles/s42256-020-00287-7>`_ of the required


### PR DESCRIPTION
For some users it is not clear how ASReview uses ranking instead of classification, see [this discussion](https://github.com/asreview/asreview/discussions/1257). So I tried to be a little more explicit about it in the readthedocs.

Also replace image in "What is ASReview LAB" section in readthedocs with the YouTube video "ASReview LAB explained".