### PR TITLE
Remove embedding from simulate CLI

### DIFF
--- a/asreview/simulation/cli.py
+++ b/asreview/simulation/cli.py
@@ -387,11 +387,4 @@ def _simulate_parser(prog="simulate", description=DESCRIPTION_SIMULATE):
         "to simulate all labels actions.",
     )
     parser.add_argument("--verbose", "-v", default=0, type=int, help="Verbosity")
-    parser.add_argument(
-        "--embedding",
-        type=str,
-        default=None,
-        dest="embedding_fp",
-        help="File path of embedding matrix. Required for LSTM models.",
-    )
     return parser

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -23,14 +23,13 @@ def test_features(feature_extraction, split_ta):
     if feature_extraction in REQUIRES_AI_MODEL_DEP:
         pytest.skip()
 
-    embedding_fp = os.path.join("tests", "demo_data", "generic.vec")
     data_fp = os.path.join("tests", "demo_data", "generic.csv")
 
     as_data = asr.load_dataset(data_fp)
     texts = as_data.texts
     if feature_extraction.startswith("embedding-"):
         model = load_extension("models.feature_extraction", feature_extraction)(
-            split_ta=split_ta, embedding_fp=embedding_fp
+            split_ta=split_ta
         )
     else:
         model = load_extension("models.feature_extraction", feature_extraction)(

--- a/tests/test_simulate_cli.py
+++ b/tests/test_simulate_cli.py
@@ -10,7 +10,6 @@ DATA_FP = Path("tests", "demo_data", "generic_labels.csv")
 DATA_FP_URL = "https://raw.githubusercontent.com/asreview/asreview/master/tests/demo_data/generic_labels.csv"  # noqa
 DATA_FP_NO_ABS = Path("tests", "demo_data", "generic_labels_no_abs.csv")
 DATA_FP_NO_TITLE = Path("tests", "demo_data", "generic_labels_no_title.csv")
-EMBEDDING_FP = Path("tests", "demo_data", "generic.vec")
 CFG_DIR = Path("tests", "cfg_files")
 STATE_DIR = Path("tests", "state_files")
 H5_STATE_FILE = Path(STATE_DIR, "test.h5")


### PR DESCRIPTION
Embedding should be loaded from the feature extractor itself. This makes it easier to implement more advanced feature extractors.  
