### PR TITLE
Remove int cast for max_features in RF Classifier

### DIFF
--- a/asreview/models/classifiers.py
+++ b/asreview/models/classifiers.py
@@ -58,7 +58,7 @@ class RandomForestClassifier(SKRandomForestClassifier):
     def __init__(self, n_estimators=100, max_features=10, **kwargs):
         super().__init__(
             n_estimators=int(n_estimators),
-            max_features=int(max_features),
+            max_features=max_features,
             **kwargs,
         )
 


### PR DESCRIPTION
`max_features` can be of types `int, float, str`: [RandomForestClassifier SKLearn Documentation](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)
Closes #2027 