### PR TITLE
Add fontSize adjustments to review screen

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -132,6 +132,7 @@ const RecordCard = (props) => {
           {props.activeRecord._debug_label !== null && (
             <ExplorationModeRecordAlert
               label={!isDebugInclusion() ? "irrelevant" : "relevant"}
+              fontSize={props.fontSize}
             />
           )}
 
@@ -249,6 +250,7 @@ const RecordCard = (props) => {
           {props.recordNote.shrink && (
             <CardActions className={classes.note}>
               <Button
+                className={"fontSize" + props.fontSize.label}
                 disabled={props.disableButton()}
                 size="small"
                 onClick={expandNoteSheet}

--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -5,6 +5,7 @@ export function ExplorationModeRecordAlert(props) {
   return (
     <Alert
       severity="info"
+      className={"fontSize" + props.fontSize.label}
       sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
     >
       {`Labeled as ${props.label} in the dataset`}


### PR DESCRIPTION
Changes proposed in this pull request:

- Resize texts in review screen

*Add screenshots for proposed visual changes*

New: 
<img width="828" alt="image" src="https://github.com/asreview/asreview/assets/12981139/fb692d1e-7908-47d8-863f-c675aa656516">

Before (with large font size):
<img width="818" alt="image" src="https://github.com/asreview/asreview/assets/12981139/2ad83c12-f5d8-4d9c-ac14-1976b29cfe49">


**Checklist**

- [x] Unit tests are added for new features and bug fixes
- [x] Documentation is added for new features
- [x] Title of the pull request is self-explaining
