### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ bower_components
 psd
 thumb
 sketch
+
+# VSCode
+.vscode


### PR DESCRIPTION
Adds the `.vscode` directory to `.gitignore`. It contains settings for the VSCode code editor so it should be ignored by git.