### PR TITLE
Bump pandas version to 2 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 license = {text = "Apache 2.0"}
 dependencies = [
     "numpy",
-    "pandas>=1.3,<3",
+    "pandas>=2,<3",
     "scikit-learn",
     "rispy~=0.7.0",
     "setuptools",


### PR DESCRIPTION
This resolves an issue with exporting datasets (https://github.com/asreview/asreview/discussions/1657).

> ERROR:root:Failed to export the csv dataset. maximum recursion depth exceeded while calling a Python object

