### PR TITLE
Add the OneHot encoder

### DIFF
--- a/asreview/models/classifiers/nb.py
+++ b/asreview/models/classifiers/nb.py
@@ -25,7 +25,8 @@ class NaiveBayesClassifier(BaseTrainClassifier):
     """Naive Bayes classifier (``nb``).
 
     Naive Bayes classifier. Only works in combination with the
-    :class:`asreview.models.feature_extraction.Tfidf` feature extraction model.
+    :class:`asreview.models.feature_extraction.Tfidf` or the
+    :class:`asreview.models.feature_extraction.OneHot` feature extraction model.
     Though relatively simplistic, seems to work quite well on a wide range of
     datasets.
 

--- a/asreview/models/feature_extraction/__init__.py
+++ b/asreview/models/feature_extraction/__init__.py
@@ -14,12 +14,14 @@
 
 __all__ = [
     "Tfidf",
+    "OneHot",
     "get_feature_class",
     "get_feature_model",
     "list_feature_extraction",
 ]
 
 from asreview.models.feature_extraction.tfidf import Tfidf
+from asreview.models.feature_extraction.onehot import OneHot
 from asreview.models.feature_extraction.utils import get_feature_class
 from asreview.models.feature_extraction.utils import get_feature_model
 from asreview.models.feature_extraction.utils import list_feature_extraction

--- a/asreview/models/feature_extraction/onehot.py
+++ b/asreview/models/feature_extraction/onehot.py
@@ -1,0 +1,71 @@
+# Copyright 2019-2022 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = ["OneHot"]
+
+from sklearn.feature_extraction.text import CountVectorizer
+
+from asreview.models.feature_extraction.base import BaseFeatureExtraction
+
+
+class OneHot(BaseFeatureExtraction):
+    """OneHot feature extraction technique (``onehot``).
+
+    Use the standard OneHot feature extraction technique from `SKLearn
+    <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`__.
+    
+    Arguments
+    ---------
+    lowercase: bool
+        Convert all characters to lowercase before tokenizing.
+    max_df: float
+        When building the vocabulary ignore terms that have a document
+        frequency strictly higher than the given threshold.
+    min_df: int
+        When building the vocabulary ignore terms that have a document
+        frequency strictly lower than the given threshold.
+        If float, the parameter represents a proportion of documents, integer
+        absolute counts.
+    """
+
+
+    name = "onehot"
+    label = "OneHot"
+
+    def __init__(self, *args, lowercase=True, max_df=0.9, min_df=5, **kwargs):
+        """Initialize onehot class."""
+        super().__init__(*args, **kwargs)
+        self.lowercase = lowercase
+        self.max_df = max_df
+        self.min_df = min_df
+
+    @property
+    def _model(self):
+        if not hasattr(self, "CV"):
+            self.CV = CountVectorizer(binary=True,  # One-hot encoding, not counts.
+                                      lowercase=self.lowercase,
+                                      max_df=self.max_df,
+                                      min_df=self.min_df,
+                                      ngram_range=(1, 3)
+                                      )
+        return self.CV
+
+    def fit(self, texts):
+        """Fit the model to the texts."""
+        self._model.fit(texts)
+
+    def transform(self, texts):
+        """Transform texts into one-hot encoded features."""
+        X = self._model.transform(texts)
+        return X

--- a/asreview/models/feature_extraction/utils.py
+++ b/asreview/models/feature_extraction/utils.py
@@ -35,7 +35,7 @@ def get_feature_class(name):
     Arguments
     ---------
     name: str
-        Name of the feature model, e.g. 'doc2vec', 'tfidf' or 'embedding-lstm'.
+        Name of the feature model, e.g. 'tfidf' or 'onehot'.
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ logistic = "asreview.models.classifiers:LogisticClassifier"
 
 [project.entry-points."asreview.models.feature_extraction"]
 tfidf = "asreview.models.feature_extraction:Tfidf"
+onehot = "asreview.models.feature_extraction:OneHot"
 
 [project.entry-points."asreview.models.balance"]
 simple = "asreview.models.balance:SimpleBalance"

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -46,4 +46,4 @@ def test_features(feature_extraction, split_ta):
 
 
 def test_feature_general():
-    assert len(list_feature_extraction()) == 1
+    assert len(list_feature_extraction()) == 2

--- a/tests/test_models.sh
+++ b/tests/test_models.sh
@@ -33,7 +33,7 @@ done
 
 
 
-FEATURE_STRATEGIES=('tfidf')
+FEATURE_STRATEGIES=('tfidf' 'onehot')
 # FEATURE_STRATEGIES=('doc2vec' 'embedding-idf' 'embedding-lstm' 'sbert' 'tfidf')
 
 for fs in "${FEATURE_STRATEGIES[@]}"


### PR DESCRIPTION
By setting the countvectorizer to binary, we effectively have a OneHot encoder.