### PR TITLE
1.0.x add manual deduplication

### DIFF
--- a/asreview/io/ris_reader.py
+++ b/asreview/io/ris_reader.py
@@ -55,7 +55,7 @@ class RISReader():
             return note_list
 
     def _label_parser(note_list):
-        """Converter function for manipulating the internal "included" and "notes" columns.
+        """Parse "included" and "notes" columns.
 
         Arguments
         ---------

--- a/asreview/utils.py
+++ b/asreview/utils.py
@@ -54,7 +54,7 @@ def _unsafe_dict_update(default_dict, override_dict):
                 try:
                     new_dict[key] = type(new_dict[key])(str_val)
                 except TypeError:
-                    raise(TypeError(f"Error at {key}"))
+                    raise TypeError(f"Error at {key}")
     return new_dict
 
 
@@ -97,7 +97,7 @@ def _safe_dict_update(default_dict, override_dict):
                 try:
                     new_dict[key] = type_val(str_val)
                 except TypeError:
-                    raise(TypeError(f"Error at {key}"))
+                    raise TypeError(f"Error at {key}")
     return new_dict
 
 

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -971,7 +971,7 @@ def api_start(project):  # noqa: F401
             ] + list(map(str, priors)) + [
                 # specify state file
                 "--state_file",
-                project.project_path,
+                str(project.project_path),
                 # specify write interval
                 "--write_interval", "100"
             ]
@@ -998,7 +998,7 @@ def api_start(project):  # noqa: F401
                 # train the model via cli
                 "web_run_model",
                 # specify project id
-                project.project_path,
+                str(project.project_path),
                 # output the error of the first model
                 "--output_error",
                 # mark the first run for status update
@@ -1451,7 +1451,7 @@ def api_classify_instance(project, doc_id):  # noqa: F401
         # retrain model
         subprocess.Popen([
             _get_executable(), "-m", "asreview", "web_run_model",
-            project.project_path
+            str(project.project_path)
         ])
 
     response = jsonify({'success': True})

--- a/asreview/webapp/package-lock.json
+++ b/asreview/webapp/package-lock.json
@@ -4080,9 +4080,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.8.tgz",
-      "integrity": "sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==",
+      "version": "17.0.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
+      "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -20373,9 +20373,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
-      "version": "18.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.8.tgz",
-      "integrity": "sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==",
+      "version": "17.0.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
+      "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/tests/test_asdata.py
+++ b/tests/test_asdata.py
@@ -12,7 +12,7 @@ from asreview import ASReviewData
 def test_bad_record_id():
     data_fp = Path("tests", "demo_data", "generic_bad_record_id.csv")
     as_data = ASReviewData.from_file(data_fp)
-    assert(len(np.unique(as_data.df.index.values)) == len(as_data))
+    assert len(np.unique(as_data.df.index.values)) == len(as_data)
 
 
 def test_record_id():


### PR DESCRIPTION
While screening large datasets, I manually identify some left-over duplicates in my dataset. I would like as a user to be able to mark these (or even check) manually as 'duplicate', such that the model is not trained twice on this records and that I get a clean set of results.