### PR TITLE
Apply colors with colorScheme API 

### DIFF
--- a/asreview/webapp/src/App.js
+++ b/asreview/webapp/src/App.js
@@ -30,6 +30,7 @@ import { HomePage } from "./HomeComponents";
 import { ProjectPage } from "ProjectComponents";
 import { useFontSize } from "hooks/SettingsHooks";
 import { useToggle } from "hooks/useToggle";
+import { colorScheme } from "constants/theme";
 
 // Ensure that on localhost we use 'localhost' instead of '127.0.0.1'
 const currentDomain = window.location.href;
@@ -67,7 +68,7 @@ const App = () => {
 
   const muiTheme = createTheme({
     // cssVariables: true,
-    colorSchemes: { dark: true },
+    colorSchemes: colorScheme,
   });
   const mobileScreen = useMediaQuery(muiTheme.breakpoints.down("md"), {
     noSsr: true,

--- a/asreview/webapp/src/constants/theme.js
+++ b/asreview/webapp/src/constants/theme.js
@@ -1,0 +1,54 @@
+export const colorScheme = {
+  light: {
+    palette: {
+      primary: {
+        main: "#bf9906",
+      },
+      secondary: {
+        main: "#A5C18E",
+      },
+      background: {
+        default: "#FFFFFA",
+        paper: "#F7F7F2",
+      },
+      text: {
+        primary: "#3E2723",
+        secondary: "#6D4C41",
+      },
+      error: { main: "#D32F2F" },
+
+      grey: {
+        400: "#DEDBD2",
+        600: "#4A5759",
+        800: "#37474F",
+      },
+    },
+  },
+  dark: {
+    palette: {
+      primary: {
+        main: "#FFCC00",
+      },
+      secondary: {
+        main: "#64B5F6",
+      },
+      background: {
+        default: "#121212",
+        paper: "#1E1E1E",
+      },
+      text: {
+        primary: "#FFFFFF",
+        secondary: "#B0B0B0",
+      },
+      error: {
+        main: "#FF6B6B",
+      },
+
+      grey: {
+        400: "#4d4d4d",
+        600: "#6F7E6F",
+        800: "#B0B0B0",
+      },
+    },
+  },
+};


### PR DESCRIPTION
This PR isolates the color scheme work by @BerkeYazan in PR #1859. 

Things I didn't manage to migrate are: 

```
    "contrast": {
      "400": "#BCA37F",
      "600": "#EAD7BB"
    },
    "accent": "#528fb4",
    "elevation": {
      "low": "#1E1E1E",
      "medium": "#232323",
      "high": "#282828"
    }
```

This is not part of https://mui.com/material-ui/customization/default-theme/. 

@BerkeYazan, feel free to continue working on this PR. 
