### PR TITLE
Add PowerShell development setup instruction

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,6 +95,13 @@ set FLASK_DEBUG=1
 asreview lab
 ```
 
+Note, when working with PowerShell use
+
+```
+$env:FLASK_DEBUG = "1"
+asreview lab
+```
+
 **Important**: Ignore `localhost:5000`, because this is not relevant for the
   development version, which will run on `localhost:3000`.
 


### PR DESCRIPTION
If you are using PowerShell the command set FLASK_DEBUG=1 is not working because set is not the correct command in PowerShell to create or modify an environment variable. Instead, you should use $env:VARIABLE_NAME = "value" to set an environment variable.