### PR TITLE
Don't use the project_path on the creation of a temporary directory for exporting dataset

### DIFF
--- a/asreview/webapp/api.py
+++ b/asreview/webapp/api.py
@@ -1126,7 +1126,7 @@ def api_export_dataset(project):
     file_format = request.args.get("file_format", None)
 
     # create temporary folder to store exported dataset
-    tmp_path = tempfile.TemporaryDirectory(dir=project.project_path)
+    tmp_path = tempfile.TemporaryDirectory()
     tmp_path_dataset = Path(tmp_path.name, f"export_dataset.{file_format}")
 
     try:


### PR DESCRIPTION
As explained in #1342, the temporary directory is deleted after use, so there is no need to create it inside the `project.project_path`. With this change, it doesn't matter if the project path is relative or absolute (for this function).

Closes #1342