### PR TITLE
Modify to_file to return content without storing by default

### DIFF
--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -174,9 +174,21 @@ class BaseDataSet:
 
         return self._filename
 
-    def to_file(self, path):
-        # todo return without store
-        urlretrieve(self.filepath, path)
+    def to_file(self, path=None):
+        #Download the file and save it if path provided
+        try: 
+            with urlopen(self.filepath) as response:
+                data=response.read() #read the data
+                
+                if path: 
+                    with open(path,'wb') as f:
+                        f.write(data) #write the data in path provided
+                
+                else:
+                    return data # return the data without storing
+        
+        except URLError as e :
+            raise Exception("URL Error")
 
 
 class BaseDataGroup(ABC):

--- a/asreview/datasets.py
+++ b/asreview/datasets.py
@@ -175,19 +175,19 @@ class BaseDataSet:
         return self._filename
 
     def to_file(self, path=None):
-        #Download the file and save it if path provided
-        try: 
+        # Download the file and save it if path provided
+        try:
             with urlopen(self.filepath) as response:
-                data=response.read() #read the data
-                
-                if path: 
-                    with open(path,'wb') as f:
-                        f.write(data) #write the data in path provided
-                
+                data = response.read()  # read the data
+
+                if path:
+                    with open(path, "wb") as f:
+                        f.write(data)  # write the data in path provided
+
                 else:
-                    return data # return the data without storing
-        
-        except URLError as e :
+                    return data  # return the data without storing
+
+        except URLError as e:
             raise Exception("URL Error")
 
 


### PR DESCRIPTION
PR updates the to_file method in BaseDataSet class to address the TODO. Previously, it only downloaded the dataset file to a specified path. now it returns the content directly if no path is provided, if path is provided it stores the data to that path. 

Changes: 
1. Modified to_file to return data without storing if path is not provided.
2. Handled possible URL Error which can occur while urlopen is being used