### PR TITLE
Add support for callable n_query for Simulate class

### DIFF
--- a/asreview/simulation/simulate.py
+++ b/asreview/simulation/simulate.py
@@ -152,7 +152,11 @@ class Simulate:
         while not self._stop_review():
             self.train()
 
-            record_ids = self.query(self.n_query)
+            n_query = (
+                self.n_query(self._results) if callable(self.n_query) else self.n_query
+            )
+
+            record_ids = self.query(n_query)
             labeled = self.label(record_ids)
 
             pbar_rel.update(labeled["label"].sum())


### PR DESCRIPTION


```python
sim = asr.Simulate(
    fm,
    labels=project.data_store["included"],
    classifier=load_extension("models.classifiers", "svm")(),
    query_strategy=load_extension("models.query", "max_random")(),
    balance_strategy=load_extension("models.balance", "balanced")(),
    feature_extraction=feature_model,
    n_query=lambda x: 2,
)
sim.review()

assert sim._results["training_set"].to_list() == [None, None, 2, 2, 4, 4]
```


```python

def n_query(x):
    return len(x) // 2

sim = asr.Simulate(
    fm,
    labels=project.data_store["included"],
    classifier=load_extension("models.classifiers", "svm")(),
    query_strategy=load_extension("models.query", "max_random")(),
    balance_strategy=load_extension("models.balance", "balanced")(),
    feature_extraction=feature_model,
    n_query=n_query,
)
sim.review()

assert sim._results["training_set"].to_list() == [None, None, 2, 3, 4, 4]

```