### PR TITLE
Update gevent dep min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'flask>=2.0',
         'flask_cors',
         'openpyxl',
-        'gevent>=20.4.0',
+        'gevent>=20',
         'jsonschema',
         'filelock',
         'tqdm'

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'flask>=2.0',
         'flask_cors',
         'openpyxl',
-        'gevent',
+        'gevent>=20.4.0',
         'jsonschema',
         'filelock',
         'tqdm'


### PR DESCRIPTION
As discovered in #1273, the minimal version of the `gevent` package dependency is 20.4.0.