### PR TITLE
Unify password validation, fix auto-complete issues and made fields 'required'

### DIFF
--- a/asreview/webapp/src/Components/ResetPassword.js
+++ b/asreview/webapp/src/Components/ResetPassword.js
@@ -18,7 +18,11 @@ import { InlineErrorHandler } from ".";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { styled } from "@mui/material/styles";
 import AuthAPI from "../api/AuthAPI";
-import { WordmarkState } from "../globals";
+import {
+  WordmarkState,
+  passwordRequirements,
+  passwordValidation
+} from "../globals";
 import { useToggle } from "../hooks/useToggle";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -68,15 +72,13 @@ const Root = styled("div")(({ theme }) => ({
 
 // VALIDATION SCHEMA
 const SignupSchema = Yup.object().shape({
-  password: Yup.string()
-    .matches(
-      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,}$/,
-      "Use 8 or more characters with a mix of letters, numbers & symbols"
-    )
-    .required("Password is required"),
-  confirmPassword: Yup.string()
-    .required("Password confirmation is required")
-    .oneOf([Yup.ref("password"), null], "Passwords must match"),
+  password: passwordValidation(Yup.string()).required("Password is required"),
+  confirmPassword: Yup.string().required("Password confirmation is required")
+    .oneOf([Yup.ref("password")], "Passwords must match")
+    .when("password", {
+      is: (value) => value !== undefined && value.length > 0,
+      then: (schema) => schema.required("Confirmation password is required"),
+    }),
 });
 
 const ResetPassword = (props) => {
@@ -127,8 +129,9 @@ const ResetPassword = (props) => {
     let userId = searchParams.get("user_id");
     let token = searchParams.get("token");
     let password = formik.values.password;
-    mutate({ userId, token, password });
-    //reset();
+    if (formik.isValid) {
+      mutate({ userId, token, password });
+    }
   };
 
   return (
@@ -145,11 +148,18 @@ const ResetPassword = (props) => {
                     alt="ASReview LAB"
                   />
                   <Typography variant="h5">Reset your password</Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ marginTop: "7px !important",}}
+                  >
+                    {passwordRequirements}
+                  </Typography>
                 </Stack>
 
                 <FormControl>
                   <Stack spacing={3}>
                     <TextField
+                      required={true}
                       id="password"
                       label="Password"
                       size="small"
@@ -160,8 +170,12 @@ const ResetPassword = (props) => {
                       value={formik.values.password}
                       onChange={formik.handleChange}
                       onBlur={formik.handleBlur}
+                      inputProps={{
+                        autoComplete: "new-password",
+                      }}
                     />
                     <TextField
+                      required={true}
                       id="confirmPassword"
                       label="Confirm Password"
                       size="small"
@@ -171,6 +185,9 @@ const ResetPassword = (props) => {
                       value={formik.values.confirmPassword}
                       onChange={formik.handleChange}
                       onBlur={formik.handleBlur}
+                      inputProps={{
+                        autoComplete: "new-password",
+                      }}
                     />
                   </Stack>
                 </FormControl>
@@ -198,6 +215,7 @@ const ResetPassword = (props) => {
                 )}
                 <Stack className={classes.button} direction="row">
                   <LoadingButton
+                    disabled={!formik.isValid || formik.values.password === ""}
                     loading={isLoading}
                     variant="contained"
                     color="primary"

--- a/asreview/webapp/src/Components/SignUpForm.js
+++ b/asreview/webapp/src/Components/SignUpForm.js
@@ -20,7 +20,11 @@ import {
 } from "@mui/material";
 
 import { InlineErrorHandler } from ".";
-import { WordmarkState, passwordValidation } from "../globals";
+import {
+  WordmarkState,
+  passwordValidation,
+  passwordRequirements
+} from "../globals";
 import { styled } from "@mui/material/styles";
 import { HelpPrivacyTermsButton } from "../Components";
 import { useToggle } from "../hooks/useToggle";
@@ -116,7 +120,9 @@ const SignUpForm = (props) => {
   });
 
   const handleSubmit = () => {
-    mutate(formik.values);
+    if (formik.isValid) {
+      mutate(formik.values);
+    }
   };
 
   const handleSignIn = () => {
@@ -148,6 +154,7 @@ const SignUpForm = (props) => {
                   <Typography variant="h5">Create your profile</Typography>
                   <Stack spacing={3} component="form" noValidate>
                     <TextField
+                      required={true}
                       id="email"
                       name="email"
                       label="Email"
@@ -165,30 +172,44 @@ const SignUpForm = (props) => {
                     <FormControl>
                       <Stack direction="row" spacing={2}>
                         <TextField
+                          required={true}
                           id="password"
                           label="Password"
                           size="small"
-                          autoComplete="new-password"
                           fullWidth
                           type={showPassword ? "text" : "password"}
                           value={formik.values.password}
                           onChange={formik.handleChange}
                           onBlur={formik.handleBlur}
+                          inputProps={{
+                            autoComplete: "new-password",
+                          }}
                         />
                         <TextField
+                          required={true}
                           id="confirmPassword"
                           label="Confirm Password"
                           size="small"
-                          autoComplete="new-password"
                           fullWidth
                           type={showPassword ? "text" : "password"}
                           onKeyDown={handleEnterKey}
                           value={formik.values.confirmPassword}
                           onChange={formik.handleChange}
                           onBlur={formik.handleBlur}
+                          inputProps={{
+                            autoComplete: "new-password",
+                          }}
                         />
                       </Stack>
                     </FormControl>
+
+                    <Typography
+                      variant="body2"
+                      sx={{ marginTop: "7px !important" }}
+                    >
+                      {passwordRequirements}
+                    </Typography>
+
                     {formik.touched.password && formik.errors.password ? (
                       <FHT error={true}>{formik.errors.password}</FHT>
                     ) : null}
@@ -232,6 +253,7 @@ const SignUpForm = (props) => {
                     {isError && <InlineErrorHandler message={error.message} />}
                     <Divider />
                     <TextField
+                      required={true}
                       id="name"
                       name="name"
                       label="Full name"
@@ -246,6 +268,7 @@ const SignUpForm = (props) => {
                       <FHT error={true}>{formik.errors.name}</FHT>
                     ) : null}
                     <TextField
+                      required={true}
                       id="affiliation"
                       label="Affiliation"
                       size="small"

--- a/asreview/webapp/src/globals.js
+++ b/asreview/webapp/src/globals.js
@@ -127,7 +127,8 @@ export const formatDate = (datetime) => {
   return dateDisplay;
 };
 
-
+export const passwordRequirements =
+  "Your password must be at least 8 characters long and includes at least one number, one lowercase letter, and one uppercase letter.";
 
 // enums
 export const projectModes = {


### PR DESCRIPTION
The same password validation is applied on sign-up, profile changes and forgot password. Also the auto complete property is now correctly set on password fields (no auto-completion, or 'new-password'). Labels of required fields are now enhanced with an asterisk.