### PR TITLE
Improve the handling of subcommands in the interface

### DIFF
--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -15,7 +15,6 @@
 """Command Line Interface (CLI) for ASReview project."""
 import argparse
 from itertools import groupby
-import logging
 import sys
 import pkg_resources
 from importlib import metadata
@@ -36,7 +35,11 @@ def main():
     # Get the available entry points.
     entry_points = get_entry_points("asreview.entry_points")
 
-    if len(sys.argv) > 1 and not sys.argv[1].startswith("-") and sys.argv[1] not in entry_points:
+    if (
+        len(sys.argv) > 1 and
+        not sys.argv[1].startswith("-") and
+        sys.argv[1] not in entry_points
+    ):
         raise ValueError(f"'{sys.argv[1]}' is not a valid subcommand.")
 
     elif len(sys.argv) > 1 and sys.argv[1] in entry_points:
@@ -49,34 +52,34 @@ def main():
         description_subcommands = ""
 
         for name, pkg_entry_points in groupby(
-                pkg_resources.iter_entry_points("asreview.entry_points"),
-                lambda entry: entry.dist
+            pkg_resources.iter_entry_points("asreview.entry_points"),
+            lambda entry: entry.dist,
         ):
-            description = metadata.metadata(name.project_name)['Summary']
+            description = metadata.metadata(name.project_name)["Summary"]
             description_subcommands += f"\n[{name}] - {description}\n"
 
             for entry in pkg_entry_points:
                 if entry.name not in INTERNAL_ENTRY_POINTS + DEPRECATED_ENTRY_POINTS:
-                    description_subcommands+= f"\t{entry.name}\n"
+                    description_subcommands += f"\t{entry.name}\n"
 
         parser = argparse.ArgumentParser(
             prog="asreview",
             formatter_class=argparse.RawTextHelpFormatter,
-            description=PROG_DESCRIPTION
+            description=PROG_DESCRIPTION,
         )
         parser.add_argument(
             "subcommand",
             nargs="?",
             default=None,
             help=f"The subcommand to launch. Available commands:\n\n"
-            f"{description_subcommands}"
+            f"{description_subcommands}",
         )
 
         parser.add_argument(
             "-V",
             "--version",
             action="version",
-            version='%(prog)s {version}'.format(version=__version__)
+            version="%(prog)s {version}".format(version=__version__),
         )
 
         args, _ = parser.parse_known_args()

--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -64,7 +64,7 @@ def main():
     entry_points = get_entry_points("asreview.entry_points")
 
     # Try to load the entry point if available.
-    if len(sys.argv) > 1 and sys.argv[1] not in entry_points:
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("-") and sys.argv[1] not in entry_points:
         raise ValueError(f"'{sys.argv[1]}' is not a valid subcommand.")
 
     elif len(sys.argv) > 1 and sys.argv[1] in entry_points:

--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -32,38 +32,10 @@ INTERNAL_ENTRY_POINTS = ["web_run_model"]
 DEPRECATED_ENTRY_POINTS = ["oracle"]
 
 
-def _output_available_entry_points():
-
-    s = ""
-
-    entry_points = pkg_resources.iter_entry_points("asreview.entry_points")
-
-    for name, pkg_entry_points in groupby(entry_points, lambda entry: entry.dist):
-
-        description = metadata.metadata(name.project_name)['Summary']
-
-        s += f"\n[{name}] - {description}\n"
-
-        for entry in pkg_entry_points:
-
-            # don't display the internal entry points
-            if entry.name in INTERNAL_ENTRY_POINTS:
-                continue
-
-            # don't display the deprecated entry points
-            if entry.name in DEPRECATED_ENTRY_POINTS:
-                continue
-
-            s+= f"\t{entry.name}\n"
-
-    return s
-
-
 def main():
     # Get the available entry points.
     entry_points = get_entry_points("asreview.entry_points")
 
-    # Try to load the entry point if available.
     if len(sys.argv) > 1 and not sys.argv[1].startswith("-") and sys.argv[1] not in entry_points:
         raise ValueError(f"'{sys.argv[1]}' is not a valid subcommand.")
 
@@ -74,8 +46,18 @@ def main():
 
     else:
 
-        # format the available subcommands
-        description_subcommands = _output_available_entry_points()
+        description_subcommands = ""
+
+        for name, pkg_entry_points in groupby(
+                pkg_resources.iter_entry_points("asreview.entry_points"),
+                lambda entry: entry.dist
+        ):
+            description = metadata.metadata(name.project_name)['Summary']
+            description_subcommands += f"\n[{name}] - {description}\n"
+
+            for entry in pkg_entry_points:
+                if entry.name not in INTERNAL_ENTRY_POINTS + DEPRECATED_ENTRY_POINTS:
+                    description_subcommands+= f"\t{entry.name}\n"
 
         parser = argparse.ArgumentParser(
             prog="asreview",
@@ -102,6 +84,5 @@ def main():
         parser.print_help()
 
 
-# execute main function
 if __name__ == "__main__":
     main()

--- a/asreview/entry_points/base.py
+++ b/asreview/entry_points/base.py
@@ -17,15 +17,9 @@ from abc import ABC
 from abc import abstractclassmethod
 from argparse import RawTextHelpFormatter
 
-from asreview import __version__
-
 
 class BaseEntryPoint(ABC):
     """Base class for defining entry points."""
-
-    # description = "Base Entry point."
-    extension_name = "asreview"
-    version = __version__
 
     @abstractclassmethod
     def execute(self, argv):

--- a/asreview/entry_points/base.py
+++ b/asreview/entry_points/base.py
@@ -23,7 +23,7 @@ from asreview import __version__
 class BaseEntryPoint(ABC):
     """Base class for defining entry points."""
 
-    description = "Base Entry point."
+    # description = "Base Entry point."
     extension_name = "asreview"
     version = __version__
 
@@ -38,22 +38,6 @@ class BaseEntryPoint(ABC):
             For example, if `asreview plot X` is executed, then argv == ['X'].
         """
         raise NotImplementedError
-
-    def format(self, entry_name="?"):
-        """Create a short formatted description of the entry point.
-
-        Arguments
-        ---------
-        entry_name: str
-            Name of the entry point. For example 'plot' in `asreview plot X`
-        """
-        description = self.description
-        version = getattr(self, "version", "?")
-        extension_name = getattr(self, "extension_name", "?")
-
-        display_name = f"{entry_name} [{extension_name}-{version}]"
-
-        return f"{display_name}\n    {description}"
 
 
 def _base_parser(prog=None, description=None):

--- a/asreview/entry_points/lab.py
+++ b/asreview/entry_points/lab.py
@@ -84,8 +84,6 @@ def _lab_parser(prog="lab"):
 class LABEntryPoint(BaseEntryPoint):
     """Entry point to start the ASReview LAB webapp."""
 
-    description = "The ASReview LAB webapp."
-
     def execute(self, argv):
 
         from asreview.webapp.start_flask import main

--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -91,8 +91,6 @@ def _set_log_verbosity(verbose):
 class SimulateEntryPoint(BaseEntryPoint):
     """Entry point for simulation with ASReview LAB."""
 
-    description = "Simulate the performance of ASReview."
-
     def execute(self, argv):  # noqa
 
         # parse arguments

--- a/asreview/entry_points/state_inspect.py
+++ b/asreview/entry_points/state_inspect.py
@@ -41,7 +41,6 @@ def _parse_state_inspect_args():
 
 class StateInspectEntryPoint(BaseEntryPoint):
     """Entry point to inspect ASReview LAB review progress."""
-    description = "Inspect ASReview LAB review progress."
 
     def execute(self, argv):
         parser = _parse_state_inspect_args()


### PR DESCRIPTION
Changes proposed in this pull request:

- entry points no longer loaded on help
- entry points fail with informative error if error is raised
- New format

*Add screenshots for proposed visual changes*

```
% asreview -h
usage: asreview [-h] [-V] [subcommand]

Automated Systematic Review (ASReview).

positional arguments:
  subcommand     The subcommand to launch. Available commands:
                 
                 
                 [asreview-wordcloud 1.0.1] - Wordcloud tools for the ASReview project
                 	wordcloud
                 
                 [asreview-insights 1.1] - Insight tools for the ASReview project
                 	metrics
                 	plot
                 
                 [asreview-makita 0.1.1+40.gad43ee9.dirty] - makita tools for the ASReview project
                 	makita
                 
                 [asreview-datatools 1.0+8.gfba362d] - Powerful command line tools for data handling in ASReview
                 	data
                 
                 [asreview 1.1+4.gd85cc1d.dirty] - ASReview LAB - A tool for AI-assisted systematic reviews
                 	algorithms
                 	lab
                 	simulate
                 	state-inspect

optional arguments:
  -h, --help     show this help message and exit
  -V, --version  show program's version number and exit
```

**Checklist**

- [x] Unit tests are added for new features and bug fixes
- [x] Documentation is added for new features
- [x] Title of the pull request is self-explaining

I think there is no documentation to be updated, let me know if you think otherwise. 
