### PR TITLE
Fix (or improve) syntax for installing backports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 import platform
 import re
 import subprocess
-import sys
 from io import open
 from os import path
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -66,14 +66,9 @@ REQUIRES = [
     "datahugger>=0.2",
     "synergy_dataset",
     "sqlalchemy-utils",
+    "tomli; python_version < '3.11'",
+    "importlib_metadata; python_version < '3.10'",
 ]
-
-if sys.version_info < (3, 11):
-    REQUIRES += ["tomli"]
-
-
-if sys.version_info < (3, 10):
-    REQUIRES += ["importlib_metadata>=3.6"]
 
 
 DEPS = {


### PR DESCRIPTION
Some users report issues with installing asreview on Python < 3.11 because tomli is not installed. I was able to sometimes reproduce, but not all the time. I suggest this improved syntax might help. 