### PR TITLE
Deprecate seed and config_file in LAB

### DIFF
--- a/asreview/entry_points/base.py
+++ b/asreview/entry_points/base.py
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 import argparse
+import warnings
 from abc import ABC
 from abc import abstractclassmethod
 from argparse import RawTextHelpFormatter
+
+
+class DeprecateAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        warnings.warn(f"Argument {self.option_strings} is deprecated and is ignored.")
+        delattr(namespace, self.dest)
 
 
 class BaseEntryPoint(ABC):
@@ -62,20 +69,5 @@ def _base_parser(prog=None, description=None):
         default=None,
         dest='embedding_fp',
         help="File path of embedding matrix. Required for LSTM models."
-    )
-    parser.add_argument(
-        "--config_file",
-        type=str,
-        default=None,
-        help="Configuration file with model settings"
-             "and parameter values."
-    )
-    parser.add_argument(
-        "--seed",
-        default=None,
-        type=int,
-        help="Seed for the model (classifiers, balance "
-             "strategies, feature extraction techniques, and query "
-             "strategies). Use an integer between 0 and 2^32 - 1."
     )
     return parser

--- a/asreview/entry_points/lab.py
+++ b/asreview/entry_points/lab.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from asreview.entry_points.base import BaseEntryPoint
+from asreview.entry_points.base import DeprecateAction
 from asreview.entry_points.base import _base_parser
 from asreview.webapp.run_model import main as main_run_model
 
@@ -78,6 +79,20 @@ def _lab_parser(prog="lab"):
         type=str,
         help="The full path to a private key file for usage with SSL/TLS.")
 
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        default=None,
+        help="Deprecated, see subcommand simulate.",
+        action=DeprecateAction
+    )
+    parser.add_argument(
+        "--seed",
+        default=None,
+        type=int,
+        help="Deprecated, see subcommand simulate.",
+        action=DeprecateAction
+    )
     return parser
 
 

--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -342,6 +342,20 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         help="Seed for setting the prior indices if the --prior_idx option is "
         "not used. If the option --prior_idx is used with one or more "
         "index, this option is ignored.")
+    parser.add_argument(
+        "--seed",
+        default=None,
+        type=int,
+        help="Seed for the model (classifiers, balance strategies, "
+             "feature extraction techniques, and query strategies)."
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        default=None,
+        help="Configuration file with model settings"
+             "and parameter values."
+    )
     parser.add_argument("--n_instances",
                         default=DEFAULT_N_INSTANCES,
                         type=int,

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,14 @@ parentdir_prefix = asreview-
 [flake8]
 max-line-length = 88
 ignore =
-	C901,  # too complex (fail on this in future)
-    E402,  # module level import not at top of file
-    W504,  # line break after binary operator
-    I201,  # Missing newline between import groups.
+	# too complex (fail on this in future)
+    C901
+    # module level import not at top of file
+    E402
+    # line break after binary operator
+    W504
+    # Missing newline between import groups.
+    I201
 exclude =
     doc/build/*.py,
     docs/source/conf.py


### PR DESCRIPTION
Changes proposed in this pull request:

- Deprecated `--seed` and `--config-file` in LAB
- Both were already not functional, no impact
-

*Add screenshots for proposed visual changes*


**Checklist**

- [ ] Unit tests are added for new features and bug fixes
- [x] Documentation is added for new features
- [x] Title of the pull request is self-explaining
