### PR TITLE
Quickfix memory usage due to broken filelocks on distributed systems

### DIFF
--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -1470,6 +1470,7 @@ def api_classify_instance(project, doc_id):  # noqa: F401
 
     retrain_model = False if is_prior == "1" else True
     prior = True if is_prior == "1" else False
+    file_lock_path = Path(project.project_path, "trainings.lock")
 
     if request.method == "POST":
         with open_state(project.project_path, read_only=False) as state:
@@ -1485,7 +1486,8 @@ def api_classify_instance(project, doc_id):  # noqa: F401
             elif label == -1:
                 state.delete_record_labeling_data(record_id)
 
-    if retrain_model:
+    # retrain only if there is no lock
+    if retrain_model and not file_lock_path.exists():
         # retrain model
         subprocess.Popen(
             [

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -71,6 +71,13 @@ def create_app(config_path=None):
     if config_fp := (config_path or app.config.get("CONFIG_PATH", None)):
         app.config.from_file(Path(config_fp).absolute(), load=tomllib.load, text=False)
 
+    # remove existing training lock files
+    [
+        Path(f, "training.lock").unlink(missing_ok=True)
+        for f in asreview_path().iterdir()
+        if f.is_dir()
+    ]
+
     # if there are no cors and config is in debug mode, add default cors
     if app.debug and not app.config.get("CORS_ORIGINS", None):
         app.config["CORS_ORIGINS"] = ["http://localhost:3000", "http://127.0.0.1:3000"]

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -71,12 +71,11 @@ def create_app(config_path=None):
     if config_fp := (config_path or app.config.get("CONFIG_PATH", None)):
         app.config.from_file(Path(config_fp).absolute(), load=tomllib.load, text=False)
 
-    # remove existing training lock files
-    [
-        Path(f, "training.lock").unlink(missing_ok=True)
-        for f in asreview_path().iterdir()
-        if f.is_dir()
-    ]
+    # remove all lock files per project folder
+    for f in asreview_path().iterdir():
+        if f.is_dir():
+            # remove lock files
+            [lockfile.unlink(missing_ok=True) for lockfile in f.glob("*.lock")]
 
     # if there are no cors and config is in debug mode, add default cors
     if app.debug and not app.config.get("CORS_ORIGINS", None):

--- a/asreview/webapp/entry_points/run_model.py
+++ b/asreview/webapp/entry_points/run_model.py
@@ -65,6 +65,9 @@ def run_model_entry_point(argv):
 
             reviewer.train()
 
+            # Update status
+            project.update_review(status="review")
+
     except Exception as err:
         project.set_error(err, save_error_message=args.output_error)
         raise err
@@ -72,5 +75,3 @@ def run_model_entry_point(argv):
     finally:
         # Ensure removal of lock file
         file_lock_path.unlink(missing_ok=True)
-        # Update status
-        project.update_review(status="review")

--- a/asreview/webapp/entry_points/run_model.py
+++ b/asreview/webapp/entry_points/run_model.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import logging
 from pathlib import Path
 
 from asreview.models.balance import get_balance_model
@@ -49,7 +48,7 @@ def run_model_entry_point(argv):
                 return
 
         # Lock so that only one training run is running at the same time.
-        with open(file_lock_path, "w") as lock:
+        with open(file_lock_path, "w"):
 
             with open_state(project) as state:
                 settings = state.settings


### PR DESCRIPTION
The FileLock for the review process is not working properly: for every labeling action a subprocess is started to run the model. This may consume an unnecessary amount of memory. This fix substitutes the FileLock implementation with a simple mechanism that creates a lock file in the project folder when the model gets trained. In the api, the training-process will be started when there is no lock file present.