### PR TITLE
Add upgrade instruction for users with outdated ASReview versions

### DIFF
--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import os
 import socket
+import time
 import webbrowser
 from threading import Timer
 
@@ -76,6 +77,8 @@ def _check_for_update():
                 "pip install --upgrade asreview"
                 "\n\n\n"
             )
+
+            time.sleep(5)
     except Exception as err:
         print("Could not check for updates.")
         raise err

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -18,8 +18,10 @@ import socket
 import webbrowser
 from threading import Timer
 
+import requests
 from gevent.pywsgi import WSGIServer
 
+from asreview import __version__
 from asreview._deprecated import DeprecateAction
 from asreview._deprecated import mark_deprecated_help_strings
 from asreview.project import ASReviewProject
@@ -47,7 +49,6 @@ def _deprecated_dev_mode():
 
 
 def _check_port_in_use(host, port):
-
     logging.info(f"Checking if host and port are available :: {host}:{port}")
     host = host.replace("https://", "").replace("http://", "")
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -55,13 +56,30 @@ def _check_port_in_use(host, port):
 
 
 def _open_browser(start_url):
-
     Timer(1, lambda: webbrowser.open_new(start_url)).start()
 
-    print(
-        "\n\n\n\nIf your browser doesn't open. "
-        f"Navigate to {start_url}\n\n\n\n"
-    )
+    print("\n\n\n\nIf your browser doesn't open. " f"Navigate to {start_url}\n\n\n\n")
+
+
+def _check_for_update():
+    """Check if there is an update available."""
+
+    try:
+        r = requests.get("https://pypi.org/pypi/asreview/json")
+        r.raise_for_status()
+        latest_version = r.json()["info"]["version"]
+        if latest_version != __version__ and "+" not in __version__:
+            print(
+                "\n\n\n"
+                f"ASReview LAB version {latest_version} is available."
+                "Please update using:\n"
+                "pip install --upgrade asreview"
+                "\n\n\n"
+            )
+    except Exception as err:
+        print("Could not check for updates.")
+        raise err
+        pass
 
 
 def lab_entry_point(argv):
@@ -71,6 +89,10 @@ def lab_entry_point(argv):
     parser = _lab_parser()
     mark_deprecated_help_strings(parser)
     args = parser.parse_args(argv)
+
+    # check for update
+    if not args.skip_update_check:
+        _check_for_update()
 
     app = create_app(
         env="production",
@@ -237,6 +259,13 @@ def _lab_parser():
         default="",
         type=str,
         help="The full path to a private key file for usage with SSL/TLS.",
+    )
+
+    parser.add_argument(
+        "--skip-update-check",
+        dest="skip_update_check",
+        action="store_true",
+        help="Skip checking for updates.",
     )
 
     return parser

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -69,10 +69,10 @@ def _check_for_update():
         r = requests.get("https://pypi.org/pypi/asreview/json")
         r.raise_for_status()
         latest_version = r.json()["info"]["version"]
-        if latest_version != __version__ and "+" not in __version__:
+        if latest_version != __version__ and "+" in __version__:
             print(
                 "\n\n\n"
-                f"ASReview LAB version {latest_version} is available."
+                f"ASReview LAB version {latest_version} is available. "
                 "Please update using:\n"
                 "pip install --upgrade asreview"
                 "\n\n\n"

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -69,7 +69,7 @@ def _check_for_update():
         r = requests.get("https://pypi.org/pypi/asreview/json")
         r.raise_for_status()
         latest_version = r.json()["info"]["version"]
-        if latest_version != __version__ and "+" in __version__:
+        if latest_version != __version__ and "+" not in __version__:
             print(
                 "\n\n\n"
                 f"ASReview LAB version {latest_version} is available. "

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -81,8 +81,6 @@ def _check_for_update():
             time.sleep(5)
     except Exception as err:
         print("Could not check for updates.")
-        raise err
-        pass
 
 
 def lab_entry_point(argv):

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -79,7 +79,7 @@ def _check_for_update():
             )
 
             time.sleep(5)
-    except Exception as err:
+    except Exception:
         print("Could not check for updates.")
 
 


### PR DESCRIPTION
```sh
> asreview lab --no-browser



ASReview LAB version 1.3.2 is available. Please update using:
pip install --upgrade asreview



Serving ASReview LAB at http://localhost:5000/



```