### PR TITLE
Resolves #1361: Inconsistencies in Y-Axis Intervals and Alignments for Progress and Recall Charts

### DIFF
--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressDensityChart.js
@@ -254,7 +254,7 @@ export default function ProgressDensityChart(props) {
         showAlways: false,
         max: 10,
         min: 0,
-        tickAmount: 3,
+        tickAmount: 5,
         title: {
           text: "Number of relevant records",
         },

--- a/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
+++ b/asreview/webapp/src/ProjectComponents/AnalyticsComponents/ProgressRecallChart.js
@@ -188,6 +188,10 @@ export default function ProgressRecallChart(props) {
    * Chart options
    */
   const optionsChart = React.useCallback(() => {
+    const maxYValue = maxY() || 0;
+    const tickAmount = 7;
+    const closestDivisibleBy7 = Math.ceil(maxYValue / tickAmount) * tickAmount; // To make the intervals consistent, max value in the y-axis should be always divisible by 7.
+
     return {
       chart: {
         animations: {
@@ -265,9 +269,10 @@ export default function ProgressRecallChart(props) {
           },
         },
         showAlways: false,
-        max: maxY(),
+        max: closestDivisibleBy7,
         forceNiceScale: false,
-        tickAmount: maxY() < 6 ? maxY() : 6,
+        min: 0,
+        tickAmount: tickAmount,
         title: {
           text: "Number of relevant records",
         },


### PR DESCRIPTION
### Description
Resolves https://github.com/asreview/asreview/issues/1361.

In the Analytics dashboard, the Y-axis gridlines of the _Progress_ and _Recall_ plots were not equally apart. Additionally, for the 'Recall' plot, there was a mismatch between the values in the plot and the values of the gridlines.

### Changes
These problems occurred because the corresponding tick amounts on the Y-axis weren't consistently divisible by the max amounts on the Y-axis. The following changes were made to address these issues:

1. Progress Chart: The `tickAmount` in the _Progress_ chart was changed to 5 from 3, which is a divisor of 10.
 
2. Recall Chart: The `tickAmount` in the _Recall_ chart was fixed to 7. Also, the maximum value on the Y-axis will now be switched by the closest number that is divisible by 7.

### Testing

- The grid amount in the _Progress_ chart is always fixed and displays the correct value.
- The maximum value of the _Recall_ chart is 5 when there are no labellings. With the first labelling, it goes to 7. It stays at 7 when 7 labellings are done. Then goes to 14 with the 8th labelling. This process repeats with every 7 labelled records.  
