### PR TITLE
Deprecated AUTHENTICATION_ENABLED parameter ignored

### DIFF
--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -67,9 +67,9 @@ def create_app(
             Path(config_file_path).absolute(), load=tomllib.load, text=False
         )
 
-    if app.config.get("ENABLE_AUTHENTICATION", None):
+    if app.config.get("AUTHENTICATION_ENABLED", None):
         warnings.warn(
-            "The use of ENABLE_AUTHENTICATION=true is deprecated and "
+            "The use of AUTHENTICATION_ENABLED=true is deprecated and "
             "will be removed in the future. Use LOGIN_DISABLED=false instead."
         )
         if "LOGIN_DISABLED" not in app.config:


### PR DESCRIPTION
There is a typo in app.py which causes create_app to ignore the deprecated AUTHENTICATION_ENABLED parameter