### PR TITLE
Issue #1481 - Update __main__.py

### DIFF
--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -15,7 +15,12 @@
 """Command Line Interface (CLI) for ASReview project."""
 import argparse
 import sys
-from importlib.metadata import metadata
+try:
+    from importlib import metadata
+except ImportError: # for Python<3.8
+    import importlib_metadata as metadata
+__version__ = metadata.version("jsonschema")
+#from importlib.metadata import metadata
 from itertools import groupby
 
 from asreview import __version__


### PR DESCRIPTION
Please, consider this suggestion to avoid "ImportError: cannot import name 'metadata' from 'importlib'" for Python<3.8. It works for me. Congrats on this awesome work!!!