### PR TITLE
Allow SBERT to load other transformer models

### DIFF
--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -66,7 +66,8 @@ class SBERT(BaseFeatureExtraction):
     pooling_mode: str, optional
         Polling mode to get sentece embeddings from word embeddings
         Default: 'mean'
-        Other options available are mean, max and cls. Only used if is_pretrained_SBERT=False
+        Other options available are mean, max and cls.
+        Only used if is_pretrained_SBERT=False
         mean: Uses mean pooling of word embeddings
         max: Uses max pooling of word embeddings
         cls: Uses embeddings of [CLS] token as sentence embeddings

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -106,5 +106,5 @@ class SBERT(BaseFeatureExtraction):
             model = SentenceTransformer(
                 modules=[word_embedding_model, pooling_layer]
             )
-        X = np.array(model.encode(texts))
+        X = model.encode(texts)
         return X

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 try:
     from sentence_transformers import models
     from sentence_transformers.SentenceTransformer import SentenceTransformer

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -80,7 +80,7 @@ class SBERT(BaseFeatureExtraction):
         self,
         *args,
         transformer_model="all-mpnet-base-v2",
-        is_pretrained_SBERT=True,
+        is_pretrained_sbert=True,
         pooling_mode="mean",
         **kwargs
     ):

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -61,12 +61,12 @@ class SBERT(BaseFeatureExtraction):
     transformer_model : str, optional
         The transformer model to use.
         Default: 'all-mpnet-base-v2'
-    is_pretrained_SBERT: boolian, optional
+    is_pretrained_SBERT: boolean, optional
         Default: True
     pooling_mode: str, optional
-        Polling mode to get sentece embeddings from word embeddings
+        Pooling mode to get sentence embeddings from word embeddings
         Default: 'mean'
-        Other options available are mean, max and cls.
+        Other options available are 'mean', 'max' and 'cls'.
         Only used if is_pretrained_SBERT=False
         mean: Uses mean pooling of word embeddings
         max: Uses max pooling of word embeddings

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -86,13 +86,13 @@ class SBERT(BaseFeatureExtraction):
     ):
         super(SBERT, self).__init__(*args, **kwargs)
         self.transformer_model = transformer_model
-        self.is_pretrained_SBERT = is_pretrained_SBERT
+        self.is_pretrained_sbert = is_pretrained_sbert
         self.pooling_mode = pooling_mode
 
     def transform(self, texts):
         _check_st()
 
-        if self.is_pretrained_SBERT:
+        if self.is_pretrained_sbert:
             model = SentenceTransformer(self.transformer_model)
         else:
             # If transformer_model is not a pretrained sentence transformer model,

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -15,8 +15,8 @@
 import numpy as np
 
 try:
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
     from sentence_transformers import models
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
 except ImportError:
     ST_AVAILABLE = False
 else:

--- a/asreview/models/feature_extraction/sbert.py
+++ b/asreview/models/feature_extraction/sbert.py
@@ -106,5 +106,6 @@ class SBERT(BaseFeatureExtraction):
             model = SentenceTransformer(
                 modules=[word_embedding_model, pooling_layer]
             )
-        X = model.encode(texts)
+        print("Encoding texts using sbert, this may take a while...")
+        X = model.encode(texts, show_progress_bar=True)
         return X


### PR DESCRIPTION
Models which are not specifically trained sentence transformer models such as SciBERT, BioBERT or longformer can be loaded from Huggingface