### PR TITLE
Fix ASData index data type

### DIFF
--- a/asreview/io/utils.py
+++ b/asreview/io/utils.py
@@ -163,7 +163,7 @@ def _standardize_dataframe(df, column_def={}):
     # # Create a new index if we haven't found it in the data.
     # else:
     #     df["record_id"] = np.arange(len(df.index))
-    df["record_id"] = np.arange(len(df.index))
+    df["record_id"] = np.arange(len(df.index)).astype('int64')
 
     # set the index
     df.set_index("record_id", inplace=True)


### PR DESCRIPTION
When reading a `ASData` object from file, the index is created as a numpy `arange`. The data type of this `arange` depends on the operating system (it's `int32` on Windows, `int64` otherwise). I fixed it to `int64`. This way `tests/test_asdata.py:test_asdata_init` also passes on Windows.