### PR TITLE
Fix dtype issue in duplicate detection algorithm due to pandas 2

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -20,6 +20,7 @@ from urllib.request import urlopen
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_object_dtype
 from pandas.api.types import is_string_dtype
 
 from asreview.config import COLUMN_DEFINITIONS
@@ -489,7 +490,7 @@ class ASReviewData():
         """
         if pid in self.df.columns:
             # in case of strings, strip whitespaces and replace empty strings with None
-            if is_string_dtype(self.df[pid]):
+            if is_string_dtype(self.df[pid]) or is_object_dtype(self.df[pid]):
                 s_pid = self.df[pid].str.strip().replace("", None)
             else:
                 s_pid = self.df[pid]


### PR DESCRIPTION
The new major version pandas (v2) seems to have little effect on the ASReview lib. We stumbled on an issue with the deduplication algorithm when DOIs were used, where values are not None but whitespace. The impact seems to be minimal. 

Thanks @gimoAI for making the test that now detects this :) 

This relates to #1393 