### PR TITLE
Add test for loading RIS files from citation-file-formatting

### DIFF
--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -201,3 +201,12 @@ def test_load_dataset_from_url(tmpdir):
     urlretrieve(url, tmpdir / "Hall.csv")
     as_data = load_dataset(tmpdir / "Hall.csv")
     assert len(as_data) == 8911
+
+
+@pytest.mark.skip()
+@pytest.mark.parametrize(
+    "dataset_fp", Path("..", "citation-file-formatting", "Datasets", "RIS").glob("*")
+)
+def test_real_datasets(dataset_fp):
+    data = load_dataset(dataset_fp)
+    assert len(data) > 5


### PR DESCRIPTION
Currently the test is skipped due to expected changes to rispy in https://github.com/MrTango/rispy/pull/66. 

The good news: all exports are supported by ASReview except from PubMed and Cochrane. The latter will be supported by rispy if https://github.com/MrTango/rispy/pull/66 gets merged. 