### PR TITLE
Replace psycopg2 by psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIRES = [
     "gevent>=20",
     "datahugger>=0.2",
     "synergy_dataset",
-    "psycopg2",
+    "psycopg2-binary",
     "sqlalchemy-utils",
 ]
 


### PR DESCRIPTION
Users might face issues when the source is not built for their platform. It's not advised by the authors, so I'm not sure how to continue. 

> 
> The psycopg2-binary package is meant for beginners to start playing with Python and PostgreSQL without the need to meet the build requirements.
> 
> If you are the maintainer of a published package depending on psycopg2 you shouldn’t use psycopg2-binary as a module dependency. For production use you are advised to use the source distribution.
> 
> The binary packages come with their own versions of a few C libraries, among which libpq and libssl, which will be used regardless of other libraries available on the client: upgrading the system libraries will not upgrade the libraries used by psycopg2. Please build psycopg2 from source if you want to maintain binary upgradeability.
