### PR TITLE
Remove KeyboardInterrupt for server

### DIFF
--- a/asreview/webapp/start_flask.py
+++ b/asreview/webapp/start_flask.py
@@ -559,4 +559,8 @@ def main(argv):
     else:
         ssl_args = {"keyfile": keyfile, "certfile": certfile} if ssl_context else {}
         server = WSGIServer((host, port), app, **ssl_args)
-        server.serve_forever()
+
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\n\nShutting down server\n\n")


### PR DESCRIPTION
This PR provides a proper shutdown: 

```
% asreview lab               
Start browser at http://localhost:5000/



If your browser doesn't open. Please navigate to 'http://localhost:5000/'




127.0.0.1 - - [2023-11-02 19:20:12] "GET / HTTP/1.1" 200 713 0.010951
127.0.0.1 - - [2023-11-02 19:20:12] "GET /static/css/main.e7922467.css HTTP/1.1" 200 7701 0.000729
127.0.0.1 - - [2023-11-02 19:20:13] "GET /static/js/main.ed2382fc.js HTTP/1.1" 200 1877371 0.047143
127.0.0.1 - - [2023-11-02 19:20:13] "GET /boot HTTP/1.1" 200 187 0.001199
127.0.0.1 - - [2023-11-02 19:20:13] "GET /boot HTTP/1.1" 200 187 0.000321
127.0.0.1 - - [2023-11-02 19:20:13] "GET /static/media/roboto-latin-500.f5b74d7ffcdf85b9dd60.woff2 HTTP/1.1" 200 16176 0.002239
127.0.0.1 - - [2023-11-02 19:20:13] "GET /static/media/roboto-latin-400.176f8f5bd5f02b3abfcf.woff2 HTTP/1.1" 200 16040 0.002821
127.0.0.1 - - [2023-11-02 19:20:13] "GET /api/projects/stats HTTP/1.1" 200 164 0.005794
127.0.0.1 - - [2023-11-02 19:20:13] "GET /api/projects HTTP/1.1" 200 1418 0.002013
127.0.0.1 - - [2023-11-02 19:20:13] "GET /static/media/asreview_sub_logo_lab_black_transparent.c4e14af313ba97465fff113a6b2e4fd7.svg HTTP/1.1" 200 127814 0.001982
127.0.0.1 - - [2023-11-02 19:20:13] "GET /static/media/roboto-latin-700.c18ee39fb002ad58b6dc.woff2 HTTP/1.1" 200 16120 0.001235
^CKeyboardInterrupt
2023-11-02T18:20:39Z


Closing down server



```