### PR TITLE
Add informative error message when extension name not found

### DIFF
--- a/asreview/extensions.py
+++ b/asreview/extensions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.metadata import entry_points as _entry_points
+from importlib.metadata import entry_points
 
 
 def extensions(group):
@@ -29,7 +29,7 @@ def extensions(group):
         The class corresponding to the extension.
     """
 
-    return _entry_points(group=f"asreview.{group}")
+    return entry_points(group=f"asreview.{group}")
 
 
 def get_extension(group, name):
@@ -49,10 +49,13 @@ def get_extension(group, name):
     """
 
     try:
-        (entry_point,) = _entry_points(group=f"asreview.{group}", name=name)
+        (entry_point,) = entry_points(group=f"asreview.{group}", name=name)
         return entry_point
     except ValueError as err:
-        raise ValueError(f"Extension {name} not found in group {group}.") from err
+        raise ValueError(
+            f"'{name}' not found in group {group}. "
+            f"Available options: {', '.join(e.name for e in extensions(group))}."
+        ) from err
 
 
 def load_extension(group, name):
@@ -71,8 +74,5 @@ def load_extension(group, name):
         The class corresponding to the extension.
 
     """
-
-    if not get_extension(group, name):
-        raise ValueError(f"Extension {name} not found in group {group}.")
 
     return get_extension(group, name).load()


### PR DESCRIPTION
Closes #905. 

```sh
% asreview simulate synergy:Bos_2018 -c foo
Traceback (most recent call last):
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 52, in get_extension
    (entry_point,) = entry_points(group=f"asreview.{group}", name=name)
    ^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 1, got 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/Bruin056/.pyenv/versions/3.12.0/envs/asreview-dev/bin/asreview", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/__main__.py", line 51, in main
    _execute_entry_point(entry, sys.argv[2:])
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/__main__.py", line 31, in _execute_entry_point
    entry(args)
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/simulation/cli.py", line 147, in _cli_simulate
    classifier_class = load_extension("models.classifiers", settings.classifier)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 78, in load_extension
    return get_extension(group, name).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 55, in get_extension
    raise ValueError(
ValueError: 'foo' not found in group models.classifiers.Available options: logistic, nb, rf, svm
(asreview-dev) Bruin056@UU083226 asreview % asreview simulate synergy:Bos_2018 -c foo
Traceback (most recent call last):
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 52, in get_extension
    (entry_point,) = entry_points(group=f"asreview.{group}", name=name)
    ^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 1, got 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/Bruin056/.pyenv/versions/3.12.0/envs/asreview-dev/bin/asreview", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/__main__.py", line 51, in main
    _execute_entry_point(entry, sys.argv[2:])
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/__main__.py", line 31, in _execute_entry_point
    entry(args)
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/simulation/cli.py", line 147, in _cli_simulate
    classifier_class = load_extension("models.classifiers", settings.classifier)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 78, in load_extension
    return get_extension(group, name).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Bruin056/Documents/GitHub/asreview/asreview/extensions.py", line 55, in get_extension
    raise ValueError(
ValueError: 'foo' not found in group models.classifiers. Available options: logistic, nb, rf, svm.

```