### PR TITLE
Mark tests as requiring internet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,3 +196,6 @@ docstring-code-line-length = "dynamic"
 
 [tool.pytest.ini_options]
 addopts = "--ignore=asreview/webapp/tests/integration_tests"
+markers = [
+    "internet_required: requires internet connection to run",
+]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -35,6 +35,7 @@ def test_fuzzy_finder(keywords, record_id):
     assert fuzzy_find(as_data, keywords)[0] == record_id
 
 
+@mark.internet_required
 @mark.parametrize(
     "data_name",
     [

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest import mark
 
 from asreview.datasets import BaseDataGroup
 from asreview.datasets import BaseDataSet
@@ -6,6 +7,7 @@ from asreview.datasets import DatasetManager
 from asreview.datasets import NaturePublicationDataGroup
 
 
+@mark.internet_required
 def test_group():
     group_nature = NaturePublicationDataGroup()
 
@@ -19,12 +21,14 @@ def test_group():
         )
 
 
+@mark.internet_required
 def test_group_to_dict():
     group_nature = NaturePublicationDataGroup()
 
     assert isinstance(group_nature.__dict__(), dict)
 
 
+@mark.internet_required
 def test_group_list():
     dm = DatasetManager()
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -27,7 +27,9 @@ from asreview.utils import _is_url
         ("scopus.ris", 6, []),
         ("ovid_zotero.ris", 6, []),
         ("proquest.ris", 6, []),
-        pytest.param("https://osf.io/download/fg93a/", 38, [], marks=mark.internet_required),
+        pytest.param(
+            "https://osf.io/download/fg93a/", 38, [], marks=mark.internet_required
+        ),
     ],
 )
 def test_reader(test_file, n_lines, ignore_col):

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from urllib.request import urlretrieve
 
+import pytest
 import rispy
 from pytest import mark
 
@@ -26,7 +27,7 @@ from asreview.utils import _is_url
         ("scopus.ris", 6, []),
         ("ovid_zotero.ris", 6, []),
         ("proquest.ris", 6, []),
-        ("https://osf.io/download/fg93a/", 38, []),
+        pytest.param("https://osf.io/download/fg93a/", 38, [], marks=mark.internet_required),
     ],
 )
 def test_reader(test_file, n_lines, ignore_col):
@@ -191,6 +192,7 @@ def test_write_data(tmpdir):
     assert list(asr_data.labels) == list(asr_data_diff.labels)
 
 
+@mark.internet_required
 def test_load_dataset_from_url(tmpdir):
     url = "https://zenodo.org/api/records/1162952/files/Hall.csv/content"
 


### PR DESCRIPTION
I'm in the train at the moment and the internet is quite spotty. So I thought it might be useful to be able to skip tests that require an internet connection to run. Not sure if this is a contribution we really need, but let me know what you think! 

I added a pytest mark `internet_required` that you can add to any test that requires an internet connection. Then you can run the tests with `pytest -k "not internet_required"` to only run the offline tests. 

I only marked tests outside of webapp, since I thought it would make less sense to have something like this in webapp. I'm also not quite sure if I've got all of the tests requiring internet (I'm also running into some other problems relating to cleaning up temporary directories on Windows, so the errors I'm getting don't make much sense). Tests that require the Synergy dataset first look locally if they can find it I think, so those only require a connection if you don't have Synergy locally.