### PR TITLE
Prepare SqlState for adding extra columns

### DIFF
--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -423,7 +423,9 @@ class SQLiteState(BaseState):
         cur = con.cursor()
         cur.execute("DELETE FROM record_table")
         cur.executemany(
-            """INSERT INTO record_table VALUES (?)""", record_sql_input)
+            "INSERT INTO record_table (record_id) VALUES (?)",
+            record_sql_input
+        )
         con.commit()
 
     def add_last_probabilities(self, probabilities):
@@ -450,8 +452,9 @@ class SQLiteState(BaseState):
 
         cur.execute("""DELETE FROM last_probabilities""")
         cur.executemany(
-            """INSERT INTO last_probabilities VALUES
-                                            (?)""", proba_sql_input)
+            "INSERT INTO last_probabilities (proba) VALUES (?)",
+            proba_sql_input
+        )
         con.commit()
 
     def add_last_ranking(self, ranked_record_ids, classifier, query_strategy,
@@ -500,8 +503,11 @@ class SQLiteState(BaseState):
         cur = con.cursor()
         cur.execute("DELETE FROM last_ranking")
         cur.executemany(
-            """INSERT INTO last_ranking VALUES
-                                    (?, ?, ?, ?, ?, ?, ?, ?)""", db_rows)
+            ("INSERT INTO last_ranking (record_id, ranking, classifier, "
+             "query_strategy, balance_strategy, feature_extraction, "
+             "training_set, time) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"),
+            db_rows
+        )
         con.commit()
         con.close()
 
@@ -609,7 +615,10 @@ class SQLiteState(BaseState):
             query_strategy: str, balance_strategy: str, feature_extraction: str,
              training_set: int, labeling_time: int, notes: str).
         """
-        query = "INSERT INTO results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        query = ("INSERT INTO results (record_id, label, classifier, "
+                 "query_strategy, balance_strategy, feature_extraction, "
+                 "training_set, labeling_time, notes) "
+                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
 
         con = self._connect_to_sql()
         cur = con.cursor()
@@ -638,8 +647,11 @@ class SQLiteState(BaseState):
                     "WHERE record_id = ?", (label, note, record_id))
 
         # Add the change to the decision changes table.
-        cur.execute("INSERT INTO decision_changes VALUES (?,?, ?)",
-                    (record_id, label, datetime.now()))
+        cur.execute(
+            ("INSERT INTO decision_changes (record_id, new_label, time) "
+             "VALUES (?, ?, ?)"),
+            (record_id, label, datetime.now())
+        )
 
         con.commit()
         con.close()
@@ -660,8 +672,11 @@ class SQLiteState(BaseState):
         cur.execute('DELETE FROM results WHERE record_id=?', (record_id, ))
 
         # Add the change to the decision changes table.
-        cur.execute("INSERT INTO decision_changes VALUES (?,?, ?)",
-                    (record_id, None, current_time))
+        cur.execute(
+            ("INSERT INTO decision_changes (record_id, new_label, time) "
+             "VALUES (?,?, ?)"),
+            (record_id, None, current_time)
+        )
         con.commit()
         con.close()
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -75,28 +75,25 @@ def test_init_project_folder(tmpdir):
     assert project.config['id'] == 'test'
 
 
-@pytest.mark.xfail(raises=ProjectExistsError,
-                   reason="Project {project_path} already exists.")
 def test_init_project_already_exists(tmpdir):
     project_path = Path(tmpdir, 'test.asreview')
     ASReviewProject.create(project_path)
-    ASReviewProject.create(project_path)
+    with pytest.raises(ProjectExistsError):
+        ASReviewProject.create(project_path)
 
 
-@pytest.mark.xfail(raises=StateNotFoundError,
-                   reason="Project folder does not exist")
 def test_invalid_project_folder():
-    with open_state('this_is_not_a_project') as state:  # noqa
-        pass
+    with pytest.raises(StateNotFoundError):
+        with open_state('this_is_not_a_project') as state:  # noqa
+            pass
 
 
-@pytest.mark.xfail(raises=StateNotFoundError,
-                   reason="State file does not exist")
 def test_state_not_found(tmpdir):
     project_path = Path(tmpdir, 'test.asreview')
     ASReviewProject.create(project_path)
-    with open_state(project_path) as state:  # noqa
-        pass
+    with pytest.raises(StateNotFoundError):
+        with open_state(project_path) as state:  # noqa
+            pass
 
 
 def test_read_basic_state():
@@ -109,11 +106,10 @@ def test_version_number_state():
         assert state.version[0] == "1"
 
 
-@pytest.mark.xfail(raises=OperationalError,
-                   reason="attempt to write a readonly database")
 def test_write_while_read_only_state():
     with open_state(TEST_STATE_FP, read_only=True) as state:
-        state.add_last_probabilities([1.0] * len(TEST_RECORD_TABLE))
+        with pytest.raises(OperationalError):
+            state.add_last_probabilities([1.0] * len(TEST_RECORD_TABLE))
 
 
 def test_print_state():
@@ -321,13 +317,10 @@ def test_get_last_probabilities():
         assert probabilities.to_list()[-10:] == TEST_LAST_PROBS
 
 
-@pytest.mark.xfail(
-    raises=ValueError,
-    reason="There are 851 probabilities in the"
-    " database, but 'probabilities' has length 3")
 def test_add_last_probabilities_fail():
     with open_state(TEST_STATE_FP) as state:
-        state.add_last_probabilities([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError):
+            state.add_last_probabilities([1.0, 2.0, 3.0])
 
 
 def test_add_last_probabilities(tmpdir):


### PR DESCRIPTION
This pull requests makes all 'INSERT' statements used in the SqlState explicit about which columns they insert into. 

Before, when data was inserted into all columns of a table, the column names were not explicitly set. This means that if a future version of the state class adds a column to the table, then the insert statement will have to change as well. Then it will no longer be backward compatible.

Now, all insert statements mention explicitly into which column they are inserting. If a column is added to a table, the insert statement will keep on working. A test has been added to verify that adding a column to the results table does not break anything.