### PR TITLE
Unify password validation, fix auto-complete issues and made fields 'required' for main Branch

### DIFF
--- a/asreview/webapp/src/Components/ResetPassword.js
+++ b/asreview/webapp/src/Components/ResetPassword.js
@@ -21,7 +21,7 @@ import AuthAPI from "api/AuthAPI";
 import {
   WordmarkState,
   passwordRequirements,
-  passwordValidation
+  passwordValidation,
 } from "globals.js";
 import { useToggle } from "hooks/useToggle";
 import { useFormik } from "formik";
@@ -73,7 +73,8 @@ const Root = styled("div")(({ theme }) => ({
 // VALIDATION SCHEMA
 const SignupSchema = Yup.object().shape({
   password: passwordValidation(Yup.string()).required("Password is required"),
-  confirmPassword: Yup.string().required("Password confirmation is required")
+  confirmPassword: Yup.string()
+    .required("Password confirmation is required")
     .oneOf([Yup.ref("password")], "Passwords must match")
     .when("password", {
       is: (value) => value !== undefined && value.length > 0,
@@ -151,7 +152,7 @@ const ResetPassword = (props) => {
                   <Typography variant="h5">Reset your password</Typography>
                   <Typography
                     variant="body2"
-                    sx={{ marginTop: "7px !important",}}
+                    sx={{ marginTop: "7px !important" }}
                   >
                     {passwordRequirements}
                   </Typography>

--- a/asreview/webapp/src/Components/ResetPassword.js
+++ b/asreview/webapp/src/Components/ResetPassword.js
@@ -18,7 +18,11 @@ import { InlineErrorHandler } from ".";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { styled } from "@mui/material/styles";
 import AuthAPI from "api/AuthAPI";
-import { WordmarkState } from "globals.js";
+import {
+  WordmarkState,
+  passwordRequirements,
+  passwordValidation
+} from "globals.js";
 import { useToggle } from "hooks/useToggle";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -68,15 +72,13 @@ const Root = styled("div")(({ theme }) => ({
 
 // VALIDATION SCHEMA
 const SignupSchema = Yup.object().shape({
-  password: Yup.string()
-    .matches(
-      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,}$/,
-      "Use 8 or more characters with a mix of letters, numbers & symbols",
-    )
-    .required("Password is required"),
-  confirmPassword: Yup.string()
-    .required("Password confirmation is required")
-    .oneOf([Yup.ref("password"), null], "Passwords must match"),
+  password: passwordValidation(Yup.string()).required("Password is required"),
+  confirmPassword: Yup.string().required("Password confirmation is required")
+    .oneOf([Yup.ref("password")], "Passwords must match")
+    .when("password", {
+      is: (value) => value !== undefined && value.length > 0,
+      then: (schema) => schema.required("Confirmation password is required"),
+    }),
 });
 
 const ResetPassword = (props) => {
@@ -127,8 +129,10 @@ const ResetPassword = (props) => {
     let userId = searchParams.get("user_id");
     let token = searchParams.get("token");
     let password = formik.values.password;
-    mutate({ userId, token, password });
-    //reset();
+
+    if (formik.isValid) {
+      mutate({ userId, token, password });
+    }
   };
 
   return (
@@ -145,6 +149,12 @@ const ResetPassword = (props) => {
                     alt="ASReview LAB"
                   />
                   <Typography variant="h5">Reset your password</Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ marginTop: "7px !important",}}
+                  >
+                    {passwordRequirements}
+                  </Typography>
                 </Stack>
 
                 <FormControl>
@@ -160,6 +170,9 @@ const ResetPassword = (props) => {
                       value={formik.values.password}
                       onChange={formik.handleChange}
                       onBlur={formik.handleBlur}
+                      inputProps={{
+                        autoComplete: "new-password",
+                      }}
                     />
                     <TextField
                       id="confirmPassword"
@@ -171,6 +184,9 @@ const ResetPassword = (props) => {
                       value={formik.values.confirmPassword}
                       onChange={formik.handleChange}
                       onBlur={formik.handleBlur}
+                      inputProps={{
+                        autoComplete: "new-password",
+                      }}
                     />
                   </Stack>
                 </FormControl>
@@ -198,6 +214,7 @@ const ResetPassword = (props) => {
                 )}
                 <Stack className={classes.button} direction="row">
                   <LoadingButton
+                    disabled={!formik.isValid || formik.values.password === ""}
                     loading={isLoading}
                     variant="contained"
                     color="primary"

--- a/asreview/webapp/src/Components/ResetPassword.js
+++ b/asreview/webapp/src/Components/ResetPassword.js
@@ -160,6 +160,7 @@ const ResetPassword = (props) => {
                 <FormControl>
                   <Stack spacing={3}>
                     <TextField
+                      required={true}
                       id="password"
                       label="Password"
                       size="small"
@@ -175,6 +176,7 @@ const ResetPassword = (props) => {
                       }}
                     />
                     <TextField
+                      required={true}
                       id="confirmPassword"
                       label="Confirm Password"
                       size="small"

--- a/asreview/webapp/src/Components/SignUpForm.js
+++ b/asreview/webapp/src/Components/SignUpForm.js
@@ -109,7 +109,7 @@ const SignUpForm = (props) => {
       formik.setValues(initialValues, false);
       if (typeof props.showNotification === "function") {
         props.showNotification(
-          `A confirmation email has been sent to ${email}.`
+          `A confirmation email has been sent to ${email}.`,
         );
       }
       navigate("/signin");

--- a/asreview/webapp/src/Components/SignUpForm.js
+++ b/asreview/webapp/src/Components/SignUpForm.js
@@ -19,7 +19,11 @@ import {
 } from "@mui/material";
 
 import { InlineErrorHandler } from ".";
-import { WordmarkState, passwordValidation } from "globals.js";
+import {
+  WordmarkState,
+  passwordRequirements,
+  passwordValidation,
+} from "globals.js";
 import { styled } from "@mui/material/styles";
 import { HelpPrivacyTermsButton } from "Components";
 import { useToggle } from "hooks/useToggle";
@@ -105,7 +109,7 @@ const SignUpForm = (props) => {
       formik.setValues(initialValues, false);
       if (typeof props.showNotification === "function") {
         props.showNotification(
-          `A confirmation email has been sent to ${email}.`,
+          `A confirmation email has been sent to ${email}.`
         );
       }
       navigate("/signin");
@@ -113,7 +117,9 @@ const SignUpForm = (props) => {
   });
 
   const handleSubmit = () => {
-    mutate(formik.values);
+    if (formik.isValid) {
+      mutate(formik.values);
+    }
   };
 
   const handleSignIn = () => {
@@ -161,27 +167,39 @@ const SignUpForm = (props) => {
                         id="password"
                         label="Password"
                         size="small"
-                        autoComplete="new-password"
                         fullWidth
                         type={showPassword ? "text" : "password"}
                         value={formik.values.password}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
+                        inputProps={{
+                          autoComplete: "new-password",
+                        }}
                       />
                       <TextField
                         id="confirmPassword"
                         label="Confirm Password"
                         size="small"
-                        autoComplete="new-password"
                         fullWidth
                         type={showPassword ? "text" : "password"}
                         onKeyDown={handleEnterKey}
                         value={formik.values.confirmPassword}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
+                        inputProps={{
+                          autoComplete: "new-password",
+                        }}
                       />
                     </Stack>
                   </FormControl>
+
+                  <Typography
+                    variant="body2"
+                    sx={{ marginTop: "7px !important" }}
+                  >
+                    {passwordRequirements}
+                  </Typography>
+
                   {formik.touched.password && formik.errors.password ? (
                     <FHT error={true}>{formik.errors.password}</FHT>
                   ) : null}

--- a/asreview/webapp/src/Components/SignUpForm.js
+++ b/asreview/webapp/src/Components/SignUpForm.js
@@ -147,6 +147,7 @@ const SignUpForm = (props) => {
                 <Typography variant="h5">Create your profile</Typography>
                 <Stack spacing={3} component="form" noValidate>
                   <TextField
+                    required={true}
                     id="email"
                     name="email"
                     label="Email"
@@ -164,6 +165,7 @@ const SignUpForm = (props) => {
                   <FormControl>
                     <Stack direction="row" spacing={2}>
                       <TextField
+                        required={true}
                         id="password"
                         label="Password"
                         size="small"
@@ -177,6 +179,7 @@ const SignUpForm = (props) => {
                         }}
                       />
                       <TextField
+                        required={true}
                         id="confirmPassword"
                         label="Confirm Password"
                         size="small"
@@ -242,6 +245,7 @@ const SignUpForm = (props) => {
                   {isError && <InlineErrorHandler message={error.message} />}
                   <Divider />
                   <TextField
+                    required={true}
                     id="name"
                     name="name"
                     label="Full name"
@@ -256,6 +260,7 @@ const SignUpForm = (props) => {
                     <FHT error={true}>{formik.errors.name}</FHT>
                   ) : null}
                   <TextField
+                    required={true}
                     id="affiliation"
                     label="Affiliation"
                     size="small"

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -75,17 +75,15 @@ const ProfilePage = (props) => {
   };
 
   const handleReset = () => {
-    formik.setValues(
-      {
-        name: initName,
-        email: initEmail,
-        affiliation: initAffiliation,
-        publicAccount: initPublic,
-        oldPassword: '',
-        newPassword: '',
-        confirmPassword: ''
-      },
-    );
+    formik.setValues({
+      name: initName,
+      email: initEmail,
+      affiliation: initAffiliation,
+      publicAccount: initPublic,
+      oldPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    });
   };
 
   const initialValues = {
@@ -105,7 +103,6 @@ const ProfilePage = (props) => {
 
   const { data, isFetched } = useQuery("fetchProfileData", AuthAPI.getProfile, {
     onSuccess: (data) => {
-
       var email = data.message.email;
       var name = data.message.name;
       var affiliation = data.message.affiliation || "";
@@ -123,7 +120,7 @@ const ProfilePage = (props) => {
           affiliation: affiliation,
           publicAccount: publicAcc,
         },
-        true
+        true,
       );
 
       // show password field?
@@ -224,10 +221,7 @@ const ProfilePage = (props) => {
           </Stack>
         </FormControl>
 
-        <Typography
-          variant="body2"
-          sx={{ marginTop: "7px !important",}}
-        >
+        <Typography variant="body2" sx={{ marginTop: "7px !important" }}>
           {passwordRequirements}
         </Typography>
 
@@ -272,10 +266,7 @@ const ProfilePage = (props) => {
               )}
               <Stack direction="row" spacing={1}>
                 <span>
-                  <Button
-                    onClick={handleReset}
-                    sx={{ marginRight: "15px" }}
-                  >
+                  <Button onClick={handleReset} sx={{ marginRight: "15px" }}>
                     reset
                   </Button>
                   <LoadingButton

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -166,6 +166,7 @@ const ProfilePage = (props) => {
           <Stack direction="column" spacing={2}>
             <Typography variant="h6">Change email & password</Typography>
             <TextField
+              required={true}
               id="email"
               label="Email"
               size="small"
@@ -304,6 +305,7 @@ const ProfilePage = (props) => {
                 <Typography variant="h6">User data</Typography>
               )}
               <TextField
+                required={true}
                 id="name"
                 label="Full name"
                 size="small"
@@ -319,6 +321,7 @@ const ProfilePage = (props) => {
                 <FHT error={true}>{formik.errors.name}</FHT>
               ) : null}
               <TextField
+                required={true}
                 id="affiliation"
                 label="Affiliation"
                 size="small"

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "react-query";
 import DashboardPage from "./DashboardPage";
 import {
   Box,
+  Button,
   Checkbox,
   Divider,
   FormControl,
@@ -20,7 +21,7 @@ import { InlineErrorHandler } from "Components";
 import { useToggle } from "hooks/useToggle";
 
 import { AuthAPI } from "api";
-import { passwordValidation } from "globals.js";
+import { passwordRequirements, passwordValidation } from "globals.js";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 
@@ -33,7 +34,7 @@ const SignupSchema = Yup.object().shape({
   name: Yup.string().required("Full name is required").nullable(),
   affiliation: Yup.string()
     .min(2, "Affiliation must be at least 2 characters long")
-    .nullable(),
+    .required("Affiliation is required"),
   oldPassword: Yup.string(),
   newPassword: passwordValidation(Yup.string()),
   confirmPassword: Yup.string()
@@ -46,6 +47,11 @@ const SignupSchema = Yup.object().shape({
 
 const ProfilePage = (props) => {
   const navigate = useNavigate();
+
+  const [initEmail, setInitEmail] = React.useState(null);
+  const [initName, setInitName] = React.useState(null);
+  const [initAffiliation, setInitAffiliation] = React.useState(null);
+  const [initPublic, setInitPublic] = React.useState(true);
 
   const [showPassword, toggleShowPassword] = useToggle();
   const [loadingSaveButton, setLoadingSaveButton] = React.useState(true);
@@ -68,6 +74,20 @@ const ProfilePage = (props) => {
     }
   };
 
+  const handleReset = () => {
+    formik.setValues(
+      {
+        name: initName,
+        email: initEmail,
+        affiliation: initAffiliation,
+        publicAccount: initPublic,
+        oldPassword: '',
+        newPassword: '',
+        confirmPassword: ''
+      },
+    );
+  };
+
   const initialValues = {
     email: "",
     name: "",
@@ -85,14 +105,27 @@ const ProfilePage = (props) => {
 
   const { data, isFetched } = useQuery("fetchProfileData", AuthAPI.getProfile, {
     onSuccess: (data) => {
-      formik.setFieldValue("email", data.message.email, true);
-      formik.setFieldValue("name", data.message.name, true);
-      formik.setFieldValue(
-        "affiliation",
-        data.message.affiliation || "",
-        false,
+
+      var email = data.message.email;
+      var name = data.message.name;
+      var affiliation = data.message.affiliation || "";
+      var publicAcc = data.message.public || true;
+
+      setInitEmail(email);
+      setInitName(name);
+      setInitAffiliation(affiliation);
+      setInitPublic(publicAcc);
+
+      formik.setValues(
+        {
+          name: name,
+          email: email,
+          affiliation: affiliation,
+          publicAccount: publicAcc,
+        },
+        true
       );
-      formik.setFieldValue("public", data.message.public || true);
+
       // show password field?
       if (data.message.origin === "asreview") {
         setShowPasswordFields(true);
@@ -140,7 +173,6 @@ const ProfilePage = (props) => {
               value={formik.values.email}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              autoComplete="off"
             />
             {formik.touched.email && formik.errors.email ? (
               <FHT error={true}>{formik.errors.email}</FHT>
@@ -154,7 +186,9 @@ const ProfilePage = (props) => {
               value={formik.values.oldPassword}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              autoComplete="current-password"
+              inputProps={{
+                autoComplete: "off",
+              }}
             />
             <TextField
               id="newPassword"
@@ -167,7 +201,9 @@ const ProfilePage = (props) => {
               onBlur={formik.handleBlur}
               style={{ opacity: passwordFieldOpacity() }}
               disabled={oldPasswordHasValue()}
-              autoComplete="new-password"
+              inputProps={{
+                autoComplete: "new-password",
+              }}
             />
             <TextField
               id="confirmPassword"
@@ -180,10 +216,20 @@ const ProfilePage = (props) => {
               onBlur={formik.handleBlur}
               style={{ opacity: passwordFieldOpacity() }}
               disabled={oldPasswordHasValue()}
-              autoComplete="new-password"
+              inputProps={{
+                autoComplete: "new-password",
+              }}
             />
           </Stack>
         </FormControl>
+
+        <Typography
+          variant="body2"
+          sx={{ marginTop: "7px !important",}}
+        >
+          {passwordRequirements}
+        </Typography>
+
         {formik.touched.newPassword && formik.errors.newPassword ? (
           <FHT error={true}>{formik.errors.newPassword}</FHT>
         ) : null}
@@ -225,6 +271,12 @@ const ProfilePage = (props) => {
               )}
               <Stack direction="row" spacing={1}>
                 <span>
+                  <Button
+                    onClick={handleReset}
+                    sx={{ marginRight: "15px" }}
+                  >
+                    reset
+                  </Button>
                   <LoadingButton
                     id="save"
                     disabled={!formik.isValid}
@@ -259,7 +311,9 @@ const ProfilePage = (props) => {
                 value={formik.values.name}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
-                autoComplete="off"
+                inputProps={{
+                  autoComplete: "off",
+                }}
               />
               {formik.touched.name && formik.errors.name ? (
                 <FHT error={true}>{formik.errors.name}</FHT>
@@ -272,7 +326,9 @@ const ProfilePage = (props) => {
                 value={formik.values.affiliation}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
-                autoComplete="off"
+                inputProps={{
+                  autoComplete: "off",
+                }}
               />
               {formik.touched.affiliation && formik.errors.affiliation ? (
                 <FHT error={true}>{formik.errors.affiliation}</FHT>

--- a/asreview/webapp/src/globals.js
+++ b/asreview/webapp/src/globals.js
@@ -119,6 +119,9 @@ export const passwordValidation = (yup_string) => {
   );
 };
 
+export const passwordRequirements =
+  "Your password must be at least 8 characters long and includes at least one number, one lowercase letter, and one uppercase letter.";
+
 /**
  * Format date and mode
  */


### PR DESCRIPTION
The same password validation is applied on sign-up, profile changes and forgot password. Also the auto complete property is now correctly set on password fields (no auto-completion, or 'new-password'). Labels of required fields are now enhanced with an asterisk.