### PR TITLE
Add `duplicate_of` column to `Record` class

### DIFF
--- a/asreview/__init__.py
+++ b/asreview/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
 from asreview.data.loader import load_dataset
 from asreview.extensions import extensions
 from asreview.extensions import get_extension
@@ -51,3 +54,20 @@ __all__ = [
     "ProjectError",
     "ProjectNotFoundError",
 ]
+
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    """Configure SQLite to use foreign keys.
+
+    By adding this function, everytime a connection is made to the sqlite engine, we
+    make sure that foreign keys are configured (by default sqlite allows foreign keys,
+    but ignores them and it's only SQLAlchemy that takes care of foreign keys). The only
+    downside of enabling foreign keys on the database level is that we will run into
+    problems if we have mutually dependent foreign keys.
+
+    See also: https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-foreign-keys
+    """
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()

--- a/asreview/data/record.py
+++ b/asreview/data/record.py
@@ -99,7 +99,7 @@ class Record(Base):
     # required to have it when we do deduplication. However, in the base class we do not
     # yet know the name of the table to which we want to make the foreign key.
     duplicate_of: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("record.record_id"), default=None
+        Integer, ForeignKey("record.record_id", ondelete="SET NULL"), default=None
     )
 
     title: Mapped[str] = mapped_column(default="")

--- a/asreview/data/record.py
+++ b/asreview/data/record.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pandas as pd
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import MappedAsDataclass
@@ -95,6 +95,13 @@ class Record(Base):
     # implementing a custom record is forced to have them.
     dataset_row: Mapped[int]
     dataset_id: Mapped[str]
+    # Ideally `duplicate_of` would be on the base class, because all record types are
+    # required to have it when we do deduplication. However, in the base class we do not
+    # yet know the name of the table to which we want to make the foreign key.
+    duplicate_of: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("record.record_id"), default=None
+    )
+
     title: Mapped[str] = mapped_column(default="")
     abstract: Mapped[str] = mapped_column(default="")
     # authors and keywords could also be in their own separate table.

--- a/asreview/data/store.py
+++ b/asreview/data/store.py
@@ -2,13 +2,30 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import NullPool
 from sqlalchemy import create_engine
+from sqlalchemy import event
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from asreview.data.record import Base
 from asreview.data.record import Record
 
 CURRENT_DATASTORE_VERSION = 0
+
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    """Configure SQLite to use foreign keys.
+    
+    By adding this function to the module, everytime a connection is made to the sqlite
+    engine, we make sure that foreign keys are configured (by default sqlite allows
+    foreign keys, but ignores them).
+    
+    See also: https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-foreign-keys
+    """
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
 
 
 class DataStore:

--- a/asreview/data/store.py
+++ b/asreview/data/store.py
@@ -116,6 +116,15 @@ class DataStore:
         with self.Session() as session, session.begin():
             session.add_all(records)
 
+    def delete_record(self, record_id):
+        with self.Session() as session, session.begin():
+            record = session.get(self.record_cls, record_id)
+            if record is None:
+                raise ValueError(
+                    f"DataStore does not contain a record with record_id {record_id}"
+                )
+            session.delete(record)
+
     def __len__(self):
         with self.Session() as session:
             return session.query(self.record_cls).count()

--- a/asreview/data/store.py
+++ b/asreview/data/store.py
@@ -2,30 +2,13 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import NullPool
 from sqlalchemy import create_engine
-from sqlalchemy import event
 from sqlalchemy import text
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from asreview.data.record import Base
 from asreview.data.record import Record
 
 CURRENT_DATASTORE_VERSION = 0
-
-
-@event.listens_for(Engine, "connect")
-def set_sqlite_pragma(dbapi_connection, connection_record):
-    """Configure SQLite to use foreign keys.
-    
-    By adding this function to the module, everytime a connection is made to the sqlite
-    engine, we make sure that foreign keys are configured (by default sqlite allows
-    foreign keys, but ignores them).
-    
-    See also: https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlite-foreign-keys
-    """
-    cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.close()
 
 
 class DataStore:

--- a/asreview/webapp/tests/test_extensions/test_auth_tool.py
+++ b/asreview/webapp/tests/test_extensions/test_auth_tool.py
@@ -129,8 +129,10 @@ def test_insert_user_duplicate(client_auth):
 def test_inserting_a_project_record(client_auth):
     # count projects
     assert crud.count_projects() == 0
+    # Make sure the project owner exists as user in the database.
+    owner = crud.create_user(DB)
     # insert this data
-    data = {"project_id": uuid4().hex, "owner_id": 2}
+    data = {"project_id": uuid4().hex, "owner_id": owner.id}
     tool.insert_project(DB.session, data)
     # count again
     assert crud.count_projects() == 1
@@ -144,13 +146,16 @@ def test_inserting_a_project_record(client_auth):
 def test_updating_a_project_record(client_auth):
     # count projects
     assert crud.count_projects() == 0
+    # Make sure the project owner exists as user in the database.
+    owner1 = crud.create_user(DB, 1)
+    owner2 = crud.create_user(DB, 2)
     # insert this data
-    data = {"project_id": uuid4().hex, "owner_id": 2}
+    data = {"project_id": uuid4().hex, "owner_id": owner1.id}
     tool.insert_project(DB.session, data)
     # count again
     assert crud.count_projects() == 1
     # change owner id
-    data["owner_id"] = 3
+    data["owner_id"] = owner2.id
     tool.insert_project(DB.session, data)
     # count again, no inserts, count remains 1
     assert crud.count_projects() == 1

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -176,6 +176,14 @@ def test_label_validation(store):
         store.add_records([Record(dataset_id="foo", dataset_row=4, included="1")])
 
 
+def test_delete_record(store):
+    record = Record(dataset_id="foo", dataset_row=1)
+    store.add_records([record])
+    assert len(store) == 1
+    store.delete_record(record.record_id)
+    assert len(store) == 0
+
+
 def test_duplicate_of(store):
     record = Record(dataset_id="foo", dataset_row=1)
     store.add_records([record])
@@ -189,3 +197,5 @@ def test_duplicate_of(store):
     )
     with pytest.raises(IntegrityError):
         store.add_records([broken_duplicate_record])
+
+    store

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -198,4 +198,9 @@ def test_duplicate_of(store):
     with pytest.raises(IntegrityError):
         store.add_records([broken_duplicate_record])
 
-    store
+    # Check that duplicate_of is set to null after duplicate is deleted.
+    store.delete_record(record.record_id)
+    with store.Session() as session:
+        session.add(duplicate_record)
+        session.refresh(duplicate_record)
+    assert duplicate_record.duplicate_of is None

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -174,3 +174,18 @@ def test_label_validation(store):
     store.add_records(records)
     with pytest.raises(ValueError):
         store.add_records([Record(dataset_id="foo", dataset_row=4, included="1")])
+
+
+def test_duplicate_of(store):
+    record = Record(dataset_id="foo", dataset_row=1)
+    store.add_records([record])
+    duplicate_record = Record(
+        dataset_id="foo", dataset_row=2, duplicate_of=record.record_id
+    )
+    store.add_records([duplicate_record])
+    non_existing_record_id = 42
+    broken_duplicate_record = Record(
+        dataset_id="foo", dataset_row=2, duplicate_of=non_existing_record_id
+    )
+    with pytest.raises(IntegrityError):
+        store.add_records([broken_duplicate_record])


### PR DESCRIPTION
This pull request prepares for marking records as duplicate inside ASReview. It adds a column `duplicate_of` to the `Record` class. This column can contain a foreign key to the duplicate of a record. Any logic concerning how we actually fill this column is not part of this pull request and needs further discussion.