### PR TITLE
Redesign startup info in command line and add projects path

### DIFF
--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -15,7 +15,6 @@ import argparse
 import logging
 import os
 import socket
-import time
 import webbrowser
 from threading import Timer
 
@@ -23,7 +22,6 @@ import requests
 from gevent.pywsgi import WSGIServer
 
 import asreview as asr
-from asreview import __version__
 from asreview._deprecated import DeprecateAction
 from asreview._deprecated import mark_deprecated_help_strings
 from asreview.project import get_project_path
@@ -48,8 +46,6 @@ def _check_port_in_use(host, port):
 def _open_browser(start_url):
     Timer(1, lambda: webbrowser.open_new(start_url)).start()
 
-    print("\n\n\n\nIf your browser doesn't open. " f"Navigate to {start_url}\n\n\n\n")
-
 
 def _check_for_update():
     """Check if there is an update available."""
@@ -58,28 +54,18 @@ def _check_for_update():
         r = requests.get("https://pypi.org/pypi/asreview/json")
         r.raise_for_status()
         latest_version = r.json()["info"]["version"]
-        if latest_version != __version__ and "+" not in __version__:
-            print(
-                "\n\n\n"
-                f"ASReview LAB version {latest_version} is available. "
-                "Please update using:\n"
-                "pip install --upgrade asreview"
-                "\n\n\n"
-            )
+        if latest_version != asr.__version__ and "+" not in asr.__version__:
+            return True, latest_version
 
-            time.sleep(5)
+        return False, latest_version
     except Exception:
-        print("Could not check for updates.")
+        pass
 
 
 def lab_entry_point(argv):
     parser = _lab_parser()
     mark_deprecated_help_strings(parser)
     args = parser.parse_args(argv)
-
-    # check for update
-    if not args.skip_update_check:
-        _check_for_update()
 
     app = create_app(
         env="production",
@@ -114,7 +100,6 @@ def lab_entry_point(argv):
     port = args.port
     original_port = port
     while _check_port_in_use(args.host, port) is True:
-        old_port = port
         port = int(port) + 1
         if port - original_port >= args.port_retries:
             raise ConnectionError(
@@ -122,7 +107,6 @@ def lab_entry_point(argv):
                 "to launch ASReview LAB. Last port \n"
                 f"was {str(port)}"
             )
-        print(f"Port {old_port} is in use.\n* Trying to start at {port}")
 
     protocol = "https://" if args.certfile and args.keyfile else "http://"
     start_url = f"{protocol}{args.host}:{port}/"
@@ -132,10 +116,45 @@ def lab_entry_point(argv):
         ssl_args = {"keyfile": args.keyfile, "certfile": args.certfile}
 
     server = WSGIServer((args.host, port), app, **ssl_args)
-    print(f"Serving ASReview LAB at {start_url}")
 
+    print("\n\nASReview LAB is starting up \u001b[31m<3\u001b[0m\n\n")
+    print("\033[1mInformation about your application\033[0m\n")
+
+    host_str = f"\033[1mURL:\033[0m {start_url}"
+    if original_port != port:
+        host_str += (
+            f" \u001b[48;5;11m[Port {original_port} was already in use]\u001b[0m"
+        )
+
+    version_str = f"\033[1mVersion:\033[0m {asr.__version__}"
+    update_available = False
+    if not args.skip_update_check:
+        update_available, latest_version = _check_for_update()
+        if update_available:
+            version_str += (
+                " \u001b[48;5;202m[Update available"
+                f": {asr.__version__} -> {latest_version}]\u001b[0m"
+            )
+
+    print(host_str)
+    print(version_str)
+    print(f"\033[1mLocal projects folder:\033[0m {asr.asreview_path()}")
+
+    if update_available:
+        print(
+            "\n\n\033[1mUpdate for ASReview LAB is available!\033[0m\n"
+            "Run `pip install --upgrade asreview` to update."
+        )
+
+    print(
+        "\n\nMake regular backups of the ASReview"
+        " projects folder to prevent data loss."
+    )
     if not args.no_browser:
         _open_browser(start_url)
+        print(f"If your browser doesn't open, navigate to {start_url}.\n\n\n")
+
+    print("Press Ctrl+C to exit.\n\n")
 
     try:
         server.serve_forever()

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -20,6 +20,7 @@ from threading import Timer
 
 import requests
 from gevent.pywsgi import WSGIServer
+from rich.console import Console
 
 import asreview as asr
 from asreview._deprecated import DeprecateAction
@@ -117,49 +118,49 @@ def lab_entry_point(argv):
 
     server = WSGIServer((args.host, port), app, **ssl_args)
 
-    print("\n\nASReview LAB is starting up \u001b[31m<3\u001b[0m\n\n")
-    print("\033[1mInformation about your application\033[0m\n")
+    console = Console()
 
-    host_str = f"\033[1mURL:\033[0m {start_url}"
+    console.print("\n\nASReview LAB is starting up [red]<3[/red]\n\n")
+    console.print("[bold]Information about your application[/bold]\n")
+
+    host_str = f"[bold]URL:[/bold] {start_url}"
     if original_port != port:
-        host_str += (
-            f" \u001b[48;5;11m[Port {original_port} was already in use]\u001b[0m"
-        )
+        host_str += f" [yellow][Port {original_port} was already in use][/yellow]"
 
-    version_str = f"\033[1mVersion:\033[0m {asr.__version__}"
+    version_str = f"[bold]Version:[/bold] {asr.__version__}"
     update_available = False
     if not args.skip_update_check:
         update_available, latest_version = _check_for_update()
-        if update_available:
+        if not update_available:
             version_str += (
-                " \u001b[48;5;202m[Update available"
-                f": {asr.__version__} -> {latest_version}]\u001b[0m"
+                " [red][Update available"
+                f": {asr.__version__} -> {latest_version}][/red]"
             )
 
-    print(host_str)
-    print(version_str)
-    print(f"\033[1mLocal projects folder:\033[0m {asr.asreview_path()}")
+    console.print(host_str)
+    console.print(version_str, highlight=False)
+    console.print(f"[bold]Local projects folder:[/bold] {asr.asreview_path()}")
 
     if update_available:
-        print(
-            "\n\n\033[1mUpdate for ASReview LAB is available!\033[0m\n"
+        console.print(
+            "\n\n[bold]Update for ASReview LAB is available![/bold]\n"
             "Run `pip install --upgrade asreview` to update."
         )
 
-    print(
+    console.print(
         "\n\nMake regular backups of the ASReview"
         " projects folder to prevent data loss."
     )
     if not args.no_browser:
         _open_browser(start_url)
-        print(f"If your browser doesn't open, navigate to {start_url}.\n\n\n")
+        console.print(f"If your browser doesn't open, navigate to {start_url}.\n\n\n")
 
-    print("Press Ctrl+C to exit.\n\n")
+    console.print("Press [bold]Ctrl+C[/bold] to exit.\n\n")
 
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        print("\n\nShutting down server\n\n")
+        console.print("\n\nShutting down server\n\n")
 
 
 def _lab_parser():

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -153,7 +153,7 @@ def lab_entry_point(argv):
     )
     if not args.no_browser:
         _open_browser(start_url)
-        console.print(f"If your browser doesn't open, navigate to {start_url}.\n\n\n")
+        console.print(f"\nIf your browser doesn't open, navigate to {start_url}.\n\n\n")
 
     console.print("Press [bold]Ctrl+C[/bold] to exit.\n\n")
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ REQUIRES = [
     "Flask-SQLAlchemy>=3.0.2",
     "requests",
     "tqdm",
+    "rich",
     "gevent>=20",
     "datahugger>=0.2",
     "synergy_dataset",


### PR DESCRIPTION
<img width="734" alt="Screenshot 2024-01-26 at 11 58 22" src="https://github.com/asreview/asreview/assets/12981139/92a0cdc9-725f-450a-bb61-f052de935332">

- New table for relevant info
- Add projects location
- Add backup instructions

The docs and discussion platform need to be updated around the release of this feature. https://github.com/asreview/asreview/discussions/1203

This PR displays a non-default location for the projects, which will be part of another PR. The location will be more platform-dependent in that version (but technically more correct and better backup functionalities). 

