### PR TITLE
Add support for customizable API URL in production without rebuilding

### DIFF
--- a/asreview/webapp/.env.production
+++ b/asreview/webapp/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL="{{ api_url }}"

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -143,7 +143,7 @@ def create_app(config_path=None):
     @app.route("/forgot_password", methods=["GET"])
     @app.route("/reset_password", methods=["GET"])
     def index():
-        return render_template("index.html")
+        return render_template("index.html", api_url=app.config.get("API_URL", "/"))
 
     @app.route("/favicon.ico")
     def send_favicon():

--- a/asreview/webapp/public/index.html
+++ b/asreview/webapp/public/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Smart software for systematic reviews." />
+    <script type="text/javascript">
+        window.api_url = "%REACT_APP_API_URL%";
+    </script>
     <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
     <title>ASReview LAB - A tool for AI-assisted systematic reviews</title>
   </head>

--- a/asreview/webapp/src/api/BaseAPI.js
+++ b/asreview/webapp/src/api/BaseAPI.js
@@ -1,10 +1,10 @@
 import { axiosErrorHandler } from "./axiosErrorHandler";
-import { base_url } from "../globals.js";
 import axios from "axios";
 
 class BaseAPI {
   static boot = ({ queryKey }) => {
-    const url = base_url + `boot`;
+    const url = window.api_url + `boot`;
+
     return new Promise((resolve, reject) => {
       axios
         .get(url)

--- a/asreview/webapp/src/globals.js
+++ b/asreview/webapp/src/globals.js
@@ -4,16 +4,10 @@ import { setProject } from "./redux/actions";
 import ASReviewLAB_black from "./images/asreview_sub_logo_lab_black_transparent.svg";
 import ASReviewLAB_white from "./images/asreview_sub_logo_lab_white_transparent.svg";
 
-// URL of backend is configured in an .env file. By default it's 
-// the same as the front-end URL.
-let b_url = "/";
-if (Boolean(process.env.REACT_APP_API_URL)) {
-  b_url = process.env.REACT_APP_API_URL;
-}
-export const base_url = b_url;
-export const api_url = base_url + "api/";
-export const auth_url = base_url + "auth/";
-export const collab_url = base_url + "team/";
+export const base_url = window.api_url;
+export const api_url = window.api_url + "api/";
+export const auth_url = window.api_url + "auth/";
+export const collab_url = window.api_url + "team/";
 
 export const asreviewURL = "https://asreview.nl/";
 export const donateURL = "https://asreview.nl/donate";


### PR DESCRIPTION
Example:

Process 1
```
ASREVIEW_LAB_PORT=5008 asreview lab
```

Process 2

```
ASREVIEW_LAB_API_URL="http://localhost:5008/" asreview lab
```

Now, process 1 makes use of process 2 for backend calls. 
