### PR TITLE
Hotfix backend not found when port != 5000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,9 @@ Thumbs.db #thumbnail cache on Windows
 logs
 **/*.backup.*
 **/*.back.*
-.env.*
+
+.env.local
+.env.*.local
 
 node_modules
 bower_components

--- a/asreview/webapp/.env
+++ b/asreview/webapp/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_URL=http://localhost:5000/

--- a/asreview/webapp/.env.development
+++ b/asreview/webapp/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:5000/


### PR DESCRIPTION
Users report infinite loader when asreview runs on port other than 5000. 

Reproduce with 
```
asreview lab --port 5010
```