### PR TITLE
Start auth documentation, hidden collabo item, conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,105 @@ LAB](https://asreview.readthedocs.io/en/latest/about.html).
 
 ## Authentication
 
+It is possible to run ASReview with authentication, enabling multiple users to run their
+projects in their own separate workspaces. Authentication requires the storage of user
+accounts and link these accounts to projects. Currently we are using a small SQLite 
+database (asreview.development.sqlite or asreview.production.sqlite) in the ASReview 
+folder to store that information.
 
+### Bare bones authentication
+
+Using authentication imposes more configuration. Let's start with running a bare bones
+authenticated version of the application from the CLI:
+```
+$ python3 -m asreview lab --enable-auth --secret-key=<secret key> --salt=<salt>
+```
+where `--enable-auth` forces the application to run in an authenticated mode, 
+`<secret key>` is a string that is used for encrypting cookies and `<salt>` is
+a string that is used to hash passwords.
+
+This bare bones application only allows an administrator to create user accounts by 
+editing the database without the use of the ASReview application! To facilitate this,
+one could use the User model that can be found in `/asreview/webapp/authentication/models.py`. Note that with this simple configuration it is not possible for a user to change forgotten passwords without the assistance of the administrator.
+
+### Full configuration
+
+To configure the authentication in more detail we need to create a JSON file
+that contains all authentication parameters. The keys in that JSON file will override any parameter that was passed in the CLI. Here's an example:
+```
+{
+    "DEBUG": true,
+    "AUTHENTICATION_ENABLED": true,
+    "SECRET_KEY": "<secret key>",
+    "SECURITY_PASSWORD_SALT": "<salt>",
+    "SESSION_COOKIE_SECURE": true,
+    "REMEMBER_COOKIE_SECURE": true,
+    "SESSION_COOKIE_SAMESITE": "Lax",
+    "SQLALCHEMY_TRACK_MODIFICATIONS": true,
+    "ALLOW_ACCOUNT_CREATION": true,
+    "EMAIL_VERIFICATION": true,
+    "EMAIL_CONFIG": {
+        "SERVER": "<smtp-server>",
+        "PORT": <smpt-server-port>,
+        "USERNAME": "<smtp-server-username>",
+        "PASSWORD": "<smtp-server-password>",
+        "USE_TLS": false,
+        "USE_SSL": true,
+        "REPLY_ADDRESS": "<preferred reply email address>"
+    },
+    "OAUTH": {
+        "GitHub": {
+            "AUTHORIZATION_URL": "https://github.com/login/oauth/authorize",
+            "TOKEN_URL": "https://github.com/login/oauth/access_token",
+            "CLIENT_ID": "<GitHub client ID>",
+            "CLIENT_SECRET": "<GitHub client secret>",
+            "SCOPE": ""
+        },
+        "Orcid": {
+            "AUTHORIZATION_URL": "https://sandbox.orcid.org/oauth/authorize",
+            "TOKEN_URL": "https://sandbox.orcid.org/oauth/token",
+            "CLIENT_ID": "<Orcid client ID>",
+            "CLIENT_SECRET": "<Orcid client secret>",
+            "SCOPE": "/authenticate"
+        },
+        "Google": {
+            "AUTHORIZATION_URL": "https://accounts.google.com/o/oauth2/auth",
+            "TOKEN_URL": "https://oauth2.googleapis.com/token",
+            "CLIENT_ID": "<Google client ID>",
+            "CLIENT_SECRET": "<Google client secret>",
+            "SCOPE": "profile email"
+        }
+    }
+}
+```
+Store the JSON file on the server and start the ASReview application from the CLI with the
+`--flask-configfile` parameter:
+```
+$ FLASK_DEBUG=1 python3 -m asreview lab --flask-configfile=<path-to-JSON-config-file>
+```
+A number of the keys in the JSON file are standard Flask parameters. The keys that are specific for authenticating ASReview 
+
+pare summarised below:
+*  AUTHENTICATION_ENABLED: if set to `true` the application will start with authentication enabled. If the SQLite database does not exist, one will be created during startup.
+* SECRET_KEY: the secret key is a string that is used to encrypt cookies and is mandatory if authentication is required.
+* SECURITY_PASSWORD_SALT: another string used to hash passwords, also mandatory if authentication is required.
+* ALLOW_ACCOUNT_CREATION: enables account creation by users, either by front- or backend.
+* EMAIL_VERIFICATION: used in conjunction with ALLOW_ACCOUNT_CREATION. If set to `true` the system sends a verification email after account creation. Only relevant if the account is __not__ created by OAuth. This parameter can be omitted if you don't want verification.
+* EMAIL_CONFIG: configuration of the SMTP email server that is used for email verification. It also allows users to retrieve a new password after forgetting it. Don't forget to enter the reply address (REPLY_ADDRESS) of your system emails. Omit this parameter if system emails for verification and password retrieval are unwanted.
+* OAUTH: an authenticated ASReview application may integrate with the OAuth functionality of Github, Orcid and Google. Provide the necessary OAuth login credentails (for [Github](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app), [Orcid](https://info.orcid.org/documentation/api-tutorials/api-tutorial-get-and-authenticated-orcid-id/) en [Google](https://support.google.com/cloud/answer/6158849?hl=en)). Please note that the AUTHORIZATION_URL and TOKEN_URL of the Orcid entry are sandbox-urls, and thus not to be used in production. Omit this parameter if OAuth is unwanted.
+
+### Converting an unauthenticated application in an authenticated one
+
+At the moment there is a very basic tool to convert your unauthenticated ASReview application into an authenticated one. The following steps sketch a possible approach for the conversion:
+
+1. In the ASReview folder (by default `~/.asreview`) you can find all projects that were created by users in the unauthenticated version. Every sub-folder contains a single project. Make sure you can link those projects to a certain user. In other words: make sure you know which project should be linked to which user.
+2. Start the application, preferably with using the config JSON file and setting the ALLOW_ACCOUNT_CREATION to `true`.
+3. Use the backend to create user accounts (done with a POST request to `/auth/signup`, see `/asreview/webapp/api/auth.py`). Make sure a full name is provided for every user account. Once done, one could restart the application with ALLOW_ACCOUNT_CREATION set to `False` if account creation by users is undesired.
+4. Run the `auth_conversion.py` (root folder) script and follow instructions. The script iterates over all project folders in the ASReview folder and asks which user account has to be associated with it. The script will establish the connection in the SQlite database and rename the project folders accordingly.
+
+TODO@Jonathan @Peter: I have verified this approach. It worked for me but
+obviously needs more testing. I don't think it has to grow into a bombproof solution, but should be used as a stepping stone for an admin
+with a little bit of Python knowledge who wants to upgrade to an authenticated version. Anyhow: give it a spin: create a couple of projects, rename the folders in the original project_ids and remove from the projects folder. The script should restore all information.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ that contains all authentication parameters. The keys in that JSON file will ove
 Store the JSON file on the server and start the ASReview application from the CLI with the
 `--flask-configfile` parameter:
 ```
-$ FLASK_DEBUG=1 python3 -m asreview lab --flask-configfile=<path-to-JSON-config-file>
+$ python3 -m asreview lab --flask-configfile=<path-to-JSON-config-file>
 ```
 A number of the keys in the JSON file are standard Flask parameters. The keys that are specific for authenticating ASReview 
 

--- a/asreview/entry_points/lab.py
+++ b/asreview/entry_points/lab.py
@@ -61,14 +61,30 @@ def _lab_parser(prog="lab"):
         "--enable-auth",
         dest="enable_authentication",
         action="store_true",
-        help="Use authentication",
+        help="Enable authentication.",
+    )
+
+    parser.add_argument(
+        "--secret-key",
+        default=None,
+        type=str,
+        help="Secret key for authentication.",
+    )
+
+    parser.add_argument(
+        "--salt",
+        default=None,
+        type=str,
+        help="When using authentication, a salt code is needed"
+        "for hasing passwords.",
     )
 
     parser.add_argument(
         "--flask-configfile",
         default="",
         type=str,
-        help="The full path to a JSON file " + "for Flask parameters.",
+        help="Full path to a JSON file containing Flask parameters"
+        "for authentication.",
     )
 
     parser.add_argument(
@@ -108,6 +124,7 @@ def _lab_parser(prog="lab"):
         help="Deprecated, see subcommand simulate.",
         action=DeprecateAction
     )
+
     parser.add_argument(
         "--seed",
         default=None,

--- a/asreview/project.py
+++ b/asreview/project.py
@@ -86,10 +86,10 @@ def project_from_id(user):
         @wraps(f)
         def decorated_function(project_id, *args, **kwargs):
 
-            # we need a user id, but if the app is not authenticated we 
+            # we need a user id, but if the app is not authenticated we
             # are dealing with an AnonymousUserMixin that doesn't have an
             # id. This try/except block makes sure this function executes
-            # without having knowledge about the User model and the 
+            # without having knowledge about the User model and the
             # AnonymousUserMixin Object from Flask_Login.
             try:
                 # authenticated: identifier is concatenated
@@ -321,7 +321,9 @@ class ASReviewProject:
                         return config
 
             except FileNotFoundError:
-               raise ProjectNotFoundError(f"Project '{self.project_path}' not found")
+                raise ProjectNotFoundError(
+                    f"Project '{self.project_path}' not found"
+                )
 
     @config.setter
     def config(self, config):

--- a/asreview/project.py
+++ b/asreview/project.py
@@ -27,17 +27,17 @@ from uuid import NAMESPACE_URL
 from uuid import uuid4
 from uuid import uuid5
 
+from filelock import FileLock
 import jsonschema
 import numpy as np
-from filelock import FileLock
 from scipy.sparse import csr_matrix
 from scipy.sparse import load_npz
 from scipy.sparse import save_npz
 
 from asreview._version import get_versions
 from asreview.config import LABEL_NA
-from asreview.config import PROJECT_MODE_SIMULATE
 from asreview.config import PROJECT_MODES
+from asreview.config import PROJECT_MODE_SIMULATE
 from asreview.config import SCHEMA
 from asreview.state.errors import StateNotFoundError
 from asreview.state.sqlstate import SQLiteState

--- a/asreview/project.py
+++ b/asreview/project.py
@@ -27,17 +27,17 @@ from uuid import NAMESPACE_URL
 from uuid import uuid4
 from uuid import uuid5
 
-from filelock import FileLock
 import jsonschema
 import numpy as np
+from filelock import FileLock
 from scipy.sparse import csr_matrix
 from scipy.sparse import load_npz
 from scipy.sparse import save_npz
 
 from asreview._version import get_versions
 from asreview.config import LABEL_NA
-from asreview.config import PROJECT_MODES
 from asreview.config import PROJECT_MODE_SIMULATE
+from asreview.config import PROJECT_MODES
 from asreview.config import SCHEMA
 from asreview.state.errors import StateNotFoundError
 from asreview.state.sqlstate import SQLiteState

--- a/asreview/project.py
+++ b/asreview/project.py
@@ -123,7 +123,9 @@ def get_projects(project_paths=None):
         Projects at the given project paths.
     """
     if project_paths is None:
-        project_paths = asreview_path().iterdir()
+        project_paths = [
+            path for path in asreview_path().iterdir() if path.is_dir()
+        ]
 
     return [ASReviewProject(project_path) for project_path in project_paths]
 

--- a/asreview/webapp/api/auth.py
+++ b/asreview/webapp/api/auth.py
@@ -14,8 +14,6 @@
 
 
 import datetime as dt
-import smtplib
-import ssl
 from pathlib import Path
 
 from flask import Blueprint

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -158,7 +158,9 @@ def api_get_projects():  # noqa: F401
         # authenticated with User accounts
         user_db_projects = list(current_user.projects) + \
             list(current_user.involved_in)
-        project_paths = [project.folder for project in user_db_projects]
+        project_paths = [
+            asreview_path() / project.folder for project in user_db_projects
+        ]
         owner_ids = [project.owner_id for project in user_db_projects]
         projects = get_projects(project_paths)
     else:
@@ -207,7 +209,7 @@ def api_get_projects_stats():  # noqa: F401
         user_db_projects = list(current_user.projects) + \
             list(current_user.involved_in)
         project_paths = [
-            Path(asreview_path(), project.folder) for project in user_db_projects
+            asreview_path() / project.folder for project in user_db_projects
         ]
     else:
         # force get_projects to list the .asreview folder

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -166,7 +166,7 @@ def api_get_projects():  # noqa: F401
     else:
         # force get_projects to list the .asreview folder
         projects = get_projects(None)
-        owner_ids = [current_user.id for p in projects]
+        owner_ids = [None for p in projects]
 
     for project, owner_id in zip(projects, owner_ids):
         try:
@@ -177,8 +177,9 @@ def api_get_projects():  # noqa: F401
                 project_config = upgrade_project_config(project_config)
                 project_config["projectNeedsUpgrade"] = True
 
-            # add ownership information
-            project_config["owner_id"] = owner_id
+            # add ownership information if authentication is enabled
+            if app_is_authenticated(current_app):
+                project_config["owner_id"] = owner_id
 
             logging.info("Project found: {}".format(project_config["id"]))
             project_info.append(project_config)

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -21,8 +21,6 @@ import urllib.parse
 from pathlib import Path
 from urllib.request import urlretrieve
 
-import numpy as np
-import pandas as pd
 from flask import Blueprint
 from flask import abort
 from flask import current_app
@@ -31,6 +29,8 @@ from flask import request
 from flask import send_file
 from flask_cors import CORS
 from flask_login import current_user
+import numpy as np
+import pandas as pd
 from sqlalchemy import and_
 from werkzeug.exceptions import InternalServerError
 from werkzeug.utils import secure_filename

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -166,7 +166,6 @@ def api_get_projects():  # noqa: F401
         projects = get_projects(None)
         owner_ids = [current_user.id for p in projects]
 
-
     for project, owner_id in zip(projects, owner_ids):
         try:
             project_config = project.config
@@ -332,7 +331,6 @@ def api_get_project_info(project):  # noqa: F401
 @project_from_id(current_user)
 def api_update_project_info(project):  # noqa: F401
     """"""
-
     # rename the project if project name is changed
     if request.form.get("name", None) is not None:
         # get new name
@@ -341,7 +339,7 @@ def api_update_project_info(project):  # noqa: F401
         if project.config["name"] != new_project_name:
             old_project_id = project.config["id"]
             new_project_id = _create_project_id(new_project_name)
-            
+
             if app_is_authenticated(current_app):
                 folder_id = _get_authenticated_folder_id(
                     new_project_id,
@@ -1711,4 +1709,3 @@ def api_delete_project(project):  # noqa: F401
 
     response = jsonify(message="project-delete-failure")
     return response, 500
-

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -21,6 +21,8 @@ import urllib.parse
 from pathlib import Path
 from urllib.request import urlretrieve
 
+import numpy as np
+import pandas as pd
 from flask import Blueprint
 from flask import abort
 from flask import current_app
@@ -29,8 +31,6 @@ from flask import request
 from flask import send_file
 from flask_cors import CORS
 from flask_login import current_user
-import numpy as np
-import pandas as pd
 from sqlalchemy import and_
 from werkzeug.exceptions import InternalServerError
 from werkzeug.utils import secure_filename

--- a/asreview/webapp/authentication/login_required.py
+++ b/asreview/webapp/authentication/login_required.py
@@ -20,6 +20,7 @@ from flask import request
 from flask_login.config import EXEMPT_METHODS
 from flask_login.utils import _get_user
 
+
 def asreview_login_required(func):
     """
     Adjusted version of login_required of flask-login

--- a/asreview/webapp/src/Components/ProfilePopper.js
+++ b/asreview/webapp/src/Components/ProfilePopper.js
@@ -207,7 +207,7 @@ const ProfilePopper = (props) => {
                   </ListItemText>
                 </MenuItem>
           
-                { allowTeams && 
+                { false && allowTeams && 
                   <MenuItem onClick={openAcceptanceDialog}>
                     <ListItemIcon>
                       <GroupAdd fontSize="small" />

--- a/asreview/webapp/src/ProjectComponents/ProjectPage.js
+++ b/asreview/webapp/src/ProjectComponents/ProjectPage.js
@@ -94,7 +94,7 @@ const ProjectPage = (props) => {
       enabled: project_id !== undefined,
       onSuccess: (data) => {
         // set ownership
-        setIsOwner(auth.id === data.ownerId);
+        setIsOwner(auth?.id === data.ownerId);
         if (
           data.reviews[0] === undefined ||
           data["reviews"][0]["status"] === projectStatuses.SETUP

--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -111,11 +111,13 @@ def create_app(**kwargs):
 
     # Get the ASReview arguments.
     app.config["asr_kwargs"] = kwargs
-    app.config["AUTHENTICATION_ENABLED"] = kwargs.get("enable_auth", False)
+    app.config["AUTHENTICATION_ENABLED"] = kwargs.get("enable_authentication", False)
+    app.config["SECRET_KEY"] = kwargs.get("secret_key", False)
+    app.config["SECURITY_PASSWORD_SALT"] = kwargs.get("salt", False)
 
     # Read config parameters if possible, this overrides
     # the previous assignments.
-    config_file_path = kwargs.get("flask_config", "").strip()
+    config_file_path = kwargs.get("flask_configfile", "").strip()
     if config_file_path != "":
         app.config.from_file(config_file_path, load=json.load)
 
@@ -291,11 +293,7 @@ def main(argv):
     parser = _lab_parser(prog="lab")
     args = parser.parse_args(argv)
 
-    app = create_app(
-        embedding_fp=args.embedding_fp,
-        enable_auth=args.enable_authentication,
-        flask_config=args.flask_configfile,
-    )
+    app = create_app(**vars(args))
     app.config["PROPAGATE_EXCEPTIONS"] = False
 
     # ssl certificate, key and protocol

--- a/asreview/webapp/tests/conftest.py
+++ b/asreview/webapp/tests/conftest.py
@@ -68,7 +68,7 @@ def setup_teardown_signed_in():
     root_dir = str(Path(os.path.abspath(__file__)).parent)
     config_file_path = f"{root_dir}/configs/auth_config.json"
     # create app and client
-    app = create_app(enable_auth=True, flask_config=config_file_path)
+    app = create_app(enable_auth=True, flask_configfile=config_file_path)
     with app.app_context():
         client = app.test_client()
         email, password = "c.s.kaandorp@uu.nl", "123456!AbC"

--- a/asreview/webapp/tests/test_asreview_database.py
+++ b/asreview/webapp/tests/test_asreview_database.py
@@ -49,7 +49,7 @@ def setup_teardown_standard():
     root_dir = str(Path(os.path.abspath(__file__)).parent)
     config_file_path = f"{root_dir}/configs/auth_config.json"
     # create app and client
-    app = create_app(enable_auth=True, flask_config=config_file_path)
+    app = create_app(enable_auth=True, flask_configfile=config_file_path)
     # clean database
     with app.app_context():
         yield app

--- a/asreview/webapp/tests/test_asreview_database.py
+++ b/asreview/webapp/tests/test_asreview_database.py
@@ -46,6 +46,9 @@ def setup_teardown_standard():
     """Standard setup and teardown, create the app and
     make sure the database is cleaned up after running
     each and every test"""
+    # setup environment variables
+    os.environ.update(TMP_ENV_VARS)
+    
     root_dir = str(Path(os.path.abspath(__file__)).parent)
     config_file_path = f"{root_dir}/configs/auth_config.json"
     # create app and client

--- a/asreview/webapp/tests/test_asreview_database.py
+++ b/asreview/webapp/tests/test_asreview_database.py
@@ -48,7 +48,7 @@ def setup_teardown_standard():
     each and every test"""
     # setup environment variables
     os.environ.update(TMP_ENV_VARS)
-    
+
     root_dir = str(Path(os.path.abspath(__file__)).parent)
     config_file_path = f"{root_dir}/configs/auth_config.json"
     # create app and client

--- a/asreview/webapp/tests/test_auth.py
+++ b/asreview/webapp/tests/test_auth.py
@@ -53,7 +53,7 @@ def setup_teardown_standard(request):
         config_file_path = f"{root_dir}/configs/auth_config.json"
 
     # create app and client
-    app = create_app(enable_auth=True, flask_config=config_file_path)
+    app = create_app(enable_auth=True, flask_configfile=config_file_path)
     client = app.test_client()
     # clean database
     with app.app_context():

--- a/asreview/webapp/tests/test_auth.py
+++ b/asreview/webapp/tests/test_auth.py
@@ -328,7 +328,7 @@ def test_expired_token(setup_teardown_standard):
     # try to confirm this account
     # now we confirm this user
     response = client.post(
-        f"/auth/confirm_account",
+        "/auth/confirm_account",
         data={"user_id": user.id, "token": user.token}
     )
     assert response.status_code == 403
@@ -356,7 +356,7 @@ def test_if_this_route_returns_404_user_not_found(setup_teardown_standard):
     user = User.query.first()
     # confirm with wrong user id
     response = client.post(
-        f"/auth/confirm_account",
+        "/auth/confirm_account",
         data={"user_id": user.id - 1, "token": user.token}
     )
     assert response.status_code == 404
@@ -378,7 +378,7 @@ def test_if_this_route_returns_404_token_not_found(setup_teardown_standard):
     user = User.query.first()
     # confirm with wrong token
     response = client.post(
-        f"/auth/confirm_account",
+        "/auth/confirm_account",
         data={"user_id": user.id - 1, "token": "A" + user.token + "A"}
     )
     assert response.status_code == 404
@@ -397,7 +397,7 @@ def test_if_this_route_returns_404_if_app_not_verified(setup_teardown_standard):
     user = User.query.first()
     # try to confirm
     response = client.post(
-        f"/auth/confirm_account",
+        "/auth/confirm_account",
         data={"user_id": user.id, "token": user.token}
     )
     assert response.status_code == 400

--- a/asreview/webapp/tests/test_project_api_unauthenticated.py
+++ b/asreview/webapp/tests/test_project_api_unauthenticated.py
@@ -70,7 +70,6 @@ def test_upgrade_project_if_old(setup_teardown_unauthorized):
     assert response.status_code == 400
 
 
-
 def test_get_projects_stats(setup_teardown_unauthorized):
     """Test get dashboard statistics of all projects"""
     _, client = setup_teardown_unauthorized

--- a/asreview/webapp/tests/test_teams_api.py
+++ b/asreview/webapp/tests/test_teams_api.py
@@ -16,10 +16,10 @@ import json
 import os
 import shutil
 
-import pytest
 from conftest import signin_user
 from conftest import signout
 from conftest import signup_user
+import pytest
 
 from asreview.utils import asreview_path
 from asreview.webapp import DB

--- a/asreview/webapp/tests/test_teams_api.py
+++ b/asreview/webapp/tests/test_teams_api.py
@@ -16,9 +16,6 @@ import json
 import os
 import shutil
 
-from conftest import signin_user
-from conftest import signout
-from conftest import signup_user
 import pytest
 
 from asreview.utils import asreview_path
@@ -27,6 +24,9 @@ from asreview.webapp.authentication.models import Collaboration
 from asreview.webapp.authentication.models import CollaborationInvitation
 from asreview.webapp.authentication.models import Project
 from asreview.webapp.authentication.models import User
+from asreview.webapp.tests.conftest import signin_user
+from asreview.webapp.tests.conftest import signout
+from asreview.webapp.tests.conftest import signup_user
 
 password_main_user = "A12bcdefg!!"
 password_coll1 = "B12345*6"

--- a/asreview/webapp/tests/test_teams_api.py
+++ b/asreview/webapp/tests/test_teams_api.py
@@ -16,10 +16,10 @@ import json
 import os
 import shutil
 
+import pytest
 from conftest import signin_user
 from conftest import signout
 from conftest import signup_user
-import pytest
 
 from asreview.utils import asreview_path
 from asreview.webapp import DB
@@ -27,7 +27,6 @@ from asreview.webapp.authentication.models import Collaboration
 from asreview.webapp.authentication.models import CollaborationInvitation
 from asreview.webapp.authentication.models import Project
 from asreview.webapp.authentication.models import User
-
 
 password_main_user = "A12bcdefg!!"
 password_coll1 = "B12345*6"

--- a/asreview/webapp/tests/test_teams_api.py
+++ b/asreview/webapp/tests/test_teams_api.py
@@ -28,9 +28,11 @@ from asreview.webapp.authentication.models import CollaborationInvitation
 from asreview.webapp.authentication.models import Project
 from asreview.webapp.authentication.models import User
 
+
 password_main_user = "A12bcdefg!!"
 password_coll1 = "B12345*6"
 password_coll2 = "C1@2a3456"
+
 
 @pytest.fixture
 def populate(setup_teardown_signed_in):

--- a/auth_conversion.py
+++ b/auth_conversion.py
@@ -1,0 +1,110 @@
+import json
+import sqlite3
+from pathlib import Path
+from uuid import NAMESPACE_URL
+from uuid import uuid5
+
+ASREVIEW_PATH = Path("/Users/casperkaandorp/.asreview")
+DATABASE_NAME = "asreview.development.sqlite"
+
+
+def get_users(cursor):
+    """Select ids, names and emails from all users"""
+    query = "SELECT id, name, email FROM users"
+    cursor.execute(query)
+    return cursor.fetchall()
+
+
+def print_user_records(selection):
+    """Print user records from database."""
+    if not bool(selection):
+        return "No records."
+    print("ID\tname (email)")
+    print("==============================")
+    for id, name, email in selection:
+        print(f"{id}.\t{name} ({email})")
+
+
+def user_project_link_exists(cursor, folder_id):
+    """Check if a project record already exists."""
+    query = "SELECT COUNT(id) FROM projects " + \
+        f"WHERE project_id='{folder_id}'"
+    cursor.execute(query)
+    return cursor.fetchone()[0] == 1
+
+
+def link_user_to_project(conn, project_id, folder_name, user_id):
+    """Inserts project record, links user id to project"""
+    query = "INSERT INTO projects(project_id, folder, owner_id)" + \
+        "VALUES(?,?,?)"
+    cursor = conn.cursor()
+    cursor.execute(query, (project_id, folder_name, user_id))
+    conn.commit()
+    return cursor.lastrowid
+
+
+if __name__ == "__main__":
+    # establish connect with database
+    con = sqlite3.connect(ASREVIEW_PATH / DATABASE_NAME)
+    # get cursor
+    cursor = con.cursor()
+    # get all users in the user table
+    users = get_users(cursor)
+    # all id numbers
+    all_ids = [row[0] for row in users]
+
+    # iterate over all files and folders in ASREVIEW_PATH
+    for folder in ASREVIEW_PATH.glob("*"):
+
+        # if folder is indeed a folder
+        if Path(folder).is_dir():
+            # open the project.json folder
+            with open(folder / "project.json") as json_file:
+                project_data = json.load(json_file)
+            # get project id
+            project_id = project_data["id"]
+            # see if this project is already connected to a user
+            if user_project_link_exists(cursor, project_id):
+                print(f"Project {project_id} is already linked to a user")
+                continue
+            else:
+                print(
+                    "==> Who is the owner of this project folder:",
+                    f"{project_id}\n"
+                )
+                print_user_records(users)
+                # ask who's the folder's owner
+                user_id = input("Provide ID number of owner > ")
+                user_id = user_id.replace(".", "")
+
+                # try to convert into id number and store project row
+                try:
+                    user_id = int(user_id)
+                    # make sure the user_id exists
+                    assert user_id in all_ids
+
+                    # create a new project_id
+                    new_project_id = f"{user_id}_{project_id}"
+                    new_folder_name = uuid5(
+                        NAMESPACE_URL,
+                        new_project_id
+                    ).hex
+
+                    # rename the folder
+                    folder.rename(ASREVIEW_PATH / new_folder_name)
+
+                    # insert record
+                    link_user_to_project(
+                        con,
+                        project_id,
+                        new_folder_name,
+                        user_id,
+                    )
+
+                except AssertionError:
+                    print("Entered user id does not exists, start again.")
+                    break
+
+                except ValueError:
+                    print("Entered input is not a string, start again.")
+                    break

--- a/auth_conversion.py
+++ b/auth_conversion.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from uuid import NAMESPACE_URL
 from uuid import uuid5
 
-ASREVIEW_PATH = Path("/Users/casperkaandorp/.asreview")
+from asreview.utils import asreview_path
+
 DATABASE_NAME = "asreview.development.sqlite"
 
 
@@ -45,7 +46,7 @@ def link_user_to_project(conn, project_id, folder_name, user_id):
 
 if __name__ == "__main__":
     # establish connect with database
-    con = sqlite3.connect(ASREVIEW_PATH / DATABASE_NAME)
+    con = sqlite3.connect(asreview_path() / DATABASE_NAME)
     # get cursor
     cursor = con.cursor()
     # get all users in the user table
@@ -53,8 +54,8 @@ if __name__ == "__main__":
     # all id numbers
     all_ids = [row[0] for row in users]
 
-    # iterate over all files and folders in ASREVIEW_PATH
-    for folder in ASREVIEW_PATH.glob("*"):
+    # iterate over all files and folders in asreview_path()
+    for folder in asreview_path().glob("*"):
 
         # if folder is indeed a folder
         if Path(folder).is_dir():
@@ -91,7 +92,7 @@ if __name__ == "__main__":
                     ).hex
 
                     # rename the folder
-                    folder.rename(ASREVIEW_PATH / new_folder_name)
+                    folder.rename(asreview_path() / new_folder_name)
 
                     # insert record
                     link_user_to_project(

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -50,11 +50,19 @@ available commands in ASReview LAB, type :code:`asreview lab --help`.
 
 .. option:: --enable-auth ENABLE_AUTH
 
-	Use authentication.
+	Enable authentication.
+
+.. option:: --secret-key SECRET_KEY
+
+	Secret key for authentication.
+
+.. option:: --salt SALT
+
+	When using authentication, a salt code is needed for hasing passwords.
 
 .. option:: --flask-configfile FLASK_CONFIGFILE
 
-    The full path to a JSON file for Flask parameters.
+    Full path to a JSON file containing Flask parameters for authentication.
 
 .. option:: --no-browser NO_BROWSER
 


### PR DESCRIPTION
I have written some initial documentation for authentication (README), the collabo menu-item in the profile-popper is finally gone (well, it's hidden), fixed a weird issue with test_asreview_database.py (destroyed the development database for testing purposes) and I have written a small script that may help converting an unauthenticated app into an authenticated one. The simple conversion workflow is described in the README.

I don't know if the README is the proper place for the documentation. Probably not. Feel free to do whatever is necessary to turn the text into proper documentation and let me know if I need to add stuff. 

The conversion script is added in the root folder of the application and is called auth_conversion.py. 

Again, let me know if you need more documentation.

God knows I have pulled flake8 several times over the repo, and isort, and black. And God also knows all my tests are still green.