### PR TITLE
Update feature matrix reading and writing

### DIFF
--- a/asreview/project.py
+++ b/asreview/project.py
@@ -31,12 +31,8 @@ from pathlib import Path
 from uuid import uuid4
 
 import jsonschema
-import numpy as np
 import pandas as pd
 from filelock import FileLock
-from scipy.sparse import csr_matrix
-from scipy.sparse import load_npz
-from scipy.sparse import save_npz
 
 from asreview import load_dataset
 from asreview.config import LABEL_NA
@@ -320,27 +316,23 @@ class Project:
         except Exception:
             return []
 
-    def add_feature_matrix(self, feature_matrix, feature_extraction_method):
+    @staticmethod
+    def get_matrix_filename(feature_model):
+        """Get the file name of the feature matrix for a specific feature model."""
+        return f"{feature_model.name}_feature_matrix.{feature_model.file_extension}"
+
+    def add_feature_matrix(self, feature_matrix, feature_model):
         """Add feature matrix to project file.
 
         Arguments
         ---------
         feature_matrix: numpy.ndarray, scipy.sparse.csr.csr_matrix
             The feature matrix to add to the project file.
-        feature_extraction_method: str
-            Name of the feature extraction method.
+        feature_model: BaseFeatureExtraction
+            Feature extraction class.
         """
-        # Make sure the feature matrix is in csr format.
-        if isinstance(feature_matrix, np.ndarray):
-            feature_matrix = csr_matrix(feature_matrix)
-        if not isinstance(feature_matrix, csr_matrix):
-            raise ValueError(
-                "The feature matrix should be convertible to type "
-                "scipy.sparse.csr.csr_matrix."
-            )
-
-        matrix_filename = f"{feature_extraction_method}_feature_matrix.npz"
-        save_npz(
+        matrix_filename = self.get_matrix_filename(feature_model)
+        feature_model.write(
             Path(self.project_path, PATH_FEATURE_MATRICES, matrix_filename),
             feature_matrix,
         )
@@ -349,7 +341,7 @@ class Project:
         config = self.config
 
         feature_matrix_config = {
-            "id": feature_extraction_method,
+            "id": feature_model.name,
             "filename": matrix_filename,
         }
 
@@ -361,21 +353,23 @@ class Project:
 
         self.config = config
 
-    def get_feature_matrix(self, feature_extraction_method):
+    def get_feature_matrix(self, feature_model):
         """Get the feature matrix from the project file.
 
         Arguments
         ---------
-        feature_extraction_method: str
-            Name of the feature extraction method for which to get the matrix.
+        feature_model : BaseFeatureExtraction
+            Feature extraction class for which to get the matrix.
 
         Returns
         -------
-        scipy.sparse.csr_matrix:
-            Feature matrix in sparse format.
+        numpy.ndarray, scipy.sparse.csr_matrix:
+            Feature matrix. This should have the same length as the dataset.
         """
-        matrix_filename = f"{feature_extraction_method}_feature_matrix.npz"
-        return load_npz(Path(self.project_path, PATH_FEATURE_MATRICES, matrix_filename))
+        matrix_filename = self.get_matrix_filename(feature_model)
+        return feature_model.read(
+            Path(self.project_path, PATH_FEATURE_MATRICES, matrix_filename)
+        )
 
     @property
     def reviews(self):

--- a/asreview/simulation/cli.py
+++ b/asreview/simulation/cli.py
@@ -201,7 +201,7 @@ def _cli_simulate(argv):
     fm = feature_model.fit_transform(
         as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
     )
-    project.add_feature_matrix(fm, feature_model.name)
+    project.add_feature_matrix(fm, feature_model)
 
     print("The following records are prior knowledge:\n")
     for record_id, _ in as_data.df.iloc[prior_idx].iterrows():

--- a/asreview/webapp/entry_points/run_model.py
+++ b/asreview/webapp/entry_points/run_model.py
@@ -61,12 +61,12 @@ def _run_model_start(project, output_error=True):
                 "models.feature_extraction", settings.feature_extraction
             )()
             try:
-                fm = project.get_feature_matrix(feature_model.name)
+                fm = project.get_feature_matrix(feature_model)
             except FileNotFoundError:
                 fm = feature_model.fit_transform(
                     as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
                 )
-                project.add_feature_matrix(fm, feature_model.name)
+                project.add_feature_matrix(fm, feature_model)
 
             # TODO: Simplify balance model input.
             # Use the balance model to sample the trainings data.
@@ -132,7 +132,7 @@ def _simulate_start(project):
     fm = feature_model.fit_transform(
         as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
     )
-    project.add_feature_matrix(fm, feature_model.name)
+    project.add_feature_matrix(fm, feature_model)
 
     sim = Simulate(
         fm,

--- a/docs/source/technical/example_api_asreview_file.ipynb
+++ b/docs/source/technical/example_api_asreview_file.ipynb
@@ -319,7 +319,7 @@
    ],
    "source": [
     "feature_extraction_id = project.feature_matrices[0][\"id\"]\n",
-    "feature_model = asr.load_extension(\"models.feature_extraction\", feature_extraction_id)()\n",
+    "feature_model = asr.load_extension(\"models.feature_extraction\", feature_extraction_id)\n",
     "feature_matrix = project.get_feature_matrix(feature_model)\n",
     "print(feature_matrix[0])\n"
    ]

--- a/docs/source/technical/example_api_asreview_file.ipynb
+++ b/docs/source/technical/example_api_asreview_file.ipynb
@@ -319,7 +319,8 @@
    ],
    "source": [
     "feature_extraction_id = project.feature_matrices[0][\"id\"]\n",
-    "feature_matrix = project.get_feature_matrix(feature_extraction_id)\n",
+    "feature_model = asr.load_extension(\"models.feature_extraction\", feature_extraction_id)()\n",
+    "feature_matrix = project.get_feature_matrix(feature_model)\n",
     "print(feature_matrix[0])\n"
    ]
   },

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -28,7 +28,7 @@ def test_simulate_basic(tmpdir):
     fm = feature_model.fit_transform(
         as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
     )
-    project.add_feature_matrix(fm, feature_model.name)
+    project.add_feature_matrix(fm, feature_model)
 
     # set numpy seed
     np.random.seed(42)
@@ -70,7 +70,7 @@ def test_simulate_no_prior(tmpdir):
     fm = feature_model.fit_transform(
         as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
     )
-    project.add_feature_matrix(fm, feature_model.name)
+    project.add_feature_matrix(fm, feature_model)
 
     # set numpy seed
     np.random.seed(42)
@@ -111,7 +111,7 @@ def test_simulate_random_prior(tmpdir):
     fm = feature_model.fit_transform(
         as_data.texts, as_data.headings, as_data.bodies, as_data.keywords
     )
-    project.add_feature_matrix(fm, feature_model.name)
+    project.add_feature_matrix(fm, feature_model)
 
     # set numpy seed
     np.random.seed(42)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -317,7 +317,7 @@ def test_get_feature_matrix(asreview_test_project):
     assert len(project.feature_matrices) == 1
 
     feature_model_name = project.feature_matrices[0]["id"]
-    feature_model = load_extension("models.feature_extraction", feature_model_name)()
+    feature_model = load_extension("models.feature_extraction", feature_model_name)
     feature_matrix = project.get_feature_matrix(feature_model)
     assert isinstance(feature_matrix, csr_matrix)
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,6 +6,7 @@ import pytest
 from scipy.sparse import csr_matrix
 
 import asreview as asr
+from asreview.extensions import load_extension
 from asreview.project import ProjectNotFoundError
 from asreview.state.exceptions import StateNotFoundError
 
@@ -315,7 +316,9 @@ def test_get_feature_matrix(asreview_test_project):
 
     assert len(project.feature_matrices) == 1
 
-    feature_matrix = project.get_feature_matrix(project.feature_matrices[0]["id"])
+    feature_model_name = project.feature_matrices[0]["id"]
+    feature_model = load_extension("models.feature_extraction", feature_model_name)()
+    feature_matrix = project.get_feature_matrix(feature_model)
     assert isinstance(feature_matrix, csr_matrix)
 
 


### PR DESCRIPTION
This pull requests moves the code for reading and writing feature matrices from the project class to the base feature extraction class. This way people can overwrite the method and implement their own format to store a feature matrix.

Some comments:
- I called the methods `read` and `write`. My other main option was `load` and `save` because that's what the matrix storing methods are called in `numpy`. In ASReview I found more mentions of `read` though. However even only in the project class I found `Project.load` and `Project.read_data`, so we don't have any consistent naming at the moment.
- I made `BaseFeatureExtraction.load` and `save` static methods since they don't use anything of the class itself at the moment. Maybe they should be class methods, or just methods?
- To call `Project.get_feature_matrix` you now need the actual feature extraction class instead of just it's name. For this I used `feature_model = load_extension("models.feature_extraction", settings.feature_extraction)`, but this seems a little ugly to ask users of the Python API to use. Maybe we should have a dedicated `load_feature_model` function?