### PR TITLE
Add more informative error when loading faulty RIS file

### DIFF
--- a/asreview/io/ris.py
+++ b/asreview/io/ris.py
@@ -15,7 +15,6 @@
 __all__ = ["RISReader", "RISWriter"]
 
 import io
-import logging
 import re
 from urllib.request import urlopen
 
@@ -150,7 +149,6 @@ class RISReader:
         bibliography_file.close()
 
         return entries
-
 
     @classmethod
     def read_data(cls, fp):


### PR DESCRIPTION
Replace encoding errors with more informative errors when there is no encoding issue but a format issue. 

<img width="833" alt="Screenshot 2024-01-05 at 12 16 57" src="https://github.com/asreview/asreview/assets/12981139/4ba8e134-e561-4b25-83ed-40791cca34d6">

Closes #602 
