### PR TITLE
Fix default authentication behaviour of lab entry-point

### DIFF
--- a/.github/workflows/ci-webapp.yml
+++ b/.github/workflows/ci-webapp.yml
@@ -53,7 +53,7 @@ jobs:
           python setup.py compile_assets
       - name: Install pytest and package
         run: |
-          pip install pytest pytest-random-order pytest-xdist
+          pip install pytest pytest-random-order pytest-xdist waitress
           pip install --no-cache-dir .
       - name: Test flask web app
         run: |

--- a/.github/workflows/ci-webapp.yml
+++ b/.github/workflows/ci-webapp.yml
@@ -53,7 +53,7 @@ jobs:
           python setup.py compile_assets
       - name: Install pytest and package
         run: |
-          pip install pytest pytest-random-order pytest-xdist waitress
+          pip install pytest pytest-random-order pytest-xdist
           pip install --no-cache-dir .
       - name: Test flask web app
         run: |

--- a/asreview/webapp/_entry_points/lab.py
+++ b/asreview/webapp/_entry_points/lab.py
@@ -117,9 +117,7 @@ def lab_entry_point(argv):
         app.config.get("AUTHENTICATION", False) or args.authentication
     )
 
-    if "--test-mode" in argv:
-        # if this is a test, there is no need to start the server,
-        # return the app.
+    if app.testing:
         return app
 
     # NO MORE APP CONFIGURATION BELOW THIS LINE
@@ -336,14 +334,6 @@ def _lab_parser():
         dest="skip_update_check",
         action="store_true",
         help="Skip checking for updates.",
-    )
-
-    parser.add_argument(
-        "--test-mode",
-        dest="test_mode",
-        default=False,
-        action="store_true",
-        help="Avoid starting the lab server",
     )
 
     return parser

--- a/asreview/webapp/_entry_points/lab.py
+++ b/asreview/webapp/_entry_points/lab.py
@@ -94,10 +94,10 @@ def lab_entry_point(argv):
         _check_for_update()
 
     app = create_app(
-        CONFIG_PATH=args.config_path,
-        SECRET_KEY=args.secret_key,
-        SALT=args.salt,
-        AUTHENTICATION=args.authentication,
+        config_path=args.config_path,
+        secret_key=args.secret_key,
+        salt=args.salt,
+        authentication=args.authentication,
     )
 
     # By default, the application is authenticated but lab is not.

--- a/asreview/webapp/_entry_points/lab.py
+++ b/asreview/webapp/_entry_points/lab.py
@@ -93,14 +93,12 @@ def lab_entry_point(argv):
     if not args.skip_update_check:
         _check_for_update()
 
-    app = create_app(config_path=args.config_path)
-
-    # override config with command line arguments
-    if args.secret_key:
-        app.config["SECRET_KEY"] = args.secret_key
-
-    if args.salt:
-        app.config["SALT"] = args.salt
+    app = create_app(
+        CONFIG_PATH=args.config_path,
+        SECRET_KEY=args.secret_key,
+        SALT=args.salt,
+        AUTHENTICATION=args.authentication,
+    )
 
     # By default, the application is authenticated but lab is not.
     # Behavior:
@@ -113,9 +111,6 @@ def lab_entry_point(argv):
     #       None       |        True      |         True
     #       None       |        False     |         False
     # ==========================================================
-    app.config["AUTHENTICATION"] = (
-        app.config.get("AUTHENTICATION", False) or args.authentication
-    )
 
     if app.testing:
         return app

--- a/asreview/webapp/_entry_points/lab.py
+++ b/asreview/webapp/_entry_points/lab.py
@@ -121,7 +121,7 @@ def lab_entry_point(argv):
         # if this is a test, there is no need to start the server,
         # return the app.
         return app
-    
+
     # NO MORE APP CONFIGURATION BELOW THIS LINE
     # =========================================
 
@@ -219,7 +219,7 @@ def lab_entry_point(argv):
                 "\n\n[red]Error: unable to startup the model server.[/red]\n\n"
             )
             return
-    
+
     try:
         waitress.serve(app, host=args.host, port=port, threads=6)
     except KeyboardInterrupt:
@@ -343,7 +343,7 @@ def _lab_parser():
         dest="test_mode",
         default=False,
         action="store_true",
-        help="Avoid starting the lab server"
+        help="Avoid starting the lab server",
     )
 
     return parser

--- a/asreview/webapp/_entry_points/lab.py
+++ b/asreview/webapp/_entry_points/lab.py
@@ -117,6 +117,14 @@ def lab_entry_point(argv):
         app.config.get("AUTHENTICATION", False) or args.authentication
     )
 
+    if "--test-mode" in argv:
+        # if this is a test, there is no need to start the server,
+        # return the app.
+        return app
+    
+    # NO MORE APP CONFIGURATION BELOW THIS LINE
+    # =========================================
+
     # clean all projects
     # TODO@{Casper}: this needs a little bit
     # of work, we need to access all sub-folders
@@ -211,7 +219,7 @@ def lab_entry_point(argv):
                 "\n\n[red]Error: unable to startup the model server.[/red]\n\n"
             )
             return
-
+    
     try:
         waitress.serve(app, host=args.host, port=port, threads=6)
     except KeyboardInterrupt:
@@ -328,6 +336,14 @@ def _lab_parser():
         dest="skip_update_check",
         action="store_true",
         help="Skip checking for updates.",
+    )
+
+    parser.add_argument(
+        "--test-mode",
+        dest="test_mode",
+        default=False,
+        action="store_true",
+        help="Avoid starting the lab server"
     )
 
     return parser

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import sys
 
 try:
     import tomllib
@@ -64,6 +65,8 @@ def create_app(config_path=None):
         template_folder="build",
     )
 
+    print(sys.argv)
+
     app.config.from_prefixed_env("ASREVIEW_LAB")
 
     # load config from file
@@ -78,6 +81,14 @@ def create_app(config_path=None):
 
     with app.app_context():
         app.register_blueprint(projects.bp)
+
+    # create_app is also called from the asreview lab entrypoint. The entrypoint
+    # assumes no authentication unless explicit configured. That opposes default
+    # configuration when the app is started by running Flask. Set authentication
+    # to False when the app is started with the entrypoint and no auth configuration
+    # is set.
+    if "lab" in sys.argv and "--enable-auth" not in sys.argv:
+        app.config["AUTHENTICATION"] = False
 
     if app.config.get("AUTHENTICATION", True):
         # Login Manager

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json
 import logging
 import os
 from pathlib import Path
-import sys
 
 try:
     import tomllib
@@ -65,8 +65,6 @@ def create_app(config_path=None):
         template_folder="build",
     )
 
-    print(sys.argv)
-
     app.config.from_prefixed_env("ASREVIEW_LAB")
 
     # load config from file
@@ -87,7 +85,8 @@ def create_app(config_path=None):
     # configuration when the app is started by running Flask. Set authentication
     # to False when the app is started with the entrypoint and no auth configuration
     # is set.
-    if "lab" in sys.argv and "--enable-auth" not in sys.argv:
+    if len(inspect.stack()) > 0 and \
+        inspect.stack()[1].function == "lab_entry_point":
         app.config["AUTHENTICATION"] = False
 
     if app.config.get("AUTHENTICATION", True):

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -65,7 +65,7 @@ def create_app(**config_vars):
     )
 
     app.config.from_prefixed_env("ASREVIEW_LAB")
-    app.config.from_mapping(**config_vars)
+    app.config.from_mapping(**{k.upper(): v for k, v in config_vars.items()})
     if config_fp := app.config.get("CONFIG_PATH", None):
         app.config.from_file(Path(config_fp).absolute(), load=tomllib.load, text=False)
 

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -85,8 +85,7 @@ def create_app(config_path=None):
     # configuration when the app is started by running Flask. Set authentication
     # to False when the app is started with the entrypoint and no auth configuration
     # is set.
-    if len(inspect.stack()) > 0 and \
-        inspect.stack()[1].function == "lab_entry_point":
+    if len(inspect.stack()) > 0 and inspect.stack()[1].function == "lab_entry_point":
         app.config["AUTHENTICATION"] = False
 
     if app.config.get("AUTHENTICATION", True):

--- a/asreview/webapp/app.py
+++ b/asreview/webapp/app.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import json
 import logging
 import os

--- a/asreview/webapp/tests/test_extensions/test_lab.py
+++ b/asreview/webapp/tests/test_extensions/test_lab.py
@@ -1,17 +1,18 @@
+import pytest
+
 import asreview.webapp._entry_points.lab as lab
 
 
-# test if the app has authentication when --enable-auth
-# is an argument
-def test_authentication_parameter():
-    # run lab with --enable-auth
-    app = lab.lab_entry_point(["--test-mode", "--enable-auth"])
+@pytest.fixture
+def mock_env_lab_testing(monkeypatch):
+    monkeypatch.setenv("ASREVIEW_LAB_TESTING", "true")
+
+
+def test_authentication_parameter(mock_env_lab_testing):
+    app = lab.lab_entry_point(["--enable-auth"])
     assert app.config.get("AUTHENTICATION")
 
 
-# test if the app is not configured for authentication,
-# authentication should be False
-def test_without_authentication_parameter():
-    # run lab without --enable-auth
-    app = lab.lab_entry_point(["--test-mode"])
+def test_without_authentication_parameter(mock_env_lab_testing):
+    app = lab.lab_entry_point([])
     assert app.config.get("AUTHENTICATION") is False

--- a/asreview/webapp/tests/test_extensions/test_lab.py
+++ b/asreview/webapp/tests/test_extensions/test_lab.py
@@ -1,0 +1,14 @@
+import pytest
+
+import asreview.webapp._entry_points.lab as lab
+
+# test if the app has authentication when --enable-auth
+# is an argument
+def test_authentication_parameter(client):
+    print(client.application.config)
+    assert False
+
+# test if the app is not configured for authentication,
+# authentication should be False
+def test_without_authentication_parameter(client):
+    assert False

--- a/asreview/webapp/tests/test_extensions/test_lab.py
+++ b/asreview/webapp/tests/test_extensions/test_lab.py
@@ -1,14 +1,15 @@
-import pytest
-
 import asreview.webapp._entry_points.lab as lab
 
 # test if the app has authentication when --enable-auth
 # is an argument
-def test_authentication_parameter(client):
-    print(client.application.config)
-    assert False
+def test_authentication_parameter():
+    # run lab with --enable-auth
+    app = lab.lab_entry_point(["--test-mode", "--enable-auth"])
+    assert app.config.get("AUTHENTICATION")
 
 # test if the app is not configured for authentication,
 # authentication should be False
-def test_without_authentication_parameter(client):
-    assert False
+def test_without_authentication_parameter():
+    # run lab without --enable-auth
+    app = lab.lab_entry_point(["--test-mode"])
+    assert app.config.get("AUTHENTICATION") is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ test = [
     "pytest",
     "pytest-random-order",
     "pytest-selenium",
-    "waitress"
 ]
 docs = [
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "requests",
     "tqdm",
     "rich",
+    "waitress",
     "gevent>=20",
     "datahugger>=0.2",
     "synergy_dataset",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,8 @@ test = [
     "coverage",
     "pytest",
     "pytest-random-order",
-    "pytest-selenium"
+    "pytest-selenium",
+    "waitress"
 ]
 docs = [
     "ipython",


### PR DESCRIPTION
When the app is started with the asreview lab entry-point without authentication configuration, we assume no authentication. This is undermined by the create_app function in app.py. 