### PR TITLE
Add loss metric from asreview-insights to simulate output

### DIFF
--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -21,7 +21,7 @@ def loss(labels: List[int]):
     Ny = sum(labels)
     Nx = len(labels)
     if Ny == 0 or Nx == Ny:
-        loss = f"{Ny = }"
+        raise ValueError("The labels must contain at least two distinct classes.")
     else:
         loss = float(
             (Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny))

--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -27,27 +27,3 @@ def loss(labels: List[int]):
             (Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny))
         )
     return loss
-
-
-def wss(labels, intercept, x_absolute=False, y_absolute=False):
-    n_docs = len(labels)
-    n_pos_docs = sum(labels)
-
-    docs_found = np.cumsum(labels)
-    docs_found_random = np.round(np.linspace(0, n_pos_docs, n_docs))
-
-    when_found = np.searchsorted(docs_found, np.arange(1, n_pos_docs + 1))
-    when_found_random = np.searchsorted(docs_found_random, np.arange(1, n_pos_docs + 1))
-    n_found_earlier = when_found_random - when_found
-
-    x = np.arange(1, n_pos_docs + 1)
-    if not x_absolute:
-        x = x / n_pos_docs
-
-    if y_absolute:
-        y = n_found_earlier
-    else:
-        y = n_found_earlier / n_docs
-
-    i = np.searchsorted(x, intercept, side="right")
-    return y[i - 1]

--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -21,7 +21,7 @@ def loss(labels: List[int]):
     Ny = sum(labels)
     Nx = len(labels)
     if Ny == 0 or Nx == Ny:
-        raise ValueError("The labels must contain at least two distinct classes.")
+        raise ValueError("Labels must contain two distinct classes.")
     else:
         loss = float(
             (Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny))

--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -15,14 +15,18 @@
 from typing import List
 import numpy as np
 
+
 def loss(labels: List[int]):
     Ny = sum(labels)
     Nx = len(labels)
     if Ny == 0 or Nx == Ny:
-        loss = f'{Ny = }'
+        loss = f"{Ny = }"
     else:
-        loss = float((Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny)))
+        loss = float(
+            (Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny))
+        )
     return loss
+
 
 def wss(labels, intercept, x_absolute=False, y_absolute=False):
     n_docs = len(labels)

--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -1,0 +1,48 @@
+# Copyright 2019-2022 The ASReview Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+import numpy as np
+
+def loss(labels: List[int]):
+    Ny = sum(labels)
+    Nx = len(labels)
+    if Ny == 0 or Nx == Ny:
+        loss = f'{Ny = }'
+    else:
+        loss = float((Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny)))
+    return loss
+
+def wss(labels, intercept, x_absolute=False, y_absolute=False):
+    n_docs = len(labels)
+    n_pos_docs = sum(labels)
+
+    docs_found = np.cumsum(labels)
+    docs_found_random = np.round(np.linspace(0, n_pos_docs, n_docs))
+
+    when_found = np.searchsorted(docs_found, np.arange(1, n_pos_docs + 1))
+    when_found_random = np.searchsorted(docs_found_random, np.arange(1, n_pos_docs + 1))
+    n_found_earlier = when_found_random - when_found
+
+    x = np.arange(1, n_pos_docs + 1)
+    if not x_absolute:
+        x = x / n_pos_docs
+
+    if y_absolute:
+        y = n_found_earlier
+    else:
+        y = n_found_earlier / n_docs
+
+    i = np.searchsorted(x, intercept, side="right")
+    return y[i - 1]

--- a/asreview/metrics.py
+++ b/asreview/metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import List
+
 import numpy as np
 
 

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -167,7 +167,9 @@ class Simulate:
             pbar_rel.close()
             pbar_total.close()
 
-            padded_results = list(self._results['label']) + [0] * (len(self.labels) - len(self._results['label']))
+            padded_results = list(self._results["label"]) + [0] * (
+                len(self.labels) - len(self._results["label"])
+            )
 
             metrics_block = f"""
 \033[95m----------------\033[0m Metrics Summary \033[95m----------------\033[0m
@@ -176,9 +178,8 @@ Records Labeled             : {len(self._results['label'])}/{len(self.labels)}
 Loss                        : {round(metrics.loss(padded_results), 2)}
 WSS@95%                     : {round(metrics.wss(padded_results, 0.95), 2)}
 \033[95m-------------------------------------------------\033[0m
-            """ 
+            """
             print(metrics_block)
-
 
     def train(self):
         """Train a new model on the labeled data."""

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 
 from asreview.config import DEFAULT_N_INSTANCES
 from asreview.state.contextmanager import open_state
-from asreview import metrics
+from asreview.metrics import loss
 
 
 class Simulate:

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -169,15 +169,7 @@ class Simulate:
                 len(self.labels) - len(self._results["label"])
             )
 
-            metrics_block = f"""
-\033[95m----------------\033[0m Metrics Summary \033[95m----------------\033[0m
-Relevant records            : {sum(self._results['label'])}/{sum(self.labels)}
-Records Labeled             : {len(self._results['label'])}/{len(self.labels)}
-Loss                        : {round(metrics.loss(padded_results), 2)}
-WSS@95%                     : {round(metrics.wss(padded_results, 0.95), 2)}
-\033[95m-------------------------------------------------\033[0m
-            """
-            print(metrics_block)
+            print(f"\nLoss: {round(loss(padded_results), 2)}")
 
     def train(self):
         """Train a new model on the labeled data."""

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -158,9 +158,7 @@ class Simulate:
             record_ids = self.query(self.n_instances)
             labeled = self.label(record_ids)
 
-            pbar_rel_update = labeled["label"].sum()
-
-            pbar_rel.update(pbar_rel_update)
+            pbar_rel.update(labeled["label"].sum())
             pbar_total.update(1)
 
         else:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,7 +12,43 @@ from asreview.metrics import loss
         ([1, 1, 0, 0, 0], 0),
         ([0, 0, 0, 1, 1], 1),
         ([1, 0, 1], 0.5),
-        ([0,1,0,0,0,1,0,1,0,1,0,0,1,1,0,0,0,1,0,0,0,0,0,1,0,1,0,1,0,0,1,1], 0.5583333333333333),
+        (
+            [
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                1,
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                1,
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ],
+            0.5583333333333333,
+        ),
     ],
 )
 def test_loss_value_function(labels, expected_value):
@@ -21,12 +57,8 @@ def test_loss_value_function(labels, expected_value):
 
 
 @pytest.mark.parametrize(
-        "labels", 
-        [
-            [0, 0, 0], 
-            [0], 
-            [1]
-        ],
+    "labels",
+    [[0, 0, 0], [0], [1]],
 )
 def test_loss_value_error_cases(labels):
     with pytest.raises(ValueError):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
-import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
+
 from asreview.metrics import loss
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_almost_equal
+from asreview.metrics import loss
+
+
+@pytest.mark.parametrize(
+    "labels, expected_value",
+    [
+        ([1, 0], 0),
+        ([0, 1], 1),
+        ([1, 1, 0, 0, 0], 0),
+        ([0, 0, 0, 1, 1], 1),
+        ([1, 0, 1], 0.5),
+        ([0,1,0,0,0,1,0,1,0,1,0,0,1,1,0,0,0,1,0,0,0,0,0,1,0,1,0,1,0,0,1,1], 0.5583333333333333),
+    ],
+)
+def test_loss_value_function(labels, expected_value):
+    loss_value = loss(labels)
+    assert_almost_equal(loss_value, expected_value)
+
+
+@pytest.mark.parametrize(
+        "labels", 
+        [
+            [0, 0, 0], 
+            [0], 
+            [1]
+        ],
+)
+def test_loss_value_error_cases(labels):
+    with pytest.raises(ValueError):
+        loss(labels)
+
+
+def test_random_loss_values():
+    np.random.seed(42)
+    for _ in range(100):
+        length = np.random.randint(2, 100)
+        labels = np.random.randint(0, 2, length)
+
+        # Ensure labels are not all 0 or all 1
+        if np.all(labels == 0) or np.all(labels == 1):
+            labels[np.random.randint(0, length)] = 1 - labels[0]
+
+        loss_value = loss(labels)
+        assert 0 <= loss_value <= 1


### PR DESCRIPTION
This PR adds a loss metrics calculation from insights to the asreview core to present to the user after running a simulation.