### PR TITLE
Resolve #1747, Add ‘Hide Prior Knowledge’ Switch, and Refactor Relevant API Calls

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/AnalyticsPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useState } from "react";
 import { useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 import {
@@ -10,14 +11,12 @@ import {
 } from "react-share";
 import {
   Box,
-  Button,
   CircularProgress,
   Fade,
   Grid,
   SpeedDial,
   SpeedDialAction,
   Stack,
-  Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Share } from "@mui/icons-material";
@@ -30,10 +29,12 @@ import {
   ProgressDensityChart,
   ProgressRecallChart,
 } from "ProjectComponents/AnalyticsComponents";
-import { TypographyH5Medium } from "StyledComponents/StyledTypography";
-
 import { ProjectAPI } from "api";
 import { projectModes } from "globals.js";
+import { Switch, FormControlLabel } from "@mui/material";
+import { Tooltip, IconButton } from "@mui/material";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import { tooltipClasses } from "@mui/material";
 
 const Root = styled("div")(({ theme }) => ({}));
 
@@ -47,20 +48,41 @@ const actions = [
 
 const AnalyticsPage = (props) => {
   const { project_id } = useParams();
+  // State for Hide Prior Knowledge switch
+  const [includePriorKnowledge, setIncludePriorKnowledge] = useState(false);
 
+  // Queries for fetching data, including includePriorKnowledge state
   const progressQuery = useQuery(
-    ["fetchProgress", { project_id }],
-    ProjectAPI.fetchProgress,
+    ["fetchProgress", { project_id, includePrior: includePriorKnowledge }],
+    ({ queryKey }) =>
+      ProjectAPI.fetchProgress({
+        queryKey,
+        includePrior: includePriorKnowledge,
+      }),
     { refetchOnWindowFocus: false },
   );
   const progressDensityQuery = useQuery(
-    ["fetchProgressDensity", { project_id }],
-    ProjectAPI.fetchProgressDensity,
+    [
+      "fetchProgressDensity",
+      { project_id, includePrior: includePriorKnowledge },
+    ],
+    ({ queryKey }) =>
+      ProjectAPI.fetchProgressDensity({
+        queryKey,
+        includePrior: includePriorKnowledge,
+      }),
     { refetchOnWindowFocus: false },
   );
   const progressRecallQuery = useQuery(
-    ["fetchProgressRecall", { project_id }],
-    ProjectAPI.fetchProgressRecall,
+    [
+      "fetchProgressRecall",
+      { project_id, includePrior: includePriorKnowledge },
+    ],
+    ({ queryKey }) =>
+      ProjectAPI.fetchProgressRecall({
+        queryKey,
+        includePrior: includePriorKnowledge,
+      }),
     { refetchOnWindowFocus: false },
   );
 
@@ -87,7 +109,6 @@ const AnalyticsPage = (props) => {
       emailRef.current?.click();
     }
   };
-
   const allQueriesReady = () => {
     return (
       !progressQuery.isFetching &&
@@ -95,36 +116,141 @@ const AnalyticsPage = (props) => {
       !progressRecallQuery.isFetching
     );
   };
+  // Handle toggling the switch
+  const handleTogglePriorKnowledge = () => {
+    setIncludePriorKnowledge((prev) => !prev);
+  };
+
+  // Custom styled tooltip for
+  const CustomTooltip = styled(({ className, ...props }) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ))(({ theme }) => ({
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: theme.palette.background.paper,
+      color: theme.palette.text.primary,
+      boxShadow: theme.shadows[1],
+      fontSize: theme.typography.pxToRem(12),
+      padding: "10px",
+    },
+  }));
 
   return (
     <Root aria-label="analytics page">
       <Fade in>
         <Box>
           {props.mode !== projectModes.SIMULATION && (
-            <PageHeader header="Analytics" mobileScreen={props.mobileScreen} />
+            <Box
+              className="main-page-sticky-header-wrapper"
+              sx={{ background: (theme) => theme.palette.background.paper }}
+            >
+              <Box
+                className="main-page-sticky-header with-button"
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <PageHeader
+                  header="Analytics"
+                  mobileScreen={props.mobileScreen}
+                />
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={!includePriorKnowledge}
+                        onChange={handleTogglePriorKnowledge}
+                      />
+                    }
+                    label="Hide Prior Knowledge"
+                    labelPlacement="start"
+                  />
+                  <CustomTooltip
+                    title={
+                      <React.Fragment>
+                        <br />
+                        <br />
+                        <ul style={{ margin: 0, paddingLeft: "1.5em" }}>
+                          <li>
+                            <strong>Hiding</strong> prior knowledge will only
+                            show labelings done using ASReview.
+                          </li>
+                          <br />
+                          <li>
+                            <strong>Showing</strong> prior knowledge will show
+                            combined labelings from the original dataset and
+                            those done using ASReview.
+                          </li>
+                        </ul>
+                      </React.Fragment>
+                    }
+                    arrow
+                  >
+                    <IconButton size="small" sx={{ marginRight: 1 }}>
+                      <HelpOutlineIcon />
+                    </IconButton>
+                  </CustomTooltip>
+                </Box>
+              </Box>
+            </Box>
           )}
           {props.mode === projectModes.SIMULATION && (
             <Box
               className="main-page-sticky-header-wrapper"
               sx={{ background: (theme) => theme.palette.background.paper }}
             >
-              <Box className="main-page-sticky-header with-button">
-                {!props.mobileScreen && (
-                  <TypographyH5Medium>Analytics</TypographyH5Medium>
-                )}
-                {props.mobileScreen && (
-                  <Typography variant="h6">Analytics</Typography>
-                )}
-                <Stack direction="row" spacing={1}>
-                  <Button
-                    disabled={!allQueriesReady() || !props.isSimulating}
-                    variant="contained"
-                    onClick={props.refetchAnalytics}
-                    size={!props.mobileScreen ? "medium" : "small"}
+              <Box
+                className="main-page-sticky-header with-button"
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <PageHeader
+                  header="Analytics"
+                  mobileScreen={props.mobileScreen}
+                />
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={!includePriorKnowledge}
+                        onChange={handleTogglePriorKnowledge}
+                      />
+                    }
+                    label="Hide Prior Knowledge"
+                    labelPlacement="start"
+                  />
+                  <CustomTooltip
+                    title={
+                      <React.Fragment>
+                        Toggle to include or hide prior knowledge from the
+                        statistics.
+                        <br />
+                        <br />
+                        <ul style={{ margin: 0, paddingLeft: "1.5em" }}>
+                          <li>
+                            <strong>Hiding</strong> prior knowledge will only
+                            show labelings done using ASReview.
+                          </li>
+                          <br />
+                          <li>
+                            <strong>Showing</strong> prior knowledge will show
+                            combined labelings from the original dataset and
+                            those done using ASReview.
+                          </li>
+                        </ul>
+                      </React.Fragment>
+                    }
+                    arrow
                   >
-                    Refresh
-                  </Button>
-                </Stack>
+                    <IconButton size="small" sx={{ marginRight: 1 }}>
+                      <HelpOutlineIcon />
+                    </IconButton>
+                  </CustomTooltip>
+                </Box>
               </Box>
             </Box>
           )}
@@ -144,12 +270,14 @@ const AnalyticsPage = (props) => {
                         mobileScreen={props.mobileScreen}
                         mode={props.mode}
                         progressQuery={progressQuery}
+                        includePriorKnowledge={includePriorKnowledge} // Pass the state as prop
                       />
                     </Grid>
                     <Grid item xs={12} sm={7}>
                       <NumberCard
                         mobileScreen={props.mobileScreen}
                         progressQuery={progressQuery}
+                        includePriorKnowledge={includePriorKnowledge} // Pass the state as prop
                       />
                     </Grid>
                   </Grid>
@@ -196,5 +324,4 @@ const AnalyticsPage = (props) => {
     </Root>
   );
 };
-
 export default AnalyticsPage;

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/NumberCard.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/NumberCard.js
@@ -19,6 +19,45 @@ export default function NumberCard(props) {
     );
   };
 
+  const getLabeledRecords = () => {
+    if (showNumber()) {
+      if (props.includePriorKnowledge) {
+        return (
+          (props.progressQuery.data["n_included"] || 0) +
+          (props.progressQuery.data["n_excluded"] || 0)
+        );
+      } else {
+        return (
+          (props.progressQuery.data["n_included_no_priors"] || 0) +
+          (props.progressQuery.data["n_excluded_no_priors"] || 0)
+        );
+      }
+    }
+    return 0;
+  };
+
+  const getRelevantRecords = () => {
+    if (showNumber()) {
+      if (props.includePriorKnowledge) {
+        return props.progressQuery.data["n_included"] || 0;
+      } else {
+        return props.progressQuery.data["n_included_no_priors"] || 0;
+      }
+    }
+    return 0;
+  };
+
+  const getIrrelevantRecordsSinceLastRelevant = () => {
+    if (showNumber()) {
+      // Always use the data without prior knowledge, regardless of the switch state
+      return props.progressQuery.data["n_since_last_inclusion_no_priors"] !==
+        null
+        ? props.progressQuery.data["n_since_last_inclusion_no_priors"]
+        : "-";
+    }
+    return 0;
+  };
+
   return (
     <Root>
       <CardErrorHandler
@@ -43,12 +82,7 @@ export default function NumberCard(props) {
                   variant={!props.mobileScreen ? "h4" : "h5"}
                 >
                   <NumberFormat
-                    value={
-                      showNumber()
-                        ? props.progressQuery.data["n_included"] +
-                          props.progressQuery.data["n_excluded"]
-                        : 0
-                    }
+                    value={getLabeledRecords()}
                     displayType="text"
                     thousandSeparator
                   />
@@ -73,9 +107,7 @@ export default function NumberCard(props) {
                   variant={!props.mobileScreen ? "h4" : "h5"}
                 >
                   <NumberFormat
-                    value={
-                      showNumber() ? props.progressQuery.data["n_included"] : 0
-                    }
+                    value={getRelevantRecords()}
                     displayType="text"
                     thousandSeparator
                   />
@@ -84,35 +116,29 @@ export default function NumberCard(props) {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} sm={12}>
-          <Card className="number-card" elevation={2}>
-            <CardContent>
-              <Stack spacing={2} className="number-card-content">
-                <Typography
-                  className="number-card-content-text"
-                  variant={!props.mobileScreen ? "subtitle1" : "subtitle2"}
-                  sx={{ color: "text.secondary" }}
-                >
-                  Irrelevant records since last relevant
-                </Typography>
-                <Typography
-                  className="number-card-content-numeral"
-                  variant={!props.mobileScreen ? "h4" : "h5"}
-                >
-                  <NumberFormat
-                    value={
-                      showNumber()
-                        ? props.progressQuery.data["n_since_last_inclusion"]
-                        : 0
-                    }
-                    displayType="text"
-                    thousandSeparator
-                  />
-                </Typography>
-              </Stack>
-            </CardContent>
-          </Card>
-        </Grid>
+        {showNumber() && (
+          <Grid item xs={12} sm={12}>
+            <Card className="number-card" elevation={2}>
+              <CardContent>
+                <Stack spacing={2} className="number-card-content">
+                  <Typography
+                    className="number-card-content-text"
+                    variant={!props.mobileScreen ? "subtitle1" : "subtitle2"}
+                    sx={{ color: "text.secondary" }}
+                  >
+                    Irrelevant records since last relevant
+                  </Typography>
+                  <Typography
+                    className="number-card-content-numeral"
+                    variant={!props.mobileScreen ? "h4" : "h5"}
+                  >
+                    {getIrrelevantRecordsSinceLastRelevant()}
+                  </Typography>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
       </Grid>
     </Root>
   );

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressChart.js
@@ -35,6 +35,12 @@ export default function ProgressChart(props) {
   const n_papers = props.progressQuery.data
     ? props.progressQuery.data["n_papers"]
     : null;
+  const n_included_no_priors = props.progressQuery.data
+    ? props.progressQuery.data["n_included_no_priors"]
+    : null;
+  const n_excluded_no_priors = props.progressQuery.data
+    ? props.progressQuery.data["n_excluded_no_priors"]
+    : null;
 
   const formattedTotal = React.useCallback(() => {
     if (props.mode !== projectModes.SIMULATION || !props.isSimulating) {
@@ -50,15 +56,27 @@ export default function ProgressChart(props) {
    * Chart data array
    */
   const seriesArray = React.useCallback(() => {
-    if (n_included && n_excluded && n_papers) {
+    if (props.includePriorKnowledge) {
       return [
         Math.round(((n_included + n_excluded) / n_papers) * 10000) / 100,
         Math.round((n_included / n_papers) * 10000) / 100,
       ];
     } else {
-      return [];
+      return [
+        Math.round(
+          ((n_included_no_priors + n_excluded_no_priors) / n_papers) * 10000,
+        ) / 100,
+        Math.round((n_included_no_priors / n_papers) * 10000) / 100,
+      ];
     }
-  }, [n_included, n_excluded, n_papers]);
+  }, [
+    n_included,
+    n_excluded,
+    n_papers,
+    props.includePriorKnowledge,
+    n_included_no_priors,
+    n_excluded_no_priors,
+  ]);
 
   /**
    * Chart options
@@ -110,18 +128,32 @@ export default function ProgressChart(props) {
           },
         },
       },
-      colors: [
-        theme.palette.mode === "light"
-          ? theme.palette.secondary.light
-          : theme.palette.secondary.main,
-        theme.palette.mode === "light"
-          ? theme.palette.primary.light
-          : theme.palette.primary.main,
-      ],
+      colors: props.includePriorKnowledge
+        ? [
+            theme.palette.mode === "light"
+              ? theme.palette.secondary.light
+              : theme.palette.secondary.main,
+            theme.palette.mode === "light"
+              ? theme.palette.primary.light
+              : theme.palette.primary.main,
+            theme.palette.mode === "light"
+              ? theme.palette.warning.light
+              : theme.palette.warning.main,
+          ]
+        : [
+            theme.palette.mode === "light"
+              ? theme.palette.secondary.light
+              : theme.palette.secondary.main,
+            theme.palette.mode === "light"
+              ? theme.palette.warning.light
+              : theme.palette.warning.main,
+          ],
       dataLabels: {
         enabled: false,
       },
-      labels: ["Labeled", "Relevant"],
+      labels: props.includePriorKnowledge
+        ? ["Labeled", "Relevant"]
+        : ["Labeled", "Relevant"],
       legend: {
         show: true,
         position: "bottom",
@@ -171,6 +203,7 @@ export default function ProgressChart(props) {
     props.mobileScreen,
     props.mode,
     props.isSimulating,
+    props.includePriorKnowledge,
   ]);
 
   const [series, setSeries] = React.useState(seriesArray());

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -22,13 +22,37 @@ class ProjectAPI {
     });
   }
 
-  static fetchDashboardStats({ queryKey }) {
+  static fetchDashboardStats({ queryKey, includePrior = true }) {
     const url = api_url + `projects/stats`;
     return new Promise((resolve, reject) => {
       axios
-        .get(url, { withCredentials: true })
+        .get(url, {
+          params: { includePrior: includePrior },
+          withCredentials: true,
+        })
         .then((result) => {
           resolve(result.data["result"]);
+        })
+        .catch((error) => {
+          reject(axiosErrorHandler(error));
+        });
+    });
+  }
+
+  static mutateInitProject(variables) {
+    let body = new FormData();
+    body.set("mode", variables.mode);
+
+    const url = api_url + `projects/info`;
+    return new Promise((resolve, reject) => {
+      axios({
+        method: "post",
+        url: url,
+        data: body,
+        withCredentials: true,
+      })
+        .then((result) => {
+          resolve(result["data"]);
         })
         .catch((error) => {
           reject(axiosErrorHandler(error));
@@ -517,11 +541,11 @@ class ProjectAPI {
   }
 
   static fetchProgress({ queryKey }) {
-    const { project_id } = queryKey[1];
+    const { project_id, includePrior } = queryKey[1];
     const url = api_url + `projects/${project_id}/progress`;
     return new Promise((resolve, reject) => {
       axios
-        .get(url, { withCredentials: true })
+        .get(url, { params: { priors: includePrior }, withCredentials: true })
         .then((result) => {
           resolve(result["data"]);
         })


### PR DESCRIPTION
**Changes:**

	•	Resolved Issue #1747: Corrected misleading `Irrelevant since last relevant` count display when including prior knowledge in the dataset.

	•	Added the `Hide Prior Knowledge` Switch: Implemented a toggle switch on the Analytics page to manage visibility of prior knowledge, enhancing user control over displayed data.

	•	Refactored API Calls: Optimized API calls to accommodate the new feature and enhance overall performance.

**Details:**

_Fixing Functionality:_ Previously, `Irrelevant since last relevant`count was only checking the difference between relevant and irrelevant counts. Now, before displaying this count, it confirms if these labelings are indeed done with ASReview and are not coming from the prior labelling.

_Enhancements for future developments:_ Introducing separate calculations for prior and recent knowledge, reflected in `n_included_no_priors` and `n_excluded_no_priors`.

_New Switch:_ The `Hide Prior Knowledge` switch toggles between including and excluding prior knowledge using the includePriorKnowledge parameter. It is currently **on** by default.

**Future:**

- The switch is currently **on** by default, we can improve this functionality by adding a preference logic at both user and project levels.

**Testing**

`Hide Prior Knowledge`switch:

- **Works as intended** with newly uploaded datasets, in both on/off states
- **Works as intended** when new labellings are conducted with ASReview, in both on/off states
- **Works as intended** with the recent `Irrelevant since last relevant` change

`Irrelevant since last relevant` display:

- **Works as intended** with the recent `Hide Prior Knowledge` switch
- Displays '-' if the user directly goes to the Analytics dashboard without labelling
- Displays '-' if the user adds prior knowledge before going to the Analytics dashboard
- Displays '0' if the user's first labelling with ASReview is 'relevant'
- Displays '1' if the user's first labelling with ASReview is 'irrelevant'
- **Works as intended** in all the labellings done after