### PR TITLE
Change default production WSGI server by waitress and add support for other WSGI servers

### DIFF
--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -62,6 +62,10 @@ def create_app(config_path=None):
     app.config.from_prefixed_env()  # deprecated, remove in version 2.0
     app.config.from_prefixed_env("ASREVIEW_LAB")
 
+    # deprecated, remove in version 2.0
+    if app.config.get(["CONFIGFILE"], None):
+        app.config["CONFIG_PATH"] = app.config["CONFIGFILE"]
+
     # load config from file
     if config_fp := (config_path or app.config.get("CONFIG_PATH", None)):
         app.config.from_file(Path(config_fp).absolute(), load=tomllib.load, text=False)

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -88,6 +88,7 @@ def create_app(config_path=None):
 
         if not app.config.get("SQLALCHEMY_DATABASE_URI", None):
             env = "development" if app.debug else "production"
+            env = "test" if app.testing else env
             uri = os.path.join(asreview_path(), f"asreview.{env}.sqlite")
             app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{uri}"
 

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -63,7 +63,7 @@ def create_app(config_path=None):
     app.config.from_prefixed_env("ASREVIEW_LAB")
 
     # deprecated, remove in version 2.0
-    if app.config.get(["CONFIGFILE"], None):
+    if app.config.get("CONFIGFILE", None):
         app.config["CONFIG_PATH"] = app.config["CONFIGFILE"]
 
     # load config from file

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import os
-import warnings
 from pathlib import Path
 
 try:

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -41,7 +41,7 @@ from asreview.webapp.authentication.models import User
 from asreview.webapp.authentication.oauth_handler import OAuthHandler
 
 
-def create_app():
+def create_app(config_path=None):
     """Create a new ASReview webapp.
 
     For use with WSGI servers, such as gunicorn:
@@ -65,7 +65,7 @@ def create_app():
     app.config.from_prefixed_env("ASREVIEW_LAB")
 
     # load config from file
-    if config_fp := app.config.get("CONFIG_PATH", None):
+    if config_fp := (config_path or app.config.get("CONFIG_PATH", None)):
         app.config.from_file(Path(config_fp).absolute(), load=tomllib.load, text=False)
 
     # if there are no cors and config is in debug mode, add default cors
@@ -190,5 +190,4 @@ def create_app():
 
         return jsonify(response)
 
-    print(app.config)
     return app

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -270,10 +270,9 @@ def _lab_parser():
     )
 
     parser.add_argument(
-        "--config", "--flask-configfile",
-        dest="config_path",
+        "--config-path", "--flask-configfile",
         type=Path,
-        help="Full path to a TOML file containing ASReview parameters"
+        help="Path to a TOML file containing ASReview parameters"
         "for authentication.",
     )
 

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -37,8 +37,8 @@ except ImportError:
     WSGIServer = None
 
 # Host name
-HOST_NAME = os.getenv("ASREVIEW_HOST", "localhost")
-PORT_NUMBER = os.getenv("ASREVIEW_PORT", 5000)
+HOST_NAME = os.getenv("ASREVIEW_LAB_HOST", "localhost")
+PORT_NUMBER = os.getenv("ASREVIEW_LAB_PORT", 5000)
 
 
 def _deprecated_dev_mode():

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -168,7 +168,7 @@ def lab_entry_point(argv):
     # deprecated, remove in version 2.0
     if args.certfile or args.keyfile:
         print(
-            "SSL/TLS is deprecated for the built-in server and will be removed. "
+            "SSL/TLS is deprecated for the built-in server and will be removed in version 2. "
             "Use a dedicated WSGI server (e.g. gUnicorn) instead to make use of TLS. "
             "See https://flask.palletsprojects.com/en/3.0.x/deploying/\n\n"
         )

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -17,8 +17,8 @@ import os
 import socket
 import time
 import webbrowser
-from threading import Timer
 from pathlib import Path
+from threading import Timer
 
 import requests
 import waitress
@@ -104,11 +104,7 @@ def lab_entry_point(argv):
     Two examples of how to set the secret key for secure sessions:
     >>> ASREVIEW_LAB_SECRET_KEY="my-secret" asreview lab
     >>> asreview lab --secret-key "my-secret"
-
-
     """
-
-
     # check deprecated dev mode
     _deprecated_dev_mode()
 
@@ -213,7 +209,7 @@ def _lab_parser():
     # parse arguments if available
     parser = argparse.ArgumentParser(
         prog="lab",
-        description="""ASReview LAB - Active learning for Systematic Reviews.""",  # noqa
+        description="ASReview LAB - Active learning for Systematic Reviews.",
         formatter_class=argparse.RawTextHelpFormatter,
     )
 

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -164,7 +164,7 @@ def lab_entry_point(argv):
     # deprecated, remove in version 2.0
     if args.certfile or args.keyfile:
         print(
-            "SSL/TLS is deprecated for the built-in server and will be removed in version 2. "
+            "SSL/TLS is deprecated for the built-in server and will be removed in v2"
             "Use a dedicated WSGI server (e.g. gUnicorn) instead to make use of TLS. "
             "See https://flask.palletsprojects.com/en/3.0.x/deploying/\n\n"
         )
@@ -270,10 +270,10 @@ def _lab_parser():
     )
 
     parser.add_argument(
-        "--config-path", "--flask-configfile",
+        "--config-path",
+        "--flask-configfile",
         type=Path,
-        help="Path to a TOML file containing ASReview parameters"
-        "for authentication.",
+        help="Path to a TOML file containing ASReview parameters" "for authentication.",
     )
 
     parser.add_argument(

--- a/asreview/webapp/tests/conftest.py
+++ b/asreview/webapp/tests/conftest.py
@@ -55,7 +55,8 @@ def _get_app(app_type="auth-basic", path=None):
     else:
         raise ValueError(f"Unknown config {app_type}")
     # create app
-    app = create_app(env="test", config_file=config_path)
+    app = create_app(config_path=config_path)
+    app.config["TESTING"] = True
     # and return it
     return app
 

--- a/docs/source/server_configuration.rst
+++ b/docs/source/server_configuration.rst
@@ -151,43 +151,40 @@ the TOML file.
 Full configuration
 ~~~~~~~~~~~~~~~~~~~
 
+ASReview LAB settings
 
-# ASReview LAB settings
+- `ASREVIEW_LAB_CONFIG_PATH` - Path to ASReview LAB config TOML file with ASReview LAB configuration.
+- `ASRVIEW_LAB_*` - All ASReview LAB settings are prefixed with `ASREVIEW_LAB_`. They include all settings from https://flask.palletsprojects.com/en/3.0.x/config/#builtin-configuration-values. Most important the secret key for ASReview LAB `ASREVIEW_LAB_SECRET_KEY`.
 
-ASREVIEW_LAB_CONFIG_PATH - Path to ASReview LAB config TOML file with ASReview LAB configuration.
+Login configuration
 
-ASRVIEW_LAB_* - All ASReview LAB settings are prefixed with ASREVIEW_LAB_. They include all settings from https://flask.palletsprojects.com/en/3.0.x/config/#builtin-configuration-values. Most important the secret key for ASReview LAB ASREVIEW_LAB_SECRET_KEY
+- `ASREVIEW_LAB_LOGIN_DISABLED` - If true, login is disabled and no password is required to use ASReview LAB.
+- `ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI` - Database URI for ASReview LAB.
 
-## Login configuration
+Account creation configuration
+- `ASRVIEW_LAB_ALLOW_ACCOUNT_CREATION` - If true, account creation is enabled.
+- `ASREVIEW_LAB_SECURITY_PASSWORD_SALT` - Salt for password hashing.
+- `ASREVIEW_LAB_RE_CAPTCHA_V3` - If true, reCAPTCHA v3 is enabled for account creation.
 
-ASREVIEW_LAB_LOGIN_DISABLED - If true, login is disabled and no password is required to use ASReview LAB.
-ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI - Database URI for ASReview LAB.
+OAuth configuration
+- `ASREVIEW_LAB_OATH` - OAuth configuration for ASReview LAB. It is a dictionary with the following keys: `GitHub`, `Orcid` and `Google`. Each of these keys is a dictionary with the following keys: `AUTHORIZATION_URL`, `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET` and `SCOPE`.
 
-### Account creation configuration
-ASRVIEW_LAB_ALLOW_ACCOUNT_CREATION -
-ASREVIEW_LAB_SECURITY_PASSWORD_SALT - Salt for password hashing.
-ASREVIEW_LAB_RE_CAPTCHA_V3 -
+Cookie configuration
 
-### OAuth configuration
-ASREVIEW_LAB_OATH -
+- `ASREVIEW_LAB_REMEMBER_COOKIE_*` - Login related config from https://flask-login.readthedocs.io/en/latest/#cookie-settings.
 
-### Cookie configuration
+Mail configuration
 
-ASREVIEW_LAB_REMEMBER_COOKIE_* - Login related config from https://flask-login.readthedocs.io/en/latest/#cookie-settings.
+- `ASRVIEW_LAB_EMAIL_VERIFICATION` - If true, email verification is required for new accounts.
+- `ASREVIEW_LAB_MAIL_*` - Mail related config from https://pythonhosted.org/Flask-Mail/#configuring-flask-mail
 
-### Mail configuration
+Teams configuration
 
-ASRVIEW_LAB_EMAIL_VERIFICATION -
+- `ASREVIEW_LAB_ALLOW_TEAMS`` - If true, teams are enabled and users can create teams.
 
-ASREVIEW_LAB_MAIL_* - Mail related config from https://pythonhosted.org/Flask-Mail/#configuring-flask-mail
+CORS configuration
 
-## Teams configuration
-
-ASREVIEW_LAB_ALLOW_TEAMS - If true, teams are enabled and users can create teams.
-
-## CORS configuration
-
-ASREVIEW_LAB_CORS_* - Cors config avialable in https://flask-cors.readthedocs.io/en/latest/configuration.html except from ASREVIEW_LAB_CORS_SUPPORTS_CREDENTIALS which is always true. ASREVIEW_LAB_CORS_ORIGINS is used to link backend to frontend on different host and port.
+- `ASREVIEW_LAB_CORS_*`` - Cors config avialable in https://flask-cors.readthedocs.io/en/latest/configuration.html except from ASREVIEW_LAB_CORS_SUPPORTS_CREDENTIALS which is always true. ASREVIEW_LAB_CORS_ORIGINS is used to link backend to frontend on different host and port.
 
 
 PostgreSQL database

--- a/docs/source/server_configuration.rst
+++ b/docs/source/server_configuration.rst
@@ -99,11 +99,11 @@ secure way (https).
             SCOPE = "profile email"
 
 Store the TOML file on the server and start the ASReview application from the
-CLI with the ``--flask-configfile`` parameter:
+CLI with the ``--config-path`` parameter:
 
 .. code:: bash
 
-        asreview lab --flask-configfile=<path-to-TOML-config-file>
+        asreview lab --config-path=<path-to-TOML-config-file>
 
 A number of the keys in the TOML file are standard Flask parameters. The keys
 that are specific for authenticating ASReview are summarized below:
@@ -146,14 +146,6 @@ is used to configure the database connection. The default value is
 use the SQLite database in the ASReview projects folder. If you would like to
 use a different database, you can add the ``SQLALCHEMY_DATABASE_URI`` key to
 the TOML file.
-
-Set the ``SQLALCHEMY_DATABASE_URI`` environment variable to the path of the
-database. For example, to use the SQLite database in the ASReview projects
-folder:
-
-.. code-block::  bash
-
-    FLASK_SQLALCHEMY_DATABASE_URI = "sqlite:///asreview.production.sqlite"
 
 
 Full configuration

--- a/docs/source/server_configuration.rst
+++ b/docs/source/server_configuration.rst
@@ -155,6 +155,49 @@ folder:
 
     FLASK_SQLALCHEMY_DATABASE_URI = "sqlite:///asreview.production.sqlite"
 
+
+Full configuration
+~~~~~~~~~~~~~~~~~~~
+
+
+# ASReview LAB settings
+
+ASREVIEW_LAB_CONFIG_PATH - Path to ASReview LAB config TOML file with ASReview LAB configuration.
+
+ASRVIEW_LAB_* - All ASReview LAB settings are prefixed with ASREVIEW_LAB_. They include all settings from https://flask.palletsprojects.com/en/3.0.x/config/#builtin-configuration-values. Most important the secret key for ASReview LAB ASREVIEW_LAB_SECRET_KEY
+
+## Login configuration
+
+ASREVIEW_LAB_LOGIN_DISABLED - If true, login is disabled and no password is required to use ASReview LAB.
+ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI - Database URI for ASReview LAB.
+
+### Account creation configuration
+ASRVIEW_LAB_ALLOW_ACCOUNT_CREATION -
+ASREVIEW_LAB_SECURITY_PASSWORD_SALT - Salt for password hashing.
+ASREVIEW_LAB_RE_CAPTCHA_V3 -
+
+### OAuth configuration
+ASREVIEW_LAB_OATH -
+
+### Cookie configuration
+
+ASREVIEW_LAB_REMEMBER_COOKIE_* - Login related config from https://flask-login.readthedocs.io/en/latest/#cookie-settings.
+
+### Mail configuration
+
+ASRVIEW_LAB_EMAIL_VERIFICATION -
+
+ASREVIEW_LAB_MAIL_* - Mail related config from https://pythonhosted.org/Flask-Mail/#configuring-flask-mail
+
+## Teams configuration
+
+ASREVIEW_LAB_ALLOW_TEAMS - If true, teams are enabled and users can create teams.
+
+## CORS configuration
+
+ASREVIEW_LAB_CORS_* - Cors config avialable in https://flask-cors.readthedocs.io/en/latest/configuration.html except from ASREVIEW_LAB_CORS_SUPPORTS_CREDENTIALS which is always true. ASREVIEW_LAB_CORS_ORIGINS is used to link backend to frontend on different host and port.
+
+
 PostgreSQL database
 ~~~~~~~~~~~~~~~~~~~
 
@@ -176,7 +219,7 @@ and an extra step in the configuration file:
 Create authentication database and tables with auth-tool
 
 
-Server administrators can create a database for authentication with the 
+Server administrators can create a database for authentication with the
 ``auth-tool`` sub command of the ASReview application:
 
 .. code:: bash

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -50,19 +50,19 @@ available commands in ASReview LAB, type :code:`asreview lab --help`.
 
 .. option:: --enable-auth ENABLE_AUTH
 
-	Enable authentication.
+	Enable authentication. Deprecated.
 
 .. option:: --secret-key SECRET_KEY
 
-	Secret key for authentication.
+	Secret key for authentication. Deprecated.
 
 .. option:: --salt SALT
 
 	When using authentication, a salt code is needed for hasing passwords.
 
-.. option:: --flask-configfile FLASK_CONFIGFILE
+.. option:: --config-path CONFIG_PATH
 
-    Full path to a JSON file containing Flask parameters for authentication.
+    Path to a TOML file containing ASReview parameters.
 
 .. option:: --no-browser NO_BROWSER
 
@@ -149,4 +149,3 @@ For example, start ASReview LAB on port 5001:
 .. code:: bash
 
 	asreview lab --port 5001
-

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ REQUIRES = [
     "Flask-SQLAlchemy>=3.0.2",
     "requests",
     "tqdm",
-    "gevent>=20",
+    "waitress",
     "datahugger>=0.2",
     "synergy_dataset",
     "sqlalchemy-utils",


### PR DESCRIPTION
This PR introduces various changes to the Flask production server and configuration. Changes should resolve various reported issues and improve the extensibility of the review-server-stack. Although we aim to avoid breaking changes, we can not fully guarantee that current ASReview LAB Server users are affected by this. If you face issues, please let us know. 

We aim to create a version 1.6 release for these changes. 

## Changelog

- Replace default event server by full Python waitress server
- Resolve installation problems and segfault crashes for MacOS users. 
- Make use of `ASREVIEW_LAB` prefix for all environment variables, FLASK environment variables included. You can still use FLASK prefixed environment variables in version 1.x. 
- Remove arguments from `create_app()`, only argument is `config_path` (points to ASReview configuration file).
- Make `create_app()` authenticated by default
- Remove `env` from `create_app()`. Setting 'development' or 'testing' now via `app.debug` and `app.testing`. 
- Add option to use any production WSGI server to server the app. See Flask https://flask.palletsprojects.com/en/3.0.x/tutorial/deploy/ for info. Example: `gunicorn -w 4 -b "127.0.0.1:5006" "asreview.webapp.app:create_app()"`
- Deprecate `--certfile` and `-keyfile` options. They will remain available in the 1.x series. For TLS support, use for example gUnicorn with certfile and keyfile options.

## Breaking changes

- When you rely heavily on environment variables or the ASReview/FLASK config file to configure ASReview, please look at the new variable overview in the documentation. We tried to keep many of the variables working, but we might have missed something. Also start using the `ASREVIEW_LAB` prefix. 
- Developers will face the authenticated version of ASReview by default. You can change this with `ASREVIEW_LAB_LOGIN_DISABLED=true flask run --debug`. I will update the VSCode task according to this. 
