### PR TITLE
Fix handling `LB` tags in RIS files

### DIFF
--- a/asreview/data/ris.py
+++ b/asreview/data/ris.py
@@ -213,7 +213,7 @@ class RISReader(BaseReader):
     @classmethod
     def clean_data(cls, df):
         # We drop the 'label' column if it's available. For RIS files ASReview stores
-        # and loads the labels from the notes field. 
+        # and loads the labels from the notes field.
         df.drop("label", axis=1, inplace=True, errors="ignore")
         return super().clean_data(df)
 

--- a/asreview/data/ris.py
+++ b/asreview/data/ris.py
@@ -210,6 +210,13 @@ class RISReader(BaseReader):
 
         return df
 
+    @classmethod
+    def clean_data(cls, df):
+        # We drop the 'label' column if it's available. For RIS files ASReview stores
+        # and loads the labels from the notes field. 
+        df.drop("label", axis=1, inplace=True, errors="ignore")
+        return super().clean_data(df)
+
 
 class RISWriter:
     """RIS file writer."""

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -193,17 +193,17 @@ def test_ris_lb_tag(tmpdir):
     record = """TY  - JOUR
 LB  - 1
 TI  - This is the title
-ER  - 
+ER  -
 
 TY  - JOUR
 LB  - 0
 TI  - This is the second title
-ER  - 
+ER  -
 
 TY  - JOUR
 LB  - 28362428
 TI  - This is another title
-ER  - 
+ER  -
 """
     fp = Path(tmpdir, "lb_data.ris")
     with open(fp, "w") as f:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -7,6 +7,7 @@ from pytest import mark
 
 from asreview.data.loader import _from_file
 from asreview.data.loader import load_records
+from asreview.data.ris import RISReader
 from asreview.utils import _is_url
 
 
@@ -186,3 +187,29 @@ def test_load_records_from_url(tmpdir):
 def test_real_datasets(dataset_fp):
     data = load_records(dataset_fp)
     assert len(data) > 5
+
+
+def test_res_lb_tag(tmpdir):
+    record = """TY  - JOUR
+LB  - 1
+TI  - This is the title
+ER  - 
+
+TY  - JOUR
+LB  - 0
+TI  - This is the second title
+ER  - 
+
+TY  - JOUR
+LB  - 28362428
+TI  - This is another title
+ER  - 
+"""
+    fp = Path(tmpdir, "lb_data.ris")
+    with open(fp, "w") as f:
+        f.write(record)
+
+    records = RISReader.read_records(fp, dataset_id="foo")
+    assert len(records) == 3
+    for record in records:
+        assert record.included is None

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -189,7 +189,7 @@ def test_real_datasets(dataset_fp):
     assert len(data) > 5
 
 
-def test_res_lb_tag(tmpdir):
+def test_ris_lb_tag(tmpdir):
     record = """TY  - JOUR
 LB  - 1
 TI  - This is the title


### PR DESCRIPTION
This pull request fixes #607 . If there are `LB` tags in the RIS file, ASReview now ignores it's values. The record labels are only parsed from the note field.