### PR TITLE
Fix entry point in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV PATH=/root/.local/bin:$PATH
 ENV ASREVIEW_PATH=/project_folder
 EXPOSE 5000
 
-ENTRYPOINT ["asreview", "lab"]
+ENTRYPOINT ["asreview"]


### PR DESCRIPTION
Revert unintentional changes to default Docker file. 

```
docker run -p 5000:5000 ghcr.io/asreview/asreview:latest lab
```

The current (broken) version:
```
docker run -p 5000:5000 ghcr.io/asreview/asreview:latest
```