### PR TITLE
Move label to front of notes when exporting to RIS

### DIFF
--- a/asreview/io/ris_writer.py
+++ b/asreview/io/ris_writer.py
@@ -78,7 +78,7 @@ class RISWriter():
             dict_note = {-1: "ASReview_not_seen",
                          0: "ASReview_irrelevant",
                          1: "ASReview_relevant"}
-            rec_copy["notes"].append(dict_note[included])
+            rec_copy["notes"].insert(0, dict_note[included])
 
             # Append the deepcopied and updated record to a new array
             records_new.append(rec_copy)


### PR DESCRIPTION
This has benefits for software not able to display multiple notes at once.