### PR TITLE
Add underline for label in Explore mode

### DIFF
--- a/asreview/webapp/src/StyledComponents/StyledAlert.js
+++ b/asreview/webapp/src/StyledComponents/StyledAlert.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Alert } from "@mui/material";
+import { Alert, Box } from "@mui/material";
 
 export function ExplorationModeRecordAlert(props) {
   return (
@@ -7,7 +7,13 @@ export function ExplorationModeRecordAlert(props) {
       severity="info"
       sx={{ borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }}
     >
-      {`Labeled as ${props.label} in the dataset`}
+      Labeled as{" "}
+      {
+        <Box sx={{ textDecoration: "underline" }} display="inline">
+          {props.label}
+        </Box>
+      }{" "}
+      in the dataset
     </Alert>
   );
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Underline label


*Add screenshots for proposed visual changes*

<img width="808" alt="image" src="https://github.com/asreview/asreview/assets/12981139/64cc36ce-f674-4f52-b431-f7fce1cb2237">


**Checklist**

- [x] Unit tests are added for new features and bug fixes
- [x] Documentation is added for new features
- [x] Title of the pull request is self-explaining
