### PR TITLE
Simplify Query Strategy

### DIFF
--- a/asreview/models/query/base.py
+++ b/asreview/models/query/base.py
@@ -24,7 +24,8 @@ class BaseQueryStrategy(BaseModel):
 
     name = "base"
 
-    def query(self, feature_matrix, relevance_scores, n_instances=None, **kwargs):
+    @abstractmethod
+    def query(self, feature_matrix, relevance_scores, **kwargs):
         """Put records in ranked order.
 
         Arguments
@@ -33,32 +34,12 @@ class BaseQueryStrategy(BaseModel):
             Feature matrix where every row contains the features of a record.
         relevance_scores: numpy.ndarray
             Relevance scores as predicted by the classifier.
-        n_instances: int
-            Number of records to query. If None returns all records in ranked order.
 
         Returns
         -------
-        numpy.ndarray or (numpy.ndarray, np.ndarray)
+        numpy.ndarray
             The QueryStrategy ranks the row numbers of the feature matrix. It returns
-            an array of shape (n_instances,) containing the row indices in ranked
+            an array of shape (len(feature_matrix),) containing the row indices in ranked
             order.
-            If n_instances is None, returns all row numbers in ranked order. If
-            n_instances is an integer, it only returns the top n_instances.
-            If return_classifier_scores=True, also returns a second array with the same
-            number of rows as the feature matrix, containing the relevance scores
-            predicted by the classifier. If the classifier is not used, this will be
-            None.
         """
-        if n_instances is None:
-            n_instances = feature_matrix.shape[0]
-
-        return self._query(
-            feature_matrix=feature_matrix,
-            relevance_scores=relevance_scores,
-            n_instances=n_instances,
-            **kwargs,
-        )
-
-    @abstractmethod
-    def _query(self, feature_matrix, relevance_scores, n_instances, **kwargs):
         raise NotImplementedError

--- a/asreview/models/query/base.py
+++ b/asreview/models/query/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ["BaseQueryStrategy", "ProbaQueryStrategy"]
+__all__ = ["BaseQueryStrategy"]
 
 from abc import abstractmethod
 
@@ -22,29 +22,19 @@ from asreview.models.base import BaseModel
 class BaseQueryStrategy(BaseModel):
     """Abstract class for query strategies."""
 
-    name = "base-query"
+    name = "base"
 
-    @abstractmethod
-    def query(
-        self,
-        X,
-        classifier=None,
-        n_instances=None,
-        return_classifier_scores=False,
-        **kwargs,
-    ):
+    def query(self, feature_matrix, relevance_scores, n_instances=None, **kwargs):
         """Put records in ranked order.
 
         Arguments
         ---------
-        X: numpy.ndarray
+        feature_matrix: numpy.ndarray
             Feature matrix where every row contains the features of a record.
-        classifier: SKLearnModel
-            Trained classifier to compute relevance scores.
+        relevance_scores: numpy.ndarray
+            Relevance scores as predicted by the classifier.
         n_instances: int
             Number of records to query. If None returns all records in ranked order.
-        return_classifier_score : bool
-            Return the relevance scores produced by the classifier.
 
         Returns
         -------
@@ -59,28 +49,16 @@ class BaseQueryStrategy(BaseModel):
             predicted by the classifier. If the classifier is not used, this will be
             None.
         """
-        raise NotImplementedError
-
-
-class ProbaQueryStrategy(BaseQueryStrategy):
-    name = "proba"
-
-    def query(
-        self, X, classifier, n_instances=None, return_classifier_scores=False, **kwargs
-    ):
-        """Query method for strategies which use class probabilities."""
         if n_instances is None:
-            n_instances = X.shape[0]
+            n_instances = feature_matrix.shape[0]
 
-        predictions = classifier.predict_proba(X)
-
-        query_idx = self._query(predictions, n_instances, X)
-
-        if return_classifier_scores:
-            return query_idx, predictions
-        else:
-            return query_idx
+        return self._query(
+            feature_matrix=feature_matrix,
+            relevance_scores=relevance_scores,
+            n_instances=n_instances,
+            **kwargs,
+        )
 
     @abstractmethod
-    def _query(self, predictions, n_instances, X=None):
+    def _query(self, feature_matrix, relevance_scores, n_instances, **kwargs):
         raise NotImplementedError

--- a/asreview/models/query/cluster.py
+++ b/asreview/models/query/cluster.py
@@ -51,7 +51,7 @@ class ClusterQuery(BaseQueryStrategy):
         self.fallback_model = MaxQuery()
         self._random_state = random_state
 
-    def _query(self, feature_matrix, relevance_scores, n_instances):
+    def query(self, feature_matrix, relevance_scores):
         n_samples = feature_matrix.shape[0]
 
         last_update = self.last_update
@@ -62,10 +62,9 @@ class ClusterQuery(BaseQueryStrategy):
         ):
             n_clusters = round(n_samples / self.cluster_size)
             if n_clusters <= 1:
-                return self.fallback_model._query(
+                return self.fallback_model.query(
                     feature_matrix=feature_matrix,
                     relevance_scores=relevance_scores,
-                    n_instances=n_instances,
                 )
             model = KMeans(
                 n_clusters=n_clusters, n_init=1, random_state=self._random_state
@@ -89,7 +88,7 @@ class ClusterQuery(BaseQueryStrategy):
 
         clust_idx = []
         cluster_ids = list(clusters)
-        for _ in range(n_instances):
+        for _ in range(feature_matrix.shape[0]):
             cluster_id = check_random_state(self._random_state).choice(cluster_ids, 1)[
                 0
             ]

--- a/asreview/models/query/max_prob.py
+++ b/asreview/models/query/max_prob.py
@@ -29,7 +29,7 @@ class MaxQuery(BaseQueryStrategy):
     name = "max"
     label = "Maximum"
 
-    def _query(self, feature_matrix, relevance_scores, n_instances):
+    def query(self, feature_matrix, relevance_scores):
         del feature_matrix
-        query_indices = np.argsort(relevance_scores[:, 0])[:n_instances]
+        query_indices = np.argsort(relevance_scores[:, 0])
         return query_indices

--- a/asreview/models/query/max_prob.py
+++ b/asreview/models/query/max_prob.py
@@ -17,10 +17,10 @@ __all__ = ["MaxQuery"]
 
 import numpy as np
 
-from asreview.models.query.base import ProbaQueryStrategy
+from asreview.models.query.base import BaseQueryStrategy
 
 
-class MaxQuery(ProbaQueryStrategy):
+class MaxQuery(BaseQueryStrategy):
     """Maximum query strategy (``max``).
 
     Choose the most likely samples to be included according to the model.
@@ -29,7 +29,7 @@ class MaxQuery(ProbaQueryStrategy):
     name = "max"
     label = "Maximum"
 
-    def _query(self, predictions, n_instances, X=None):
-        query_indices = np.argsort(predictions[:, 0])[:n_instances]
-
+    def _query(self, feature_matrix, relevance_scores, n_instances):
+        del feature_matrix
+        query_indices = np.argsort(relevance_scores[:, 0])[:n_instances]
         return query_indices

--- a/asreview/models/query/mixed.py
+++ b/asreview/models/query/mixed.py
@@ -71,12 +71,12 @@ class MixedQuery(BaseQueryStrategy):
         self.mix_probability = mix_probability
         self._random_state = random_state
 
-    def _query(self, feature_matrix, relevance_scores, n_instances=None, **kwargs):
+    def query(self, feature_matrix, relevance_scores):
         query_idx_1 = self.query_model1.query(
-            feature_matrix, relevance_scores, n_instances=n_instances
+            feature_matrix=feature_matrix, relevance_scores=relevance_scores
         )
         query_idx_2 = self.query_model2.query(
-            feature_matrix, relevance_scores, n_instances=n_instances
+            feature_matrix=feature_matrix, relevance_scores=relevance_scores
         )
 
         # mix the 2 query strategies into one list
@@ -93,7 +93,7 @@ class MixedQuery(BaseQueryStrategy):
                 j = j + 1
 
         indexes = np.unique(query_idx_mix, return_index=True)[1]
-        ranking = [query_idx_mix[i] for i in sorted(indexes)][0:n_instances]
+        ranking = [query_idx_mix[i] for i in sorted(indexes)]
 
         return ranking
 

--- a/asreview/models/query/random.py
+++ b/asreview/models/query/random.py
@@ -39,13 +39,12 @@ class RandomQuery(BaseQueryStrategy):
         super().__init__()
         self._random_state = random_state
 
-    def _query(
+    def query(
         self,
         feature_matrix,
         relevance_scores,
-        n_instances=None,
     ):
         del relevance_scores
-        return check_random_state(self._random_state).choice(
-            np.arange(feature_matrix.shape[0]), n_instances, replace=False
-        )
+        row_indices = np.arange(feature_matrix.shape[0])
+        check_random_state(self._random_state).shuffle(row_indices)
+        return row_indices

--- a/asreview/models/query/random.py
+++ b/asreview/models/query/random.py
@@ -39,22 +39,13 @@ class RandomQuery(BaseQueryStrategy):
         super().__init__()
         self._random_state = random_state
 
-    def query(
+    def _query(
         self,
-        X,
-        classifier=None,
+        feature_matrix,
+        relevance_scores,
         n_instances=None,
-        return_classifier_scores=False,
-        **kwargs,
     ):
-        if n_instances is None:
-            n_instances = X.shape[0]
-
-        query_idx = check_random_state(self._random_state).choice(
-            np.arange(X.shape[0]), n_instances, replace=False
+        del relevance_scores
+        return check_random_state(self._random_state).choice(
+            np.arange(feature_matrix.shape[0]), n_instances, replace=False
         )
-
-        if return_classifier_scores:
-            return query_idx, None
-        else:
-            return query_idx

--- a/asreview/models/query/uncertainty.py
+++ b/asreview/models/query/uncertainty.py
@@ -32,8 +32,8 @@ class UncertaintyQuery(BaseQueryStrategy):
     name = "uncertainty"
     label = "Uncertainty"
 
-    def _query(self, feature_matrix, relevance_scores, n_instances):
+    def query(self, feature_matrix, relevance_scores):
         del feature_matrix
         uncertainty = 1 - np.max(relevance_scores, axis=1)
-        query_idx = np.argsort(-uncertainty)[:n_instances]
+        query_idx = np.argsort(-uncertainty)
         return query_idx

--- a/asreview/models/query/uncertainty.py
+++ b/asreview/models/query/uncertainty.py
@@ -17,14 +17,14 @@ __all__ = ["UncertaintyQuery"]
 
 import numpy as np
 
-from asreview.models.query.base import ProbaQueryStrategy
+from asreview.models.query.base import BaseQueryStrategy
 
 
-class UncertaintyQuery(ProbaQueryStrategy):
+class UncertaintyQuery(BaseQueryStrategy):
     """Uncertainty query strategy (``uncertainty``).
 
     Choose the most uncertain samples according to the model (i.e. closest to
-    0.5 probability). Doesn’t work very well in the case of LSTM’s, since the
+    0.5 probability). Doesn't work very well in the case of LSTM's, since the
     probabilities are rather arbitrary.
 
     """
@@ -32,7 +32,8 @@ class UncertaintyQuery(ProbaQueryStrategy):
     name = "uncertainty"
     label = "Uncertainty"
 
-    def _query(self, predictions, n_instances, X=None):
-        uncertainty = 1 - np.max(predictions, axis=1)
+    def _query(self, feature_matrix, relevance_scores, n_instances):
+        del feature_matrix
+        uncertainty = 1 - np.max(relevance_scores, axis=1)
         query_idx = np.argsort(-uncertainty)[:n_instances]
         return query_idx

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -172,10 +172,11 @@ class Simulate:
         )
 
         self.classifier.fit(X_train, y_train)
+        relevance_scores = self.classifier.predict_proba(self.fm)
 
         ranked_record_ids = self.query_strategy.query(
-            self.fm,
-            classifier=self.classifier,
+            feature_matrix=self.fm,
+            relevance_scores=relevance_scores,
         )
 
         self._last_ranking = pd.concat(

--- a/asreview/webapp/entry_points/run_model.py
+++ b/asreview/webapp/entry_points/run_model.py
@@ -86,10 +86,11 @@ def _run_model_start(project, output_error=True):
 
             classifier = load_extension("models.classifiers", settings.classifier)()
             classifier.fit(X_train, y_train)
+            relevance_scores = classifier.predict_proba(fm)
 
             query_strategy = load_extension("models.query", settings.query_strategy)()
-            ranked_record_ids, relevance_scores = query_strategy.query(
-                fm, classifier=classifier, return_classifier_scores=True
+            ranked_record_ids = query_strategy.query(
+                feature_matrix=fm, relevance_scores=relevance_scores
             )
 
             with open_state(project) as state:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,9 +16,7 @@ from asreview.extensions import load_extension
         "cluster",
     ],
 )
-@mark.parametrize("n_instances", [0, 1, 5, 50])
-@mark.parametrize("n_train", [0, 1, 5, 50])
-def test_query(query_strategy, n_instances, n_train):
+def test_query(query_strategy):
     n_features = 50
     n_sample = 100
     classifier = load_extension("models.classifiers", "rf")()
@@ -37,13 +35,8 @@ def test_query(query_strategy, n_instances, n_train):
     assert isinstance(query_model.param, dict)
     assert query_model.name == query_strategy
 
-    query_idx = query_model.query(
-        feature_matrix=X, relevance_scores=relevance_scores, n_instances=n_instances
-    )
-    assert len(query_idx) == n_instances
-    assert len(query_idx) == len(np.unique(query_idx))
-
     query_idx = query_model.query(feature_matrix=X, relevance_scores=relevance_scores)
+    assert len(query_idx) == len(np.unique(query_idx))
     assert len(query_idx) == X.shape[0]
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -32,20 +32,19 @@ def test_query(query_strategy, n_instances, n_train):
     y = y[order]
 
     classifier.fit(X, y)
+    relevance_scores = classifier.predict_proba(X)
 
     assert isinstance(query_model.param, dict)
     assert query_model.name == query_strategy
 
-    query_idx = query_model.query(X, classifier, n_instances=n_instances)
+    query_idx = query_model.query(
+        feature_matrix=X, relevance_scores=relevance_scores, n_instances=n_instances
+    )
     assert len(query_idx) == n_instances
     assert len(query_idx) == len(np.unique(query_idx))
 
-    query_idx, relevance_scores = query_model.query(
-        X, classifier, return_classifier_scores=True
-    )
+    query_idx = query_model.query(feature_matrix=X, relevance_scores=relevance_scores)
     assert len(query_idx) == X.shape[0]
-    if relevance_scores is not None:
-        assert relevance_scores.shape == (X.shape[0], 2)
 
 
 def test_query_general():


### PR DESCRIPTION
This pull request aims to simplify the query strategy class. 

Currently there are two 'base' classes for query strategies: `BaseQueryStrategy` and `ProbaQueryStrategy`. The first expects someone to implement the method `query` which takes the feature matrix, a classifier and the number of result instances as input. The second expects someone to implement `_query` which takes as input the predicted relevance scores by the classifier, the feature matrix and the number of result instances. The methods should return the row indices of the feature matrix in ranked order, but the methods have an additional option to also return the relevance scores of the classifier.

This basically means that the classifier can't be separated from the query strategy, and that if you want the results of the classifier, you need to go through the query strategy.

This pull request:
- Removes `ProbaQueryStrategy`
- Renames the `query` input argument `X` to `feature_matrix`
- Replaces the `query` input argument `classifier` by `relevance_scores`
- Removes the `query` input argument `n_instances` since it wasn't used anywhere, the method will always return a ranking for all the records in the feature matrix
- Renames the `mix_ratio` argument for `MixQuery` to `mix_probability` and better describes the meaning in the docstring 

Note that this does limit a little bit what you can do with query strategies, since a query strategy no longer has access to everything that a classifier produces. However, you can always get around this by implementing this query logic at the end of the `predict_proba` method of the classifier.