### PR TITLE
CORS issue, OAuth

### DIFF
--- a/asreview/webapp/api/auth.py
+++ b/asreview/webapp/api/auth.py
@@ -44,12 +44,19 @@ bp = Blueprint("auth", __name__, url_prefix="/auth")
 
 # NOTE: not too sure about this, what if we are dealing with a
 # domain name
-ROOT_URL = "http://127.0.0.1:3000/"
+ROOT_URL = "http://127.0.0.1:3000"
 
 CORS(
     bp,
-    resources={r"*": {"origins": ["http://localhost:3000", ROOT_URL]}},
-    supports_credentials=True,
+    resources={
+        r"*": {
+            "origins": [
+                ROOT_URL,
+                "http://localhost:3000"
+            ]
+        }
+    },
+    supports_credentials=True
 )
 
 

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -87,13 +87,12 @@ CORS(
     resources={
         r"*": {
             "origins": [
-                "http://localhost:3000",
                 "http://127.0.0.1:3000",
-                "localhost:3000",
+                "http://localhost:3000"
             ]
         }
     },
-    supports_credentials=True,
+    supports_credentials=True
 )
 
 

--- a/asreview/webapp/api/team.py
+++ b/asreview/webapp/api/team.py
@@ -14,8 +14,15 @@ from asreview.webapp.authentication.models import User
 bp = Blueprint("team", __name__, url_prefix="/api")
 CORS(
     bp,
-    resources={r"*": {"origins": ["http://localhost:3000", "http://127.0.0.1:3000"]}},
-    supports_credentials=True,
+    resources={
+        r"*": {
+            "origins": [
+                "http://127.0.0.1:3000",
+                "http://localhost:3000"
+            ]
+        }
+    },
+    supports_credentials=True
 )
 
 REQUESTER_FRAUD = {"message": "Request can not made by current user."}


### PR DESCRIPTION
The goal of this pull request is to fix the OAuth issues in production. While tracing an OAuth roundtrip I stumbled upon a CORS issue. Auth wasn't simply working. Perhaps because of a trailing slash in an origin url. After correcting this all was fine again. The first commit represents this correction, this makes all Cors inits uniform. Manual OAuth testing is forthcoming. 