### PR TITLE
Rename 'debug_label' to 'label_included' in export file

### DIFF
--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1167,8 +1167,7 @@ def api_export_dataset(project):
         # read the dataset into a ASReview data object
         as_data = read_data(project)
 
-        # Convert -1 to NaN
-        as_data.df["debug_label"] = as_data.df["debug_label"].replace(-1, np.nan)
+        as_data.df["debug_label"] = as_data.df["debug_label"].replace(LABEL_NA, np.nan)
 
         # Merge labeled labels with as_data.df based on record_id
         merge_cols = ['record_id', 'label']
@@ -1177,8 +1176,6 @@ def api_export_dataset(project):
         if project.config["mode"] == PROJECT_MODE_EXPLORE:
             # Rename original label column if it exists
             if 'debug_label' in as_data.df.columns:
-                as_data.df.rename(
-                    columns={'debug_label': 'label_included'}, inplace=True)
                 as_data.df.rename(
                     columns={'debug_label': 'label_included'}, inplace=True)
             if 'label' in as_data.df.columns:

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1168,12 +1168,16 @@ def api_export_dataset(project):
         as_data = read_data(project)
 
         # Merge labeled labels with as_data.df based on record_id
-        as_data.df = as_data.df.merge(labeled[['record_id', 'label']], on='record_id', how='left')
+        merge_cols = ['record_id', 'label']
+        as_data.df = as_data.df.merge(labeled[merge_cols], on='record_id', how='left')
+
 
         if project.config["mode"] == PROJECT_MODE_EXPLORE:
             # Rename original label column if it exists
             if 'debug_label' in as_data.df.columns:
                 as_data.df.rename(columns={'debug_label': 'label_included'}, inplace=True)
+                as_data.df.rename(
+                    columns={'debug_label': 'label_included'}, inplace=True)
             if 'label' in as_data.df.columns:
                 as_data.df.rename(columns={'label': 'label_validated'}, inplace=True)
 
@@ -1186,7 +1190,8 @@ def api_export_dataset(project):
             as_data.df.rename(columns={'label': 'label_included'}, inplace=True)
 
         # Reorder as_data.df according to the ranking and save the ranking order
-        as_data.df['asreview_ranking'] = as_data.df['record_id'].apply(lambda x: export_order.index(x) if x in export_order else None)
+        ranking_func = lambda x: export_order.index(x) if x in export_order else None
+        as_data.df['asreview_ranking'] = as_data.df['record_id'].apply(ranking_func)
         as_data.df = as_data.df.set_index('record_id').loc[export_order].reset_index()
 
         # Adding Notes from State file to the exported dataset

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1167,6 +1167,9 @@ def api_export_dataset(project):
         # read the dataset into a ASReview data object
         as_data = read_data(project)
 
+        # Convert -1 to NaN
+        as_data.df["debug_label"] = as_data.df["debug_label"].replace(-1, np.nan)
+
         # Merge labeled labels with as_data.df based on record_id
         merge_cols = ['record_id', 'label']
         as_data.df = as_data.df.merge(labeled[merge_cols], on='record_id', how='left')

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -40,6 +40,7 @@ from asreview.config import DEFAULT_BALANCE_STRATEGY
 from asreview.config import DEFAULT_FEATURE_EXTRACTION
 from asreview.config import DEFAULT_MODEL
 from asreview.config import DEFAULT_QUERY_STRATEGY
+from asreview.config import LABEL_NA
 from asreview.config import PROJECT_MODE_EXPLORE
 from asreview.config import PROJECT_MODE_ORACLE
 from asreview.config import PROJECT_MODE_SIMULATE
@@ -1189,14 +1190,6 @@ def api_export_dataset(project):
         if project.config["mode"] == PROJECT_MODE_ORACLE:
             as_data.df.rename(columns={'label': 'label_included'}, inplace=True)
 
-        def rank_records(record_id):
-            if record_id in export_order:
-                return export_order.index(record_id)
-            return None
-
-        as_data.df['asreview_ranking'] = as_data.df['record_id'].apply(rank_records)
-        as_data.df = as_data.df.set_index('record_id').loc[export_order].reset_index()
-
         # Adding Notes from State file to the exported dataset
         # Check if exported_notes column already exists due to multiple screenings
         screening = 0
@@ -1223,6 +1216,7 @@ def api_export_dataset(project):
 
         as_data.to_file(
             fp=tmp_path_dataset,
+            ranking=export_order,
             writer=writer,
         )
 

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -40,9 +40,9 @@ from asreview.config import DEFAULT_BALANCE_STRATEGY
 from asreview.config import DEFAULT_FEATURE_EXTRACTION
 from asreview.config import DEFAULT_MODEL
 from asreview.config import DEFAULT_QUERY_STRATEGY
+from asreview.config import PROJECT_MODE_EXPLORE
 from asreview.config import PROJECT_MODE_ORACLE
 from asreview.config import PROJECT_MODE_SIMULATE
-from asreview.config import PROJECT_MODE_EXPLORE
 from asreview.data import ASReviewData
 from asreview.data.statistics import n_duplicates
 from asreview.datasets import DatasetManager

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1166,9 +1166,20 @@ def api_export_dataset(project):
         # read the dataset into a ASReview data object
         as_data = read_data(project)
 
-        # Rename 'debug_label' to 'initial_label'
-        if 'debug_label' in as_data.df.columns:
-            as_data.df.rename(columns={'debug_label': 'initial_label'}, inplace=True)
+        # Check project mode and rename columns accordingly for exploration mode
+        if project.config["mode"] == PROJECT_MODE_EXPLORE:
+            # Rename original label column if it exists
+            if 'debug_label' in as_data.df.columns:
+                as_data.df.rename(columns={'debug_label': 'label_included'}, inplace=True)
+    
+            # Rename generated labels column if it exists
+            if 'included' in as_data.df.columns:
+                as_data.df.rename(columns={'included': 'label_validated'}, inplace=True)
+
+        if project.config["mode"] == PROJECT_MODE_SIMULATE:
+            # Rename original label column if it exists
+            if 'debug_label' in as_data.df.columns:
+                as_data.df.rename(columns={'debug_label': 'label_included'}, inplace=True)
 
         # Adding Notes from State file to the exported dataset
         # Check if exported_notes column already exists due to multiple screenings

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1171,7 +1171,7 @@ def api_export_dataset(project):
             # Rename original label column if it exists
             if 'debug_label' in as_data.df.columns:
                 as_data.df.rename(columns={'debug_label': 'label_included'}, inplace=True)
-    
+
             # Rename generated labels column if it exists
             if 'included' in as_data.df.columns:
                 as_data.df.rename(columns={'included': 'label_validated'}, inplace=True)

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1166,6 +1166,10 @@ def api_export_dataset(project):
         # read the dataset into a ASReview data object
         as_data = read_data(project)
 
+        # Rename 'debug_label' to 'initial_label'
+        if 'debug_label' in as_data.df.columns:
+            as_data.df.rename(columns={'debug_label': 'initial_label'}, inplace=True)
+        
         # Adding Notes from State file to the exported dataset
         # Check if exported_notes column already exists due to multiple screenings
         screening = 0

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1169,7 +1169,7 @@ def api_export_dataset(project):
         # Rename 'debug_label' to 'initial_label'
         if 'debug_label' in as_data.df.columns:
             as_data.df.rename(columns={'debug_label': 'initial_label'}, inplace=True)
-        
+
         # Adding Notes from State file to the exported dataset
         # Check if exported_notes column already exists due to multiple screenings
         screening = 0

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -126,7 +126,8 @@ The following variables will be added to your tabular dataset:
   not seen during the screening process.
 - The column titled **asreview_ranking** contains an identifier to
   preserve the rank ordering as described below.
-- The column **Notes** contain any notes you made during screening. 
+- The column **Notes** contain any notes you made during screening.
+- The column **label_validation** is added in the exploration mode and contains the labels you assigned during the screening phase. The labels initially present in the data are stored in the colum **label_included**. 
 
 For RIS files, the labels **ASReview_relevant**, **ASReview_irrelevant**,
 and **ASReview_not_seen** are stored with the `N1` (Notes) tag. In citation

--- a/docs/source/screening.rst
+++ b/docs/source/screening.rst
@@ -63,6 +63,9 @@ displayed on top of the record indicating whether the record has been labeled
 relevant or irrelevant in the dataset. You can make the same labeling
 decision without the need to be the oracle. 
 
+The labels from the initial dataset are stored in the column **label_included**
+and the labels your assigned are stored in the column **label_validation**. 
+
 .. figure:: ../images/project_screening_exploration.png
    :alt: ASReview Screening
 


### PR DESCRIPTION
This pull request modifies column names in exported datasets from ASReview to enhance clarity, based on the project mode:

- Exploration Mode: The column initially containing labeling decisions, internally renamed to 'debug_label', is exported as 'label_included'. A new column, 'label_validated', stores labels made during screening.
- Simulation Mode: Renames 'debug_label' to 'label_included' in the exported dataset.
- Oracle Mode: No changes, as 'debug_label' does not exist in this mode.