### PR TITLE
Allow relative path to flask configfile

### DIFF
--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -18,6 +18,7 @@ import logging
 import os
 import socket
 import webbrowser
+from pathlib import Path
 from threading import Timer
 
 from flask import Flask
@@ -248,8 +249,9 @@ def create_app(**kwargs):
     # Read config parameters if possible, this overrides
     # the previous assignments.
     config_file_path = kwargs.get("flask_configfile", "").strip()
+    # Use absolute path, because otherwise it is relative to the config root.
     if config_file_path != "":
-        app.config.from_file(config_file_path, load=json.load)
+        app.config.from_file(Path(config_file_path).absolute(), load=json.load)
 
     # set env (test / development / production) according to
     # Flask 2.2 specs (ENV is deprecated)


### PR DESCRIPTION
Currently, when starting the app through the command line with a flask configfile you need to give the absolute path to the file. This pull request changes that to a relative path, which should be more intiutive to use.