### PR TITLE
Update docker.yml to include latest tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,5 +52,5 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }},ghcr.io/asreview/asreview:latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#1815 is correct, there's no latest package. Maybe we should also add this to the 1.6 tag branch.