### PR TITLE
Refactor get project path

### DIFF
--- a/asreview/entry_points/simulate.py
+++ b/asreview/entry_points/simulate.py
@@ -382,16 +382,12 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         help="Configuration file with model settings"
              "and parameter values."
     )
-    parser.add_argument("--n_instances",
-                        default=DEFAULT_N_INSTANCES,
-                        type=int,
-                        help="Number of papers queried each query."
-                        f"Default {DEFAULT_N_INSTANCES}.")
     parser.add_argument(
         "--n_instances",
         default=DEFAULT_N_INSTANCES,
         type=int,
-        help="Number of papers queried each query." f"Default {DEFAULT_N_INSTANCES}.",
+        help="Number of papers queried each query."
+        f"Default {DEFAULT_N_INSTANCES}.",
     )
     parser.add_argument(
         "--n_queries",

--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -32,7 +32,7 @@ from asreview import __version__ as asreview_version
 from asreview.entry_points.lab import _lab_parser
 from asreview.project import ASReviewProject
 from asreview.project import get_project_path
-from asreview.project import list_asreview_projects
+from asreview.project import get_projects
 from asreview.utils import asreview_path
 from asreview.webapp import DB
 from asreview.webapp.api import auth
@@ -322,7 +322,7 @@ def main(argv):
     # of work, we need to access all sub-folders
     if args.clean_all_projects:
         print("Cleaning all project files.")
-        for project in list_asreview_projects():
+        for project in get_projects():
             project.clean_tmp_files()
         print("Done")
         return

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -300,7 +300,7 @@ Utils
 
    project.get_project_path
    project.project_from_id
-   project.list_asreview_projects
+   project.get_projects
    project.is_project
    project.is_v0_project
 


### PR DESCRIPTION
This pull request moves the use of the database models User and Project to webapp. I also think that it is no longer necessary to dynamically add the owner_id attribute to the ASReviewProject instances, since these are only used in webapp/api/projects.py. I think that tests not related to javascript now pass.