### PR TITLE
Fix BaseReview.review bug

### DIFF
--- a/asreview/review/base.py
+++ b/asreview/review/base.py
@@ -194,7 +194,6 @@ class BaseReview(ABC):
             # write to state when stopped
             pbar_rel.close()
             pbar_total.close()
-            self._write_to_state()
 
     def _label_priors(self):
         """Make sure the prior records are labeled."""

--- a/asreview/review/simulate.py
+++ b/asreview/review/simulate.py
@@ -226,6 +226,10 @@ class ReviewSimulate(BaseReview):
             pending_labels = self.data_labels[pending]
             state.add_labeling_data(pending, pending_labels)
 
+    def review(self):
+        super().review()
+        self._write_to_state()
+
     def _stop_review(self):
         """In simulation mode, the stop review function should get the labeled
         records list from the reviewer attribute."""


### PR DESCRIPTION
(Fixes #1526) Moves the call to `_write_to_state` from `BaseReview` to `ReviewSimulate`. It is a little ugly, but I don't think there is a pretty solution until these two classes are refactored.