### PR TITLE
Add option to add files from DOI and improve data upload from URL UX

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -68,7 +68,7 @@ def load_data(name, *args, **kwargs):
 def _get_filename_from_url(url):
 
     if not is_url(url):
-        raise ValueError(f"{url} is not a valid URL.")
+        raise ValueError(f"'{url}' is not a valid URL.")
 
     if Path(urlparse(url).path).suffix:
         return Path(urlparse(url).path).name, url

--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -331,9 +331,21 @@ def api_upload_data_to_project(project):  # noqa: F401
         url = request.form.get('url')
         filename, url = _get_filename_from_url(url)
 
-        if not filename or not Path(filename).suffix:
-            # TODO use datahugger in the future
+        if bool(request.form.get('validate', None)):
+
+            if not filename or not Path(filename).suffix:
+                # TODO use datahugger in the future
+                print("DATAHUGGER")
+                import datahugger
+
+                dh = datahugger.get(url, output_folder=".", print_only=True)
+
+                return jsonify(files=dh.files), 201
+
             raise BadFileFormatError("Can't determine file format.")
+
+        else:
+            print("Continue without validation")
 
     if request.form.get('plugin', None) or request.form.get(
             'benchmark', None) or request.form.get('url', None):

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
@@ -153,7 +153,7 @@ const AddDataset = (props) => {
                 <FormControlLabel
                   value="url"
                   control={<Radio />}
-                  label="URL"
+                  label="URL or DOI"
                   onChange={handleDatasetSource}
                 />
                 {props.mode === projectModes.ORACLE && (
@@ -175,14 +175,35 @@ const AddDataset = (props) => {
                 )}
               </RadioGroup>
             </FormControl>
-            {(datasetSource === "file" || datasetSource === "url") && (
+            {datasetSource === "file" && (
               <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                ASReview LAB accepts RIS file format (<code>.ris</code>,{" "}
+                Add a dataset from your device. Supported formats are RIS file format (<code>.ris</code>,{" "}
                 <code>.txt</code>) and tabular datasets (<code>.csv</code>,{" "}
                 <code>.tab</code>, <code>.tsv</code>, <code>.xlsx</code>). The
                 dataset should contain a title and abstract for each record.{" "}
                 {props.mode !== projectModes.ORACLE
-                  ? "The dataset should also contain labels for each record. "
+                  ? "The dataset should contain labels for each record. "
+                  : ""}
+                To optimally benefit from the performance of the active learning
+                model, it is highly recommended to add a dataset without
+                duplicate records and complete records.{" "}
+                <Link
+                  underline="none"
+                  href="https://asreview.readthedocs.io/en/latest/intro/datasets.html"
+                  target="_blank"
+                >
+                  Learn more
+                </Link>
+              </Typography>
+            )}
+            {datasetSource === "url" && (
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                Add a dataset from a URL or DOI. Supported formats are RIS (<code>.ris</code>,{" "}
+                <code>.txt</code>) and tabular datasets (<code>.csv</code>,{" "}
+                <code>.tab</code>, <code>.tsv</code>, <code>.xlsx</code>). The
+                dataset should contain a title and abstract for each record.{" "}
+                {props.mode !== projectModes.ORACLE
+                  ? "The dataset should contain labels for each record. "
                   : ""}
                 To optimally benefit from the performance of the active learning
                 model, it is highly recommended to add a dataset without

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
@@ -175,33 +175,12 @@ const AddDataset = (props) => {
                 )}
               </RadioGroup>
             </FormControl>
-            {datasetSource === "file" && (
+            {(datasetSource === "file" || datasetSource === "url") && (
               <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                Add a dataset from your device. Supported formats are RIS file format (<code>.ris</code>,{" "}
-                <code>.txt</code>) and tabular datasets (<code>.csv</code>,{" "}
-                <code>.tab</code>, <code>.tsv</code>, <code>.xlsx</code>). The
-                dataset should contain a title and abstract for each record.{" "}
-                {props.mode !== projectModes.ORACLE
-                  ? "The dataset should contain labels for each record. "
-                  : ""}
-                To optimally benefit from the performance of the active learning
-                model, it is highly recommended to add a dataset without
-                duplicate records and complete records.{" "}
-                <Link
-                  underline="none"
-                  href="https://asreview.readthedocs.io/en/latest/intro/datasets.html"
-                  target="_blank"
-                >
-                  Learn more
-                </Link>
-              </Typography>
-            )}
-            {datasetSource === "url" && (
-              <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                Add a dataset from a URL or DOI. Supported formats are RIS (<code>.ris</code>,{" "}
-                <code>.txt</code>) and tabular datasets (<code>.csv</code>,{" "}
-                <code>.tab</code>, <code>.tsv</code>, <code>.xlsx</code>). The
-                dataset should contain a title and abstract for each record.{" "}
+                Supported formats are RIS (<code>.ris</code>, <code>.txt</code>)
+                and tabular datasets (<code>.csv</code>, <code>.tab</code>,{" "}
+                <code>.tsv</code>, <code>.xlsx</code>). The dataset should
+                contain a title and abstract for each record.{" "}
                 {props.mode !== projectModes.ORACLE
                   ? "The dataset should contain labels for each record. "
                   : ""}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/AddDataset.js
@@ -235,6 +235,7 @@ const AddDataset = (props) => {
             )}
             {datasetSource === "url" && (
               <DatasetFromURL
+                project_id={props.project_id}
                 addDatasetError={error}
                 handleSaveDataset={handleSaveDataset}
                 url={url}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -2,19 +2,17 @@ import React from "react";
 import { InputBase, Paper, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {
-  useQuery,
   useMutation,
-  useQueryClient,
 } from "react-query";
 
 
 import LoadingButton from "@mui/lab/LoadingButton";
 import InputLabel from '@mui/material/InputLabel';
-import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormControl from '@mui/material/FormControl';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
+import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined';
 
 import { InlineErrorHandler } from "../../../Components";
 import { ProjectAPI } from "../../../api/index.js";
@@ -41,82 +39,46 @@ const Root = styled("div")(({ theme }) => ({
 
 const DatasetFromURL = (props) => {
 
-  const queryClient = useQueryClient()
+  const [localURL, setLocalURL] = React.useState('');
 
-  const { error, isError, isLoading, mutate, reset, data } = useMutation(
-    ProjectAPI.mutateData,
-    // {
-    //   onSettled: () => {
-    //     // props.setDisableFetchInfo(false);
-    //     // queryClient.invalidateQueries("fetchInfo");
-    //   },
-    //   onSuccess: () => {
-
-    //     console.log("succes")
-    //     console.log(data);
-    //     // setListFiles(data);
-
-    //     // queryClient.invalidateQueries("fetchLabeledStats");
-    //     // props.toggleAddDataset();
-    //   },
-    // }
+  const { error, isError, isLoading, mutate, data } = useMutation(
+    ProjectAPI.mutateData, {
+      onSuccess: (data, variables, context) => {
+        if (data["files"] && data["files"].length === 1){
+          props.setURL(data["files"][0]["link"]);
+        }
+      },
+    }
   );
 
-  console.log(data && data["files"])
-
   const handleURL = (event) => {
-    console.log("hdgjkfd")
+    setLocalURL(event.target.value);
+  };
 
-    // if (props.isAddDatasetError) {
-    //   props.reset();
-    // }
-    props.setURL(event.target.value);
-    // setFile(null);
+  const addURL = (event) => {
 
+    // validate the url first
+    mutate({project_id: props.project_id, url: localURL, validate: true})
 
   };
 
   const addURLOnEnter = (event) => {
 
-    // if (file === null){
-    //   if(event.keyCode === 13){
-    //       // setListFiles([10, 20, 30])
-    //       setFile(10)
-    //   }
-    // } else {
-    //   props.handleSaveDataset();
-    // }
+    if(event.keyCode === 13){
+        addURL(event);
+    }
   };
 
-  const addURL = (event) => {
+  const addFile = (event) => {
 
-    // const query = useQuery("url", postValidateURL)
+    // upload dataset
+    props.handleSaveDataset();
 
-    console.log(props.url)
-    console.log(file)
-    console.log({project_id: props.project_id, url: props.url, validate: true})
-
-    // try to validate the url first
-    mutate({project_id: props.project_id, url: props.url, validate: true})
-
-    console.log("end mutate")
-    // if (file === null){
-
-    //     mutate({project_id: props.project_id, url: props.url, validate: 1})
-
-    //     setListFiles([10, 20, 30])
-    //     setFile(10)
-
-    // } else {
-    //   props.handleSaveDataset();
-    // }
   };
 
-  // const [listFiles, setListFiles] = React.useState(null);
-  const [file, setFile] = React.useState('');
-
-  const handleChange = (event: SelectChangeEvent) => {
-    setFile(event.target.value);
+  const handleFileChange = (event) => {
+    console.log("change")
+    props.setURL(event.target.value);
   };
 
   return (
@@ -132,43 +94,59 @@ const DatasetFromURL = (props) => {
         >
           <InputBase
             autoFocus
-            disabled={props.isAddingDataset}
+            disabled={props.isAddingDataset || isLoading}
             fullWidth
             id="url-dataset"
-            placeholder="Dataset URL"
-            value={props.url}
+            placeholder="Type a URL or DOI of the dataset"
+            value={localURL}
             onChange={handleURL}
             onKeyDown={addURLOnEnter}
             sx={{ ml: 1, flex: 1 }}
           />
+          <LoadingButton
+            disabled={!localURL || props.isAddingDataset}
+            loading={isLoading}
+            onClick={addURL}
+          >
+            <ArrowForwardOutlinedIcon/>
+          </LoadingButton>
         </Paper>
 
           {(data && data["files"]) && (
-          <FormControl sx={{ m: 1, minWidth: 120 }} disabled={isLoading}>
+          <FormControl sx={{ m: 1, minWidth: 120 }} disabled={props.isAddingDataset || data["files"].length === 1}>
             <InputLabel id="select-file-label">File</InputLabel>
             <Select
               labelId="select-file-label"
               id="select-file"
-              value={file}
+              value={props.url}
               label="File"
-              onChange={handleChange}
+              onChange={handleFileChange}
             >
               {data["files"].map((val,id)=>{
-                return <MenuItem key={val["name"]} value={val["link"]}>{val["name"]}</MenuItem>
+                return <MenuItem key={val["name"]} value={val["link"]} disabled={val["disabled"]}>{val["name"]}</MenuItem>
               })}
             </Select>
-            <FormHelperText>Select the file you want to use.</FormHelperText>
+            {(data && data["files"] && data["files"].length > 1) && (
+              <FormHelperText>Multiple files found. Select the file you want to use.</FormHelperText>
+            )}
           </FormControl>
           )}
 
+          {(data && data["files"]) && (
           <LoadingButton
             disabled={!props.url}
-            loading={isLoading}
-            onClick={addURL}
+            loading={props.isAddingDataset || isLoading}
+            onClick={addFile}
           >
             Add
           </LoadingButton>
+          )}
 
+        {isError && (
+          <InlineErrorHandler
+            message={error?.message + " Use a valid URL or DOI."}
+          />
+        )}
         {props.isAddDatasetError && (
           <InlineErrorHandler
             message={props.addDatasetError?.message + " Please try again."}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -6,7 +6,6 @@ import { useMutation } from "react-query";
 import LoadingButton from "@mui/lab/LoadingButton";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
-import FormHelperText from "@mui/material/FormHelperText";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import ArrowForwardOutlinedIcon from "@mui/icons-material/ArrowForwardOutlined";

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -1,9 +1,23 @@
 import React from "react";
 import { InputBase, Paper, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from "react-query";
+
+
 import LoadingButton from "@mui/lab/LoadingButton";
+import InputLabel from '@mui/material/InputLabel';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import FormHelperText from '@mui/material/FormHelperText';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 
 import { InlineErrorHandler } from "../../../Components";
+import { ProjectAPI } from "../../../api/index.js";
 
 const PREFIX = "DatasetFromURL";
 
@@ -26,21 +40,83 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 const DatasetFromURL = (props) => {
+
+  const queryClient = useQueryClient()
+
+  const { error, isError, isLoading, mutate, reset, data } = useMutation(
+    ProjectAPI.mutateData,
+    // {
+    //   onSettled: () => {
+    //     // props.setDisableFetchInfo(false);
+    //     // queryClient.invalidateQueries("fetchInfo");
+    //   },
+    //   onSuccess: () => {
+
+    //     console.log("succes")
+    //     console.log(data);
+    //     // setListFiles(data);
+
+    //     // queryClient.invalidateQueries("fetchLabeledStats");
+    //     // props.toggleAddDataset();
+    //   },
+    // }
+  );
+
+  console.log(data && data["files"])
+
   const handleURL = (event) => {
-    if (props.isAddDatasetError) {
-      props.reset();
-    }
+    console.log("hdgjkfd")
+
+    // if (props.isAddDatasetError) {
+    //   props.reset();
+    // }
     props.setURL(event.target.value);
+    // setFile(null);
+
+
   };
 
   const addURLOnEnter = (event) => {
-    if(event.keyCode === 13){
-       props.handleSaveDataset();
-    }
+
+    // if (file === null){
+    //   if(event.keyCode === 13){
+    //       // setListFiles([10, 20, 30])
+    //       setFile(10)
+    //   }
+    // } else {
+    //   props.handleSaveDataset();
+    // }
   };
 
-  const addURL = () => {
-    props.handleSaveDataset();
+  const addURL = (event) => {
+
+    // const query = useQuery("url", postValidateURL)
+
+    console.log(props.url)
+    console.log(file)
+    console.log({project_id: props.project_id, url: props.url, validate: true})
+
+    // try to validate the url first
+    mutate({project_id: props.project_id, url: props.url, validate: true})
+
+    console.log("end mutate")
+    // if (file === null){
+
+    //     mutate({project_id: props.project_id, url: props.url, validate: 1})
+
+    //     setListFiles([10, 20, 30])
+    //     setFile(10)
+
+    // } else {
+    //   props.handleSaveDataset();
+    // }
+  };
+
+  // const [listFiles, setListFiles] = React.useState(null);
+  const [file, setFile] = React.useState('');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setFile(event.target.value);
   };
 
   return (
@@ -65,14 +141,34 @@ const DatasetFromURL = (props) => {
             onKeyDown={addURLOnEnter}
             sx={{ ml: 1, flex: 1 }}
           />
+        </Paper>
+
+          {(data && data["files"]) && (
+          <FormControl sx={{ m: 1, minWidth: 120 }} disabled={isLoading}>
+            <InputLabel id="select-file-label">File</InputLabel>
+            <Select
+              labelId="select-file-label"
+              id="select-file"
+              value={file}
+              label="File"
+              onChange={handleChange}
+            >
+              {data["files"].map((val,id)=>{
+                return <MenuItem key={val["name"]} value={val["link"]}>{val["name"]}</MenuItem>
+              })}
+            </Select>
+            <FormHelperText>Select the file you want to use.</FormHelperText>
+          </FormControl>
+          )}
+
           <LoadingButton
             disabled={!props.url}
-            loading={props.isAddingDataset}
+            loading={isLoading}
             onClick={addURL}
           >
             Add
           </LoadingButton>
-        </Paper>
+
         {props.isAddDatasetError && (
           <InlineErrorHandler
             message={props.addDatasetError?.message + " Please try again."}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -110,12 +110,12 @@ const DatasetFromURL = (props) => {
             sx={{ m: 1, minWidth: 120 }}
             disabled={props.isAddingDataset || data["files"].length === 1}
           >
-            <InputLabel id="select-file-label">File</InputLabel>
+            <InputLabel id="select-file-label">Select dataset</InputLabel>
             <Select
               labelId="select-file-label"
               id="select-file"
               value={props.url}
-              label="File"
+              label="Select dataset"
               onChange={handleFileChange}
             >
               {data["files"].map((val, id) => {
@@ -130,11 +130,6 @@ const DatasetFromURL = (props) => {
                 );
               })}
             </Select>
-            {data && data["files"] && data["files"].length > 1 && (
-              <FormHelperText>
-                Multiple files found. Select the file you want to use.
-              </FormHelperText>
-            )}
           </FormControl>
         )}
 

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -1,18 +1,15 @@
 import React from "react";
 import { InputBase, Paper, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import {
-  useMutation,
-} from "react-query";
-
+import { useMutation } from "react-query";
 
 import LoadingButton from "@mui/lab/LoadingButton";
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import FormHelperText from '@mui/material/FormHelperText';
-import FormControl from '@mui/material/FormControl';
-import Select from '@mui/material/Select';
-import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined';
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormHelperText from "@mui/material/FormHelperText";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import ArrowForwardOutlinedIcon from "@mui/icons-material/ArrowForwardOutlined";
 
 import { InlineErrorHandler } from "../../../Components";
 import { ProjectAPI } from "../../../api/index.js";
@@ -38,13 +35,13 @@ const Root = styled("div")(({ theme }) => ({
 }));
 
 const DatasetFromURL = (props) => {
-
-  const [localURL, setLocalURL] = React.useState('');
+  const [localURL, setLocalURL] = React.useState("");
 
   const { error, isError, isLoading, mutate, data } = useMutation(
-    ProjectAPI.mutateData, {
+    ProjectAPI.mutateData,
+    {
       onSuccess: (data, variables, context) => {
-        if (data["files"] && data["files"].length === 1){
+        if (data["files"] && data["files"].length === 1) {
           props.setURL(data["files"][0]["link"]);
         }
       },
@@ -56,28 +53,22 @@ const DatasetFromURL = (props) => {
   };
 
   const addURL = (event) => {
-
     // validate the url first
-    mutate({project_id: props.project_id, url: localURL, validate: true})
-
+    mutate({ project_id: props.project_id, url: localURL, validate: true });
   };
 
   const addURLOnEnter = (event) => {
-
-    if(event.keyCode === 13){
-        addURL(event);
+    if (event.keyCode === 13) {
+      addURL(event);
     }
   };
 
   const addFile = (event) => {
-
     // upload dataset
     props.handleSaveDataset();
-
   };
 
   const handleFileChange = (event) => {
-    console.log("change")
     props.setURL(event.target.value);
   };
 
@@ -108,12 +99,15 @@ const DatasetFromURL = (props) => {
             loading={isLoading}
             onClick={addURL}
           >
-            <ArrowForwardOutlinedIcon/>
+            <ArrowForwardOutlinedIcon />
           </LoadingButton>
         </Paper>
 
-          {(data && data["files"]) && (
-          <FormControl sx={{ m: 1, minWidth: 120 }} disabled={props.isAddingDataset || data["files"].length === 1}>
+        {data && data["files"] && (
+          <FormControl
+            sx={{ m: 1, minWidth: 120 }}
+            disabled={props.isAddingDataset || data["files"].length === 1}
+          >
             <InputLabel id="select-file-label">File</InputLabel>
             <Select
               labelId="select-file-label"
@@ -122,17 +116,27 @@ const DatasetFromURL = (props) => {
               label="File"
               onChange={handleFileChange}
             >
-              {data["files"].map((val,id)=>{
-                return <MenuItem key={val["name"]} value={val["link"]} disabled={val["disabled"]}>{val["name"]}</MenuItem>
+              {data["files"].map((val, id) => {
+                return (
+                  <MenuItem
+                    key={val["name"]}
+                    value={val["link"]}
+                    disabled={val["disabled"]}
+                  >
+                    {val["name"]}
+                  </MenuItem>
+                );
               })}
             </Select>
-            {(data && data["files"] && data["files"].length > 1) && (
-              <FormHelperText>Multiple files found. Select the file you want to use.</FormHelperText>
+            {data && data["files"] && data["files"].length > 1 && (
+              <FormHelperText>
+                Multiple files found. Select the file you want to use.
+              </FormHelperText>
             )}
           </FormControl>
-          )}
+        )}
 
-          {(data && data["files"]) && (
+        {data && data["files"] && (
           <LoadingButton
             disabled={!props.url}
             loading={props.isAddingDataset || isLoading}
@@ -140,7 +144,7 @@ const DatasetFromURL = (props) => {
           >
             Add
           </LoadingButton>
-          )}
+        )}
 
         {isError && (
           <InlineErrorHandler

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataComponents/DatasetFromURL.js
@@ -12,6 +12,7 @@ import Select from "@mui/material/Select";
 import ArrowForwardOutlinedIcon from "@mui/icons-material/ArrowForwardOutlined";
 
 import { InlineErrorHandler } from "../../../Components";
+import { StyledLoadingButton } from "../../../StyledComponents/StyledButton";
 import { ProjectAPI } from "../../../api/index.js";
 
 const PREFIX = "DatasetFromURL";
@@ -94,13 +95,14 @@ const DatasetFromURL = (props) => {
             onKeyDown={addURLOnEnter}
             sx={{ ml: 1, flex: 1 }}
           />
-          <LoadingButton
+          <StyledLoadingButton
             disabled={!localURL || props.isAddingDataset}
             loading={isLoading}
             onClick={addURL}
+            sx={{ minWidth: "32px" }}
           >
             <ArrowForwardOutlinedIcon />
-          </LoadingButton>
+          </StyledLoadingButton>
         </Paper>
 
         {data && data["files"] && (
@@ -137,13 +139,15 @@ const DatasetFromURL = (props) => {
         )}
 
         {data && data["files"] && (
-          <LoadingButton
-            disabled={!props.url}
-            loading={props.isAddingDataset || isLoading}
-            onClick={addFile}
-          >
-            Add
-          </LoadingButton>
+          <Stack className={classes.root}>
+            <LoadingButton
+              disabled={!props.url}
+              loading={props.isAddingDataset || isLoading}
+              onClick={addFile}
+            >
+              Add
+            </LoadingButton>
+          </Stack>
         )}
 
         {isError && (

--- a/asreview/webapp/src/StyledComponents/StyledButton.js
+++ b/asreview/webapp/src/StyledComponents/StyledButton.js
@@ -1,7 +1,16 @@
 import { IconButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { LoadingButton } from "@mui/lab";
 
 export const StyledIconButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  [`:hover`]: {
+    backgroundColor: "transparent",
+    color: theme.palette.text.primary,
+  },
+}));
+
+export const StyledLoadingButton = styled(LoadingButton)(({ theme }) => ({
   color: theme.palette.text.secondary,
   [`:hover`]: {
     backgroundColor: "transparent",

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -126,11 +126,6 @@ class ProjectAPI {
   }
 
   static mutateData(variables) {
-
-    console.log("test")
-
-    console.log(variables.url)
-
     let body = new FormData();
     if (variables.file) {
       body.append("file", variables.file);

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -126,12 +126,20 @@ class ProjectAPI {
   }
 
   static mutateData(variables) {
+
+    console.log("test")
+
+    console.log(variables.url)
+
     let body = new FormData();
     if (variables.file) {
       body.append("file", variables.file);
     }
     if (variables.url) {
       body.append("url", variables.url);
+      if (variables.validate) {
+        body.append("validate", variables.validate);
+      }
     }
     if (variables.extension) {
       body.append("plugin", variables.extension);

--- a/docs/source/project_create.rst
+++ b/docs/source/project_create.rst
@@ -76,13 +76,17 @@ From File
 
 Drag and drop your file or select your file. Click on *Save* on the top right.
 
-From URL
-~~~~~~~~
+From URL or DOI
+~~~~~~~~~~~~~~~
 
-Use a link to a dataset on the Internet. For example, a link from this
-`dataset repository
-<https://github.com/asreview/systematic-review-datasets>`__. Click on *Save* on
-the top right.
+Insert a URL to a dataset. For example, use a URL from this
+`dataset repository <https://github.com/asreview/systematic-review-datasets>`__.
+It is also possible to provide a DOI to a data repository (supported for many
+data repositories via `Datahugger <https://github.com/J535D165/datahugger>`__).
+In a DOI points to multiple files, select the file you want to use (e.g.
+`10.17605/OSF.IO/WDZH5 <https://doi.org/10.17605/OSF.IO/WDZH5>`__).
+
+Click on *Add* to add the dataset.
 
 From Extension
 ~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,8 @@ setup(
         'gevent>=20',
         'jsonschema',
         'filelock',
-        'tqdm'
+        'tqdm',
+        'datahugger>=0.2'
     ],
     extras_require=DEPS,
     entry_points={


### PR DESCRIPTION
This PR introduces importing datasets from URL and DOI via [Datahugger](https://github.com/J535D165/datahugger). Datahugger is a new technology that makes it possible to import files from 200+ data repositories via the DOI. 

## **FROM URL**

From URL is still more or less identical in UI. The main difference is the 2 step approach. In this PR, you first have to look up the URL, and the filename is returned. Thereafter the dataset is uploaded by clicking ADD. This has additional benefits not directly clear to the user, but there is support for more URLs due to the initial validation and lookup. 

![localhost_3000_projects(iPad Mini)](https://user-images.githubusercontent.com/12981139/221805613-7f8c2dd9-d95d-4de3-b1d1-abe3903e7a6c.png)

![localhost_3000_projects(iPad Mini) (1)](https://user-images.githubusercontent.com/12981139/221805604-9e54b2d4-b914-44c5-9fe9-6de47dcdfbeb.png)

 ## **FROM DOI**

This is the cool part. The DOI can be used to build a highly reproducible workflow. First, you publish your search result and thereafter, you start labeling. Like preregistration of data. This makes it also very easy to simulate the performance of a dataset from an existing systematic review. See the example here with `Yu, Zhe, Kraft, Nicholas, & Menzies, Tim. (2017). Data sets for FASTREAD (v1.3) [Data set]. Zenodo.` https://doi.org/10.5281/zenodo.1162952. 

![localhost_3000_projects(iPad Mini) (2)](https://user-images.githubusercontent.com/12981139/221806951-b70d07c0-2322-41a1-b4f9-f25c0dc68f95.png)
![localhost_3000_projects(iPad Mini) (3)](https://user-images.githubusercontent.com/12981139/221806949-171755f7-6bda-48e1-ba84-7d452b2067d0.png)
![localhost_3000_projects(iPad Mini) (4)](https://user-images.githubusercontent.com/12981139/221806945-815d8472-85c7-436a-be31-84738bbcb4c6.png)
![localhost_3000_projects(iPad Mini) (5)](https://user-images.githubusercontent.com/12981139/221806941-ae4ac47d-6b33-46f6-8d74-9a676130f8ff.png)

## Remarks

@terrymyc, I really need a refactor of the AddDataset.js module to improve the workflows and build the OpenAlex pipeline. I think the react query calls should not be handled in AddDataset.js anymore, but only in the subcomponents. In this PR, I can hack myself around it, but it is needed for further improvements. We need to check your work before we can work on this. 
