### PR TITLE
Simplify load_dataset API

### DIFF
--- a/asreview/data/base_reader.py
+++ b/asreview/data/base_reader.py
@@ -60,10 +60,10 @@ class BaseReader(ABC):
     __fillna_default__ = (None,)
 
     @classmethod
-    def read_records(cls, fp, dataset_id, record_class=Record, *args, **kwargs):
+    def read_records(cls, fp, dataset_id, record_cls=Record, *args, **kwargs):
         df = cls.read_data(fp, *args, **kwargs)
         df = cls.clean_data(df)
-        return cls.to_records(df, dataset_id=dataset_id, record_class=record_class)
+        return cls.to_records(df, dataset_id=dataset_id, record_cls=record_cls)
 
     @classmethod
     @abstractmethod
@@ -116,7 +116,7 @@ class BaseReader(ABC):
         return df
 
     @classmethod
-    def to_records(cls, df, dataset_id=None, record_class=Record):
+    def to_records(cls, df, dataset_id=None, record_cls=Record):
         """Turn the cleaned data into records.
 
         Parameters
@@ -125,7 +125,7 @@ class BaseReader(ABC):
             Cleaned data.
         dataset_id : str, optional
             Identifier of the dataset, by default None
-        record_class : asreview.data.record.Base, optional
+        record_cls : asreview.data.record.Base, optional
             Record class to use, by default Record
 
         Returns
@@ -133,9 +133,9 @@ class BaseReader(ABC):
         list[Record]
             List of records.
         """
-        columns_present = set(df.columns).intersection(set(record_class.get_columns()))
+        columns_present = set(df.columns).intersection(set(record_cls.get_columns()))
         return [
-            record_class(dataset_row=idx, dataset_id=dataset_id, **row)
+            record_cls(dataset_row=idx, dataset_id=dataset_id, **row)
             for idx, row in df[list(columns_present)].iterrows()
         ]
 

--- a/asreview/simulation/cli.py
+++ b/asreview/simulation/cli.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import numpy as np
 
 from asreview import load_dataset
-from asreview.data import DataStore
 from asreview.datasets import DatasetManager
 from asreview.extensions import load_extension
 from asreview.project.api import Project
@@ -184,10 +183,7 @@ def _cli_simulate(argv):
         project.add_dataset(args.dataset, dataset_id=filename)
         data_store = project.data_store
     else:
-        records = load_dataset(args.dataset, dataset_id=filename)
-        data_store = DataStore(":memory:")
-        data_store.create_tables()
-        data_store.add_records(records)
+        data_store = load_dataset(args.dataset, dataset_id=filename)
 
     prior_idx = args.prior_idx
     if args.prior_record_id is not None and len(args.prior_record_id) > 0:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pytest import mark
 
 import asreview as asr
-from asreview.data import DataStore
+from asreview import load_dataset
 from asreview.datasets import DatasetManager
 from asreview.search import fuzzy_find
 
@@ -28,14 +28,10 @@ def exists(url):
         ("Cancer case computer contrast pancreatomy Yamada", 2),
     ],
 )
-def test_fuzzy_finder(tmpdir, keywords, record_id):
+def test_fuzzy_finder(keywords, record_id):
     fp = Path("tests", "demo_data", "embase.csv")
-    records = asr.load_dataset(fp, dataset_id="foo")
-    data_store = DataStore(Path(tmpdir, "store.db"))
-    data_store.create_tables()
-    data_store.add_records(records)
-
-    assert fuzzy_find(data_store, keywords)[0] == record_id
+    dataset = load_dataset(fp)
+    assert fuzzy_find(dataset, keywords)[0] == record_id
 
 
 @mark.internet_required

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped
 
-from asreview import load_dataset
+from asreview.data.loader import load_records
 from asreview.data.record import Base
 from asreview.data.record import Record
 from asreview.data.store import CURRENT_DATASTORE_VERSION
@@ -17,7 +17,7 @@ from asreview.project.api import PATH_DATA_STORE
 @pytest.fixture
 def records():
     data_fp = Path("tests", "demo_data", "generic.csv")
-    return load_dataset(data_fp, dataset_id="foo")
+    return load_records(data_fp, dataset_id="foo")
 
 
 @pytest.fixture

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1,10 +1,7 @@
 import os
-from pathlib import Path
-
 import pytest
 
 import asreview as asr
-from asreview.data import DataStore
 from asreview.extensions import extensions
 from asreview.extensions import load_extension
 
@@ -21,16 +18,13 @@ REQUIRES_AI_MODEL_DEP = ["doc2vec", "embedding-idf", "sbert"]
     "split_ta",
     [False, True],
 )
-def test_features(tmpdir, feature_extraction, split_ta):
+def test_features(feature_extraction, split_ta):
     if feature_extraction in REQUIRES_AI_MODEL_DEP:
         pytest.skip()
 
     data_fp = os.path.join("tests", "demo_data", "generic.csv")
 
-    records = asr.load_dataset(data_fp, dataset_id="test_id")
-    data_store = DataStore(Path(tmpdir, "store.db"))
-    data_store.create_tables()
-    data_store.add_records(records)
+    data_store = asr.load_dataset(data_fp)
     if feature_extraction.startswith("embedding-"):
         model = load_extension("models.feature_extraction", feature_extraction)()
     else:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -5,9 +5,9 @@ import pytest
 import rispy
 from pytest import mark
 
-from asreview import load_dataset
-from asreview.utils import _is_url
 from asreview.data.loader import _from_file
+from asreview.data.loader import load_records
+from asreview.utils import _is_url
 
 
 @mark.parametrize(
@@ -171,11 +171,11 @@ def test_nan_values_csv():
 
 
 @mark.internet_required
-def test_load_dataset_from_url(tmpdir):
+def test_load_records_from_url(tmpdir):
     url = "https://zenodo.org/api/records/1162952/files/Hall.csv/content"
 
     urlretrieve(url, tmpdir / "Hall.csv")
-    records = load_dataset(tmpdir / "Hall.csv")
+    records = load_records(tmpdir / "Hall.csv")
     assert len(records) == 8911
 
 
@@ -184,5 +184,5 @@ def test_load_dataset_from_url(tmpdir):
     "dataset_fp", Path("..", "citation-file-formatting", "Datasets", "RIS").glob("*")
 )
 def test_real_datasets(dataset_fp):
-    data = load_dataset(dataset_fp)
+    data = load_records(dataset_fp)
     assert len(data) > 5

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -26,13 +26,7 @@ from asreview.data.loader import _get_writer
         ("ris_issue_992.txt", ["title"]),
         ("ris_issue_1099.txt", ["primary_title"]),
         ("baseline_tag-notes.ris", ["title", "notes"]),
-        pytest.param(
-            "baseline_tag-notes_labels.ris",
-            ["title", "included"],
-            marks=pytest.mark.xfail(
-                reason="Included column changes data type from float to int."
-            ),
-        ),
+        ("baseline_tag-notes_labels.ris", ["title", "included"]),
     ],
 )
 def test_asreview_ris(test_file, columns, tmpdir):


### PR DESCRIPTION
Currently `load_dataset` gives a list of records. The caller still needs to create a datastore and add the records to the datastore. In this PR is separate this into a function `load_records` which is the old `load_dataset`. The new `load_dataset` creates an in memory datastore, loads the records and puts them in the datastore. This way someone can call `load_dataset(fp)` without needing to create anything else.