### PR TITLE
Fix loader animation in reviewer screen

### DIFF
--- a/asreview/state/sqlstate.py
+++ b/asreview/state/sqlstate.py
@@ -225,12 +225,9 @@ class SQLiteState:
                 f"{list(RANKING_TABLE_COLUMNS_PANDAS_DTYPES.keys())}."
             )
 
-        cur = self._conn.cursor()
-        cur.execute("delete from last_ranking")
-        self._conn.commit()
-        cur.close()
-
-        last_ranking.to_sql("last_ranking", self._conn, if_exists="append", index=False)
+        last_ranking.to_sql(
+            "last_ranking", self._conn, if_exists="replace", index=False
+        )
 
     def add_last_ranking(
         self,

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
@@ -177,9 +177,13 @@ const RecordCardLabeler = ({
     setAnchorEl(null);
   };
 
-  useHotkeys("v", () => hotkeys && makeDecision(1));
-  useHotkeys("x", () => hotkeys && makeDecision(0));
-  useHotkeys("n", () => hotkeys && toggleShowNotesDialog(), { keyup: true });
+  useHotkeys("v", () => hotkeys && !isLoading && !isSuccess && makeDecision(1));
+  useHotkeys("x", () => hotkeys && !isLoading && !isSuccess && makeDecision(0));
+  useHotkeys(
+    "n",
+    () => hotkeys && !isLoading && !isSuccess && toggleShowNotesDialog(),
+    { keyup: true },
+  );
 
   return (
     <Stack


### PR DESCRIPTION
This is a first attempt to fix the "Warmup screen" that randomly pops up on the reviewer page. It is a challenging issue. 

It's hard for me to reproduce this issue on my device/environment. However, we see it more often on the test server. It might have something to do with concurrency to our SQLite database. Maybe @PeterLombaers can think with me about this. 

Basically, what happens:
- Sometimes, querying the ranking table results in an empty table
- Shortly after, the same request will succeed with a filled table. 

I think this has something to do with updating the ranking table from the other thread. However, we haven't seen this before, so that confuses me. In this PR, I merged two sqlite queries (select and insert) to avoid edge cases with concurrency. 



