### PR TITLE
Fix RIS export userwarning

### DIFF
--- a/asreview/io/ris_writer.py
+++ b/asreview/io/ris_writer.py
@@ -71,17 +71,12 @@ class RISWriter():
                 except Exception:
                     rec_copy[m] = []
 
-            # Relevant records
-            if "included" in rec_copy and rec_copy["included"] == 1:
-                rec_copy["notes"].append("ASReview_relevant")
-            # Irrelevant records
-            elif "included" in rec_copy and rec_copy["included"] == 0:
-                rec_copy["notes"].append("ASReview_irrelevant")
-            # Not seen records
-            elif "included" in rec_copy and rec_copy["included"] == -1:
-                rec_copy["notes"].append("ASReview_not_seen")
-            else:
-                rec_copy["notes"].append("ASReview_not_seen")
+            # Get label for record if specified, if not specified set to -1
+            included = rec_copy.pop("included", -1)
+
+            # Map labels to notes
+            dict_note = {-1: "ASReview_not_seen", 0: "ASReview_irrelevant", 1: "ASReview_relevant"}
+            rec_copy["notes"].append(dict_note[included])
 
             # Append the deepcopied and updated record to a new array
             records_new.append(rec_copy)

--- a/asreview/io/ris_writer.py
+++ b/asreview/io/ris_writer.py
@@ -75,7 +75,9 @@ class RISWriter():
             included = rec_copy.pop("included", -1)
 
             # Map labels to notes
-            dict_note = {-1: "ASReview_not_seen", 0: "ASReview_irrelevant", 1: "ASReview_relevant"}
+            dict_note = {-1: "ASReview_not_seen",
+                         0: "ASReview_irrelevant",
+                         1: "ASReview_relevant"}
             rec_copy["notes"].append(dict_note[included])
 
             # Append the deepcopied and updated record to a new array


### PR DESCRIPTION
In some cases, when exporting in RIS format, the following userwarning is shown:
```
C:\Python310\lib\site-packages\rispy\writer.py:114: UserWarning: label `included` not exported
  warnings.warn(UserWarning(f"label `{label}` not exported"))
```
The 'included' label is properly processed to the output file despite the warning.

To solve this, I propose popping the 'included' key from the dict. Performance remains equal (tested a couple of runs on the Brouwers_2019 dataset).