### PR TITLE
Use `Parameters` instead of `Arguments` in docstrings

### DIFF
--- a/asreview/data/loader.py
+++ b/asreview/data/loader.py
@@ -10,8 +10,8 @@ from asreview.utils import _is_url
 def _get_reader(fp):
     """Get the reader that can read the file at the given file path.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     fp : Path
         File path of the file to read.
 
@@ -33,7 +33,7 @@ def _get_reader(fp):
 def _get_writer(fp):
     """Get a writer for writing a file to a given location.
 
-    Arguments
+    Parameters
     ----------
     fp : Path
         Path where the file will be written to.
@@ -57,8 +57,8 @@ def _from_file(fp, reader=None, dataset_id=None, **kwargs):
     functions are supplied or automatic, where it searches in the entry
     points for the right conversion functions.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     fp: str, pathlib.Path
         Read the data from this file or url.
     reader: BaseReader
@@ -74,8 +74,8 @@ def _from_file(fp, reader=None, dataset_id=None, **kwargs):
 def _from_extension(name, reader=None, dataset_id=None, **kwargs):
     """Load a dataset from extension.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     fp: str, pathlib.Path
         Read the data from this file or url.
     reader: BaseReader

--- a/asreview/data/ris.py
+++ b/asreview/data/ris.py
@@ -78,8 +78,8 @@ def _parse_asreview_data_from_notes(note_list):
 def _remove_asreview_data_from_notes(note_list):
     """Remove ASReview data from notes.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     note_list: list
         A list of notes, coming from the Dataframe's "notes" column.
 
@@ -108,8 +108,8 @@ class RISReader(BaseReader):
     def _strip_zotero_p_tags(note_list):
         """Converter function for removing the XHTML <p></p> tags from Zotero export.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         note_list: list
             A list of notes, coming from the Dataframe's "notes" column.
 
@@ -150,8 +150,8 @@ class RISReader(BaseReader):
     def read_data(cls, fp):
         """Import dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, pathlib.Path
             File path to the RIS file.
         note_list: list
@@ -223,8 +223,8 @@ class RISWriter:
     def write_data(cls, df, fp):
         """Export dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df: pd.Dataframe
             Dataframe of all available record data.
         fp: str, pathlib.Path

--- a/asreview/data/store.py
+++ b/asreview/data/store.py
@@ -152,8 +152,8 @@ class DataStore:
     def get_records(self, record_id):
         """Get the records with the given record identifiers.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_id : int | list[int]
             Record identifier or list record identifiers.
 

--- a/asreview/data/tabular.py
+++ b/asreview/data/tabular.py
@@ -31,8 +31,8 @@ class CSVReader(BaseReader):
     def read_data(cls, fp):
         """Import dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, pathlib.Path
             File path to the CSV file.
 
@@ -62,8 +62,8 @@ class CSVWriter:
     def write_data(cls, df, fp, sep=","):
         """Export dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df: pandas.Dataframe
             Dataframe of all available record data.
         fp: str, NoneType
@@ -89,8 +89,8 @@ class ExcelReader(BaseReader):
     def read_data(cls, fp):
         """Import dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, pathlib.Path
             File path to the Excel file (.xlsx).
 
@@ -131,8 +131,8 @@ class ExcelWriter:
     def write_data(cls, df, fp):
         """Export dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df: pandas.Dataframe
             Dataframe of all available record data.
         fp: str, NoneType
@@ -157,8 +157,8 @@ class TSVWriter:
     def write_data(cls, df, fp, sep="\t"):
         """Export dataset.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df: pandas.Dataframe
             Dataframe of all available record data.
         fp: str, NoneType

--- a/asreview/data/utils.py
+++ b/asreview/data/utils.py
@@ -12,8 +12,8 @@ def duplicated(df, pid="doi"):
     on a persistent identifier (PID) such as the Digital Object Identifier
     (`DOI <https://www.doi.org/>`_).
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     df : pd.DataFrame or DataStore
         Dataframe containing columns 'title', 'abstract' and optionally a column
         containing identifiers of type `pid`.

--- a/asreview/extensions.py
+++ b/asreview/extensions.py
@@ -18,8 +18,8 @@ from importlib.metadata import entry_points as _entry_points
 def extensions(group):
     """Get the extension class from an entry point.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     group: str
         The group of the extension.
 
@@ -35,8 +35,8 @@ def extensions(group):
 def get_extension(group, name):
     """Get the extension class from an entry point.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     group: str
         The group of the extension.
     name: str
@@ -58,8 +58,8 @@ def get_extension(group, name):
 def load_extension(group, name):
     """Load the extension class from an entry point.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     group: str
         The group of the extension.
     name: str

--- a/asreview/migrate.py
+++ b/asreview/migrate.py
@@ -82,8 +82,8 @@ def _project_model_settings_converter_v1_v2(model_settings_path):
 def migrate_v1_v2(folder):
     """Migrate a project from version 1 to version 2.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     folder: str
         The folder of the project to migrate
 

--- a/asreview/models/balance/base.py
+++ b/asreview/models/balance/base.py
@@ -28,8 +28,8 @@ class BaseBalance(BaseModel):
     def sample(self, labeled_idx, y):
         """Resample the training data.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         labeled_idx: numpy.ndarray
             Training indices, that is all records that have been reviewed.
         y: numpy.ndarray

--- a/asreview/models/balance/double.py
+++ b/asreview/models/balance/double.py
@@ -54,8 +54,8 @@ class DoubleBalance(BaseBalance):
     It super samples ones depending on the number of 0's and total number
     of samples in the training data.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     a: float
         Governs the weight of the 1's. Higher values mean linearly more 1's
         in your training sample.
@@ -88,8 +88,8 @@ class DoubleBalance(BaseBalance):
     def sample(self, labeled_idx, y):
         """Resample the training data.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         labeled_idx: numpy.ndarray
             Training indices, that is all records that have been reviewed.
         y: numpy.ndarray

--- a/asreview/models/balance/undersample.py
+++ b/asreview/models/balance/undersample.py
@@ -28,8 +28,8 @@ class UndersampleBalance(BaseBalance):
     This undersamples the data, leaving out irrelevant records so that the
     relevant and irrelevant records are in some particular ratio (closer to one).
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     ratio: float
         Undersampling ratio relevant to irrelevant. If for example we set a ratio of
         0.25, we would sample all the relevant and 4 times irrelevant.
@@ -47,8 +47,8 @@ class UndersampleBalance(BaseBalance):
     def sample(self, labeled_idx, y):
         """Resample the training data.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         labeled_idx: numpy.ndarray
             Training indices, that is all records that have been reviewed.
         y: numpy.ndarray

--- a/asreview/models/classifiers/base.py
+++ b/asreview/models/classifiers/base.py
@@ -36,8 +36,8 @@ class BaseTrainClassifier(BaseModel):
     def fit(self, X, y):
         """Fit the model to the data.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         X: numpy.ndarray
             Feature matrix to fit.
         y: numpy.ndarray
@@ -48,8 +48,8 @@ class BaseTrainClassifier(BaseModel):
     def predict_proba(self, X):
         """Get the inclusion probability for each sample.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         X: numpy.ndarray
             Feature matrix to predict.
 

--- a/asreview/models/classifiers/logistic.py
+++ b/asreview/models/classifiers/logistic.py
@@ -29,8 +29,8 @@ class LogisticClassifier(BaseTrainClassifier):
     The Logistic regressions classifier is an implementation based
     on the sklearn Logistic regressions classifier.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     C: float
         Parameter inverse to the regularization strength of the model.
     class_weight: float

--- a/asreview/models/classifiers/nb.py
+++ b/asreview/models/classifiers/nb.py
@@ -33,8 +33,8 @@ class NaiveBayesClassifier(BaseTrainClassifier):
     The naive Bayes classifier is an implementation based
     on the sklearn multinomial naive Bayes classifier.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     alpha : float, default=3.822
         Additive (Laplace/Lidstone) smoothing parameter
         (0 for no smoothing).

--- a/asreview/models/classifiers/rf.py
+++ b/asreview/models/classifiers/rf.py
@@ -27,8 +27,8 @@ class RandomForestClassifier(BaseTrainClassifier):
     The Random Forest classifier is an implementation based
     on the sklearn Random Forest classifier.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     n_estimators : int, default=100
         The number of trees in the forest.
     max_features: int, default=10

--- a/asreview/models/classifiers/svm.py
+++ b/asreview/models/classifiers/svm.py
@@ -27,8 +27,8 @@ class SVMClassifier(BaseTrainClassifier):
     The Support Vector Machine classifier is an implementation based
     on the sklearn Support Vector Machine classifier.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     gamma: str
         Gamma parameter of the SVM model.
     class_weight: float

--- a/asreview/models/feature_extraction/base.py
+++ b/asreview/models/feature_extraction/base.py
@@ -49,8 +49,8 @@ class BaseFeatureExtraction(BaseModel):
     def fit_transform(self, data):
         """Fit and transform a list of texts.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         texts: numpy.ndarray
             A sequence of texts to be transformed. They are not yet tokenized.
 
@@ -87,8 +87,8 @@ class BaseFeatureExtraction(BaseModel):
         It is not always necessary to implement this if there's not real
         fitting being done.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         texts: numpy.ndarray
             Texts to be fitted.
         """
@@ -98,8 +98,8 @@ class BaseFeatureExtraction(BaseModel):
     def transform(self, texts):
         """Transform a list of texts.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         texts: numpy.ndarray
             A sequence of texts to be transformed. They are not yet tokenized.
 

--- a/asreview/models/feature_extraction/onehot.py
+++ b/asreview/models/feature_extraction/onehot.py
@@ -25,8 +25,8 @@ class OneHot(BaseFeatureExtraction):
     Use the standard OneHot feature extraction technique from `SKLearn
     <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`__.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     lowercase: bool
         Convert all characters to lowercase before tokenizing.
     max_df: float

--- a/asreview/models/feature_extraction/tfidf.py
+++ b/asreview/models/feature_extraction/tfidf.py
@@ -29,8 +29,8 @@ class Tfidf(BaseFeatureExtraction):
     :class:`asreview.models.classifiers.NaiveBayesClassifier` and other fast
     training models (given that the features vectors are relatively wide).
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     ngram_max: int
         Can use up to ngrams up to ngram_max. For example in the case of
         ngram_max=2, monograms and bigrams could be used.

--- a/asreview/models/query/base.py
+++ b/asreview/models/query/base.py
@@ -28,8 +28,8 @@ class BaseQueryStrategy(BaseModel):
     def query(self, feature_matrix, relevance_scores, **kwargs):
         """Put records in ranked order.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         feature_matrix: numpy.ndarray
             Feature matrix where every row contains the features of a record.
         relevance_scores: numpy.ndarray

--- a/asreview/models/query/cluster.py
+++ b/asreview/models/query/cluster.py
@@ -28,8 +28,8 @@ class ClusterQuery(BaseQueryStrategy):
     Use clustering after feature extraction on the dataset. Then the highest
     probabilities within random clusters are sampled.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     cluster_size: int
         Size of the clusters to be made. If the size of the clusters is
         smaller than the size of the pool, fall back to max sampling.

--- a/asreview/models/query/mixed.py
+++ b/asreview/models/query/mixed.py
@@ -36,8 +36,8 @@ class MixedQuery(BaseQueryStrategy):
     to come from the second query strategy. What actually happens is close to this, but
     for full details look at the implemenatation of the algorithm in the code.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     query_model1: str
         Name of the first query strategy.
     query_model2: str

--- a/asreview/project/api.py
+++ b/asreview/project/api.py
@@ -191,8 +191,8 @@ class Project:
     def add_dataset(self, fp, dataset_id=None, file_writer=None):
         """Add a dataset to the project file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, Path
             Filepath to the dataset. It will be copied to the correct location in the
             project file.
@@ -279,8 +279,8 @@ class Project:
     def add_feature_matrix(self, feature_matrix, feature_model):
         """Add feature matrix to project file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         feature_matrix: numpy.ndarray, scipy.sparse.csr.csr_matrix
             The feature matrix to add to the project file.
         feature_model: BaseFeatureExtraction
@@ -311,8 +311,8 @@ class Project:
     def get_feature_matrix(self, feature_model):
         """Get the feature matrix from the project file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         feature_model : BaseFeatureExtraction
             Feature extraction class for which to get the matrix.
 
@@ -343,8 +343,8 @@ class Project:
     ):
         """Add new review metadata.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         review_id: str
             The review_id uuid4.
         settings: ReviewSettings
@@ -409,8 +409,8 @@ class Project:
     def update_review(self, review_id=None, settings=None, state=None, **kwargs):
         """Update review metadata.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         review_id: str
             The review_id uuid4. Default None, which is the
             first added review.
@@ -477,8 +477,8 @@ class Project:
 
         If no review_id is given, mark the first review as finished.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         review_id: str
             Identifier of the review to mark as finished.
         """

--- a/asreview/search.py
+++ b/asreview/search.py
@@ -39,8 +39,8 @@ def _create_inverted_index(match_strings):
 def _get_fuzzy_scores(keywords, match_strings, threshold=0.9):
     """Rank a list of strings, depending on a set of keywords.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     keywords: str
         Keywords that we are trying to find in the string list.
     str_list: list
@@ -90,8 +90,8 @@ def fuzzy_find(
     (for as much is available). Using the diflib package it creates
     a ranking based on token set matching.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     data: pd.DataFrame or DataStore
         Dataframe containing the column 'title' and optionally 'authors' and 'keywords'.
     keywords: str

--- a/asreview/settings.py
+++ b/asreview/settings.py
@@ -49,8 +49,8 @@ class ReviewSettings:
     def from_file(cls, fp, load=None):
         """Fill the contents of settings by reading a config file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, Path
             Review config file.
         load: object

--- a/asreview/simulation/cli.py
+++ b/asreview/simulation/cli.py
@@ -66,8 +66,8 @@ def _unpack_params(params):
 def _print_record(record, use_cli_colors=True):
     """Format one record for displaying in the CLI.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     record: Record
         The record to format.
     use_cli_colors: bool

--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -34,8 +34,8 @@ class Simulate:
     To seed the simulation, provide the seed to the classifier, query strategy,
     feature extraction model, and balance strategy or use a global random seed.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     fm: numpy.ndarray
         The feature matrix to use for the simulation.
     labels: numpy.ndarray, pandas.Series, list
@@ -207,8 +207,8 @@ class Simulate:
     def query(self, n):
         """Query the next n records to label.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         n: int
             The number of records to query.
 
@@ -227,8 +227,8 @@ class Simulate:
     def label(self, record_ids, prior=False):
         """Label the records with the given record_ids.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_ids: list
             The record ids to label.
         prior: bool
@@ -282,8 +282,8 @@ class Simulate:
     ):
         """Label random records.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         n_included: int
             Number of included records to label.
         n_excluded: int
@@ -321,8 +321,8 @@ class Simulate:
     def to_sql(self, fp):
         """Write the data a sql file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         fp: str, Path, asreview.Project
             The path to the sqlite file to write the results to.
         """

--- a/asreview/state/contextmanager.py
+++ b/asreview/state/contextmanager.py
@@ -40,8 +40,8 @@ def _get_state_path(project, review_id=None, create_new=True):
 def open_state(asreview_obj, review_id=None, create_new=True, check_integrety=False):
     """Initialize a state class instance from a project folder.
 
-    Arguments
-    ---------
+        Parameters
+        ----------
     asreview_obj: str/pathlike/Project
 
         Filepath to the (unzipped) project folder or Project object.

--- a/asreview/state/contextmanager.py
+++ b/asreview/state/contextmanager.py
@@ -40,10 +40,9 @@ def _get_state_path(project, review_id=None, create_new=True):
 def open_state(asreview_obj, review_id=None, create_new=True, check_integrety=False):
     """Initialize a state class instance from a project folder.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
     asreview_obj: str/pathlike/Project
-
         Filepath to the (unzipped) project folder or Project object.
     review_id: str
         Identifier of the review from which the state will be instantiated.

--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -60,8 +60,8 @@ class SQLiteState:
     of the review process, the ranking of the last model, and the changes in
     the decisions.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     fp: str, Path
         Path to the SQLite database file.
 
@@ -246,8 +246,8 @@ class SQLiteState:
         Save the ranking of the last iteration of the model, in the ranking
         order, so the record on row 0 is ranked first by the model.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         ranked_record_ids: list, numpy.ndarray
             A list of records ids in the order that they were ranked.
         classifier: str
@@ -278,8 +278,8 @@ class SQLiteState:
     def add_labeling_data(self, record_ids, labels, tags=None, user_id=None):
         """Add the data corresponding to a labeling action to the state file.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_ids: list, numpy.ndarray
             A list of ids of the labeled records as int.
         labels: list, numpy.ndarray
@@ -357,8 +357,8 @@ class SQLiteState:
         Get the top n instances from the pool according to the last ranking.
         Add the model data to the results table.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         n: int
             Number of instances. Default is 1.
         user_id: int
@@ -394,8 +394,8 @@ class SQLiteState:
     def get_results_record(self, record_id):
         """Get the data of a specific query from the results table.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_id: int
             Record id of which you want the data.
 
@@ -422,8 +422,8 @@ class SQLiteState:
         Most other get functions use this one, except some that use a direct
         SQL query for efficiency.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         columns: list, str
             List of columns names of the results table, or a string containing
             one column name.
@@ -517,8 +517,8 @@ class SQLiteState:
     def get_pending(self, user_id=None):
         """Get pending records from the results table.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         user_id: int
             User id of the user who labeled the records.
 
@@ -562,8 +562,8 @@ class SQLiteState:
     def update(self, record_id, label=None, tags=None):
         """Change the label or tag of an already labeled record.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_id: int
             Id of the record whose label should be changed.
         label: 0 / 1
@@ -595,8 +595,8 @@ class SQLiteState:
     def update_note(self, record_id, note=None):
         """Change the note of an already labeled or pending record.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         record_id: int
             Id of the record whose label should be changed.
         note: str
@@ -617,7 +617,7 @@ class SQLiteState:
     def delete_record_labeling_data(self, record_id):
         """Delete the labeling data for the given record id.
 
-        Arguments
+        Parameters
         ----------
         record_id : str
             Identifier of the record to delete.

--- a/asreview/webapp/api/projects.py
+++ b/asreview/webapp/api/projects.py
@@ -72,8 +72,8 @@ bp = Blueprint("api", __name__, url_prefix="/api")
 def _fill_last_ranking(project, ranking):
     """Fill the last ranking with a random or top-down ranking.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     project: asreview.Project
         The project to fill the last ranking of.
     ranking: str

--- a/asreview/webapp/entry_points/lab.py
+++ b/asreview/webapp/entry_points/lab.py
@@ -70,8 +70,8 @@ def lab_entry_point(argv):
 
     This function is called when the `asreview lab` command is used.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     argv: list
         Command line arguments.
 

--- a/asreview/webapp/utils.py
+++ b/asreview/webapp/utils.py
@@ -23,8 +23,8 @@ def asreview_path():
 def get_project_path(folder_id):
     """Get the project directory.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     folder_id: str
         The id of the folder containing a project. If there is no
         authentication, the folder_id is equal to the project_id. Otherwise,
@@ -36,8 +36,8 @@ def get_project_path(folder_id):
 def get_projects(project_paths=None):
     """Get the ASReview projects at the given paths.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     project_paths : list[Path], optional
         List of paths to projects. By default all the projects in the asreview
         folder are used, by default None


### PR DESCRIPTION
This PR standardizes the docstrings to always use `Parameters` instead of `Arguments`. Closes #1911