### PR TITLE
Improve passwordmanager and autocomplete features for account creation

### DIFF
--- a/asreview/webapp/src/Components/SignInForm.js
+++ b/asreview/webapp/src/Components/SignInForm.js
@@ -109,6 +109,7 @@ const SignInForm = (props) => {
           variant="outlined"
           fullWidth
           autoFocus
+          autoComplete="email"
         />
         <FormControl>
           <TextField
@@ -120,6 +121,7 @@ const SignInForm = (props) => {
             variant="outlined"
             fullWidth
             type={returnType()}
+            autoComplete="current-password"
           />
           <FormControlLabel
             control={

--- a/asreview/webapp/src/Components/SignUpForm.js
+++ b/asreview/webapp/src/Components/SignUpForm.js
@@ -15,6 +15,7 @@ import {
   Stack,
   TextField,
   Typography,
+  Divider,
 } from "@mui/material";
 
 import { InlineErrorHandler } from ".";
@@ -82,11 +83,7 @@ const SignUpForm = (props) => {
   // be called when the form is submitted
   const navigate = useNavigate();
 
-  const [showPassword, toggleShowPassword] = useToggle();
-
-  const returnType = () => {
-    return !showPassword ? "password" : "text";
-  };
+  const [showPassword, toggleShowPassword] = useToggle(false);
 
   const initialValues = {
     email: "",
@@ -146,7 +143,6 @@ const SignUpForm = (props) => {
                   spacing={3}
                   component="form"
                   noValidate
-                  autoComplete="off"
                 >
                   <TextField
                     id="email"
@@ -154,6 +150,7 @@ const SignUpForm = (props) => {
                     label="Email"
                     size="small"
                     type="email"
+                    autoComplete="email"
                     fullWidth
                     value={formik.values.email}
                     onChange={formik.handleChange}
@@ -161,32 +158,6 @@ const SignUpForm = (props) => {
                   />
                   {formik.touched.email && formik.errors.email ? (
                     <FHT error={true}>{formik.errors.email}</FHT>
-                  ) : null}
-                  <TextField
-                    id="name"
-                    name="name"
-                    label="Full name"
-                    size="small"
-                    fullWidth
-                    value={formik.values.name}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
-                  />
-                  {formik.touched.name && formik.errors.name ? (
-                    <FHT error={true}>{formik.errors.name}</FHT>
-                  ) : null}
-                  <TextField
-                    id="affiliation"
-                    label="Affiliation"
-                    size="small"
-                    name="affiliation"
-                    fullWidth
-                    value={formik.values.affiliation}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
-                  />
-                  {formik.touched.affiliation && formik.errors.affiliation ? (
-                    <FHT error={true}>{formik.errors.affiliation}</FHT>
                   ) : null}
                   <FormControl>
                     <Stack direction="row" spacing={2}>
@@ -196,7 +167,7 @@ const SignUpForm = (props) => {
                         size="small"
                         autoComplete="new-password"
                         fullWidth
-                        type={returnType()}
+                        type={showPassword ? "text" : "password"}
                         value={formik.values.password}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
@@ -205,8 +176,9 @@ const SignUpForm = (props) => {
                         id="confirmPassword"
                         label="Confirm Password"
                         size="small"
+                        autoComplete="new-password"
                         fullWidth
-                        type={returnType()}
+                        type={showPassword ? "text" : "password"}
                         onKeyDown={handleEnterKey}
                         value={formik.values.confirmPassword}
                         onChange={formik.handleChange}
@@ -254,7 +226,35 @@ const SignUpForm = (props) => {
                     )}
                   </FormControl>
                   {isError && <InlineErrorHandler message={error.message} />}
-
+                  <Divider />
+                  <TextField
+                    id="name"
+                    name="name"
+                    label="Full name"
+                    size="small"
+                    autoComplete="name"
+                    fullWidth
+                    value={formik.values.name}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                  />
+                  {formik.touched.name && formik.errors.name ? (
+                    <FHT error={true}>{formik.errors.name}</FHT>
+                  ) : null}
+                  <TextField
+                    id="affiliation"
+                    label="Affiliation"
+                    size="small"
+                    name="affiliation"
+                    autoComplete="organization"
+                    fullWidth
+                    value={formik.values.affiliation}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                  />
+                  {formik.touched.affiliation && formik.errors.affiliation ? (
+                    <FHT error={true}>{formik.errors.affiliation}</FHT>
+                  ) : null}
                   <Stack className={classes.button} direction="row">
                     <Button
                       id="sign-in"

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -129,10 +129,22 @@ const ProfilePage = (props) => {
   const renderPasswordFields = (formik) => {
     return (
       <>
-        <Divider />
         <FormControl>
           <Stack direction="column" spacing={2}>
-            <Typography variant="h6">Change Password</Typography>
+            <Typography variant="h6">Change email & password</Typography>
+            <TextField
+              id="email"
+              label="Email"
+              size="small"
+              fullWidth
+              value={formik.values.email}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              autoComplete="off"
+            />
+            {formik.touched.email && formik.errors.email ? (
+              <FHT error={true}>{formik.errors.email}</FHT>
+            ) : null}
             <TextField
               id="oldPassword"
               label="Old Password"
@@ -142,7 +154,7 @@ const ProfilePage = (props) => {
               value={formik.values.oldPassword}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              autoComplete="off"
+              autoComplete="current-password"
             />
             <TextField
               id="newPassword"
@@ -155,6 +167,7 @@ const ProfilePage = (props) => {
               onBlur={formik.handleBlur}
               style={{ opacity: passwordFieldOpacity() }}
               disabled={oldPasswordHasValue()}
+              autoComplete="new-password"
             />
             <TextField
               id="confirmPassword"
@@ -167,6 +180,7 @@ const ProfilePage = (props) => {
               onBlur={formik.handleBlur}
               style={{ opacity: passwordFieldOpacity() }}
               disabled={oldPasswordHasValue()}
+              autoComplete="new-password"
             />
           </Stack>
         </FormControl>
@@ -188,6 +202,7 @@ const ProfilePage = (props) => {
             label="Show passwords"
           />
         </FormControl>
+        <Divider />
       </>
     );
   };
@@ -237,19 +252,6 @@ const ProfilePage = (props) => {
                 <Typography variant="h6">User data</Typography>
               )}
               <TextField
-                autoFocus
-                id="email"
-                label="Email"
-                size="small"
-                fullWidth
-                value={formik.values.email}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-              />
-              {formik.touched.email && formik.errors.email ? (
-                <FHT error={true}>{formik.errors.email}</FHT>
-              ) : null}
-              <TextField
                 id="name"
                 label="Full name"
                 size="small"
@@ -257,6 +259,7 @@ const ProfilePage = (props) => {
                 value={formik.values.name}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
+                autoComplete="off"
               />
               {formik.touched.name && formik.errors.name ? (
                 <FHT error={true}>{formik.errors.name}</FHT>
@@ -269,6 +272,7 @@ const ProfilePage = (props) => {
                 value={formik.values.affiliation}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
+                autoComplete="off"
               />
               {formik.touched.affiliation && formik.errors.affiliation ? (
                 <FHT error={true}>{formik.errors.affiliation}</FHT>


### PR DESCRIPTION
Password managers and browsers messed up with saving the right username and password. This PR resolves these problems to some extend. It should be easier to create accounts and update your profile. 

<img width="547" alt="Screenshot 2024-03-18 at 11 16 06" src="https://github.com/asreview/asreview/assets/12981139/27c3873e-bfeb-4676-bba1-f6e0408114a3">

Profile page

<img width="956" alt="Screenshot 2024-03-18 at 11 15 34" src="https://github.com/asreview/asreview/assets/12981139/106b7e3c-1f11-4a3a-84e3-02524b7756bc">
