### PR TITLE
Sign in a user after successful account creation or password reset

### DIFF
--- a/asreview/webapp/_api/auth.py
+++ b/asreview/webapp/_api/auth.py
@@ -87,6 +87,7 @@ def signin():
                 result = (404, {"message": f"Please login with the {service} service."})
 
     status, message = result
+    print(message)
     response = jsonify(message)
     return response, status
 
@@ -209,8 +210,10 @@ def confirm_account():
             DB.session.rollback()
             result = (500, "Account not confirmed")
 
-    status, message = result
-    response = jsonify({"message": message})
+    status, payload = result
+    payload = {"message": payload} if isinstance(payload, str) else payload
+
+    response = jsonify(payload)
     return response, status
 
 
@@ -315,8 +318,10 @@ def reset_password():
     else:
         result = (404, "Reset-password feature is not used in this app.")
 
-    status, message = result
-    response = jsonify({"message": message})
+    status, payload = result
+    payload = {"message": payload} if isinstance(payload, str) else payload
+
+    response = jsonify(payload)
     return response, status
 
 

--- a/asreview/webapp/_api/auth.py
+++ b/asreview/webapp/_api/auth.py
@@ -90,7 +90,6 @@ def signin():
                 result = (404, {"message": f"Please login with the {service} service."})
 
     status, message = result
-    print(message)
     response = jsonify(message)
     return response, status
 

--- a/asreview/webapp/src/Components/ConfirmAccount.js
+++ b/asreview/webapp/src/Components/ConfirmAccount.js
@@ -63,7 +63,8 @@ const ConfirmAccount = () => {
     },
     onSuccess: () => {
       formik.setValues(initialValues, false);
-      navigate("/signin");
+      // if successful, than the user is signed in.
+      navigate("/");
     },
     onError: (data) => {
       setErrorMessage(data.message);

--- a/asreview/webapp/src/Components/ResetPassword.js
+++ b/asreview/webapp/src/Components/ResetPassword.js
@@ -80,7 +80,7 @@ const ResetPassword = () => {
     },
     onSuccess: () => {
       formik.setValues(initialValues, false);
-      navigate("/signin");
+      navigate("/");
     },
     onError: (data) => {
       setErrorMessage(data.message);

--- a/asreview/webapp/src/api/AuthAPI.js
+++ b/asreview/webapp/src/api/AuthAPI.js
@@ -153,6 +153,7 @@ class AuthAPI {
         method: "post",
         url: url,
         data: body,
+        withCredentials: true,
       })
         .then((result) => {
           resolve(result["data"]);
@@ -174,6 +175,7 @@ class AuthAPI {
         method: "post",
         url: url,
         data: body,
+        withCredentials: true,
       })
         .then((result) => {
           resolve(result["data"]);

--- a/asreview/webapp/tests/test_api/test_auth.py
+++ b/asreview/webapp/tests/test_api/test_auth.py
@@ -227,8 +227,8 @@ def test_token_confirmation_after_signup(client_auth_verified):
     r = au.confirm_user(client_auth_verified, user)
     payload = json.loads(r.text)
     assert r.status_code == 200
-    assert isinstance(payload["message"], dict)
-    assert payload["message"]["logged_in"]
+    assert isinstance(payload, dict)
+    assert payload["logged_in"]
 
 
 # A token expires in 24 hours, test confirmation response after
@@ -410,8 +410,8 @@ def test_reset_password(client_auth_verified):
     # reset it
     r = au.reset_password(client_auth_verified, user)
     assert r.status_code == 200
-    assert isinstance(r.json["message"], dict)
-    assert r.json["message"]["logged_in"]
+    assert isinstance(r.json, dict)
+    assert r.json["logged_in"]
 
 
 # Test reset password: id not found

--- a/asreview/webapp/tests/test_api/test_auth.py
+++ b/asreview/webapp/tests/test_api/test_auth.py
@@ -227,7 +227,8 @@ def test_token_confirmation_after_signup(client_auth_verified):
     r = au.confirm_user(client_auth_verified, user)
     payload = json.loads(r.text)
     assert r.status_code == 200
-    assert payload["message"] == "Account confirmed"
+    assert isinstance(payload["message"], dict)
+    assert payload["message"]["logged_in"]
 
 
 # A token expires in 24 hours, test confirmation response after
@@ -409,7 +410,8 @@ def test_reset_password(client_auth_verified):
     # reset it
     r = au.reset_password(client_auth_verified, user)
     assert r.status_code == 200
-    assert r.json["message"] == "Password updated."
+    assert isinstance(r.json["message"], dict)
+    assert r.json["message"]["logged_in"]
 
 
 # Test reset password: id not found


### PR DESCRIPTION
In the email-verified version of the app, the end-user should be signed in after the token is verified after account creation or password-reset.