### PR TITLE
Fix Flask-Login version to 1.6.3 due to removal of LOGIN_DISABLED

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRES = [
     "setuptools",
     "flask>=2.3.0",
     "flask_cors",
-    "flask-login>=0.6.3",
+    "flask-login==0.6.3",
     "flask-mail",
     "Werkzeug>=2.3.2",
     "openpyxl>=3.0.3",


### PR DESCRIPTION
We rely on the removed LOGIN_DISABLED feature. Users might face a login screen in the unauthenticated version of ASReview LAB if we don't act.