### PR TITLE
Add Endnote XML file reader

### DIFF
--- a/asreview/io/__init__.py
+++ b/asreview/io/__init__.py
@@ -21,5 +21,6 @@ from asreview.io.paper_record import PaperRecord
 from asreview.io.ris_reader import RISReader
 from asreview.io.ris_writer import RISWriter
 from asreview.io.tsv_writer import TSVWriter
+from asreview.io.xml_reader import EndnoteXMLReader
 from asreview.io.utils import list_readers
 from asreview.io.utils import list_writers

--- a/asreview/io/__init__.py
+++ b/asreview/io/__init__.py
@@ -21,6 +21,6 @@ from asreview.io.paper_record import PaperRecord
 from asreview.io.ris_reader import RISReader
 from asreview.io.ris_writer import RISWriter
 from asreview.io.tsv_writer import TSVWriter
-from asreview.io.xml_reader import EndnoteXMLReader
 from asreview.io.utils import list_readers
 from asreview.io.utils import list_writers
+from asreview.io.xml_reader import EndnoteXMLReader

--- a/asreview/io/xml_reader.py
+++ b/asreview/io/xml_reader.py
@@ -1,0 +1,118 @@
+import pandas as pd
+import xml.etree.ElementTree as ET
+
+from asreview.io.utils import _standardize_dataframe
+
+
+class EndnoteXMLReader:
+    """Endnote XML file reader."""
+
+    read_format = [".xml"]
+    write_format = [".csv", ".tsv", ".xlsx"]
+
+    @classmethod
+    def read_data(cls, fp):
+        """Import dataset from Endnote XML file.
+
+        Arguments
+        ---------
+        fp: str, pathlib.Path
+            File path to the XML file.
+
+        Returns
+        -------
+        list:
+            List with entries.
+        """
+        tree = ET.parse(fp)
+        root = tree.getroot()
+        dataset_list = []
+        for i, record in enumerate(root[0]):
+            try:
+                record_id = record.find("rec-number").text
+            except:
+                record_id = None
+            try:
+                ref_type = record.find("ref-type").attrib["name"]
+            except:
+                ref_type = None
+            try:
+                authors = ", ".join(
+                    author[0].text
+                    for author in record.find("contributors").find("authors")
+                )
+            except:
+                authors = None
+            try:
+                title = record.find("titles").find("title")[0].text
+            except:
+                title = None
+            try:
+                second_title = record.find("titles").find("secondary-title")[0].text
+            except:
+                second_title = None
+            try:
+                journal = record.find("periodical").find("full-title")[0].text
+            except:
+                journal = None
+            try:
+                doi = record.find("electronic-resource-num")[0].text
+            except:
+                doi = None
+            try:
+                pages = record.find("pages")[0].text
+            except:
+                pages = None
+            try:
+                volume = record.find("volume")[0].text
+            except:
+                volume = None
+            try:
+                number = record.find("number")[0].text
+            except:
+                number = None
+            try:
+                year = record.find("dates").find("year")[0].text
+            except:
+                year = None
+            try:
+                url = record.find("urls").find("related-urls").find("url")[0].text
+            except:
+                url = None
+            try:
+                isbn = record.find("isbn")[0].text
+            except:
+                isbn = None
+            try:
+                abstract = record.find("abstract")[0].text
+            except:
+                abstract = None
+            # try:
+            #     label = record.find("label")[0].text
+            # except:
+            #     label = None
+            dataset_list.append(
+                {
+                    "recordID": record_id,
+                    # record_id is overwritten by ASReview standardize_dataframe
+                    "ref_type": ref_type,
+                    "authors": authors,
+                    "title": title,
+                    "year": year,
+                    "journal": journal,
+                    "secondary_title": second_title,
+                    "doi": doi,
+                    "pages": pages,
+                    "volume": volume,
+                    "number": number,
+                    "abstract": abstract,
+                    "isbn": isbn,
+                    "url": url,
+                    # "label": label,
+                    # TODO: Handle conflict between Endnote label and ASReview label
+                }
+            )
+
+        df = pd.DataFrame(dataset_list)
+        df, _ = _standardize_dataframe(df)
+        return df

--- a/asreview/io/xml_reader.py
+++ b/asreview/io/xml_reader.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import xml.etree.ElementTree as ET
+
+import pandas as pd
 
 from asreview.io.utils import _standardize_dataframe
 
@@ -30,66 +31,66 @@ class EndnoteXMLReader:
         for i, record in enumerate(root[0]):
             try:
                 record_id = record.find("rec-number").text
-            except:
+            except (AttributeError, TypeError):
                 record_id = None
             try:
                 ref_type = record.find("ref-type").attrib["name"]
-            except:
+            except (AttributeError, TypeError):
                 ref_type = None
             try:
                 authors = ", ".join(
                     author[0].text
                     for author in record.find("contributors").find("authors")
                 )
-            except:
+            except (AttributeError, TypeError):
                 authors = None
             try:
                 title = record.find("titles").find("title")[0].text
-            except:
+            except (AttributeError, TypeError):
                 title = None
             try:
                 second_title = record.find("titles").find("secondary-title")[0].text
-            except:
+            except (AttributeError, TypeError):
                 second_title = None
             try:
                 journal = record.find("periodical").find("full-title")[0].text
-            except:
+            except (AttributeError, TypeError):
                 journal = None
             try:
                 doi = record.find("electronic-resource-num")[0].text
-            except:
+            except (AttributeError, TypeError):
                 doi = None
             try:
                 pages = record.find("pages")[0].text
-            except:
+            except (AttributeError, TypeError):
                 pages = None
             try:
                 volume = record.find("volume")[0].text
-            except:
+            except (AttributeError, TypeError):
                 volume = None
             try:
                 number = record.find("number")[0].text
-            except:
+            except (AttributeError, TypeError):
                 number = None
             try:
                 year = record.find("dates").find("year")[0].text
-            except:
+            except (AttributeError, TypeError):
                 year = None
             try:
                 url = record.find("urls").find("related-urls").find("url")[0].text
-            except:
+            except (AttributeError, TypeError):
                 url = None
             try:
                 isbn = record.find("isbn")[0].text
-            except:
+            except (AttributeError, TypeError):
                 isbn = None
             try:
                 abstract = record.find("abstract")[0].text
-            except:
+            except (AttributeError, TypeError):
                 abstract = None
             # try:
             #     label = record.find("label")[0].text
-            # except:
+            # except (AttributeError, TypeError):
             #     label = None
             dataset_list.append(
                 {

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
@@ -224,7 +224,7 @@ const AddDataset = (props) => {
             )}
             {datasetSource === "file" && (
               <ImportFromFile
-                acceptFormat=".txt,.tsv,.tab,.csv,.ris,.xlsx"
+                acceptFormat=".txt,.tsv,.tab,.csv,.ris,.xlsx,.xml"
                 addFileError={error}
                 file={file}
                 setFile={setFile}

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
             '.ris = asreview.io:RISReader',
             '.txt = asreview.io:RISReader',
             '.xlsx = asreview.io:ExcelReader',
+            '.xml = asreview.io:EndnoteXMLReader'
         ],
         'asreview.writers': [
             '.csv = asreview.io:CSVWriter',


### PR DESCRIPTION
Adds Endnote XML file reader which can be used to import XML files generated using Endnote reference manager. There are many open source systematic review datasets available in Endnote xml format, which can be added to the dataset repository