### PR TITLE
Update compatible search engines list with OpenAlex.rst

### DIFF
--- a/docs/source/lab/data.rst
+++ b/docs/source/lab/data.rst
@@ -95,6 +95,7 @@ acceptance in ASReview:
 **Cochrane**         ✅       N/A      ✅       N/A
 **Embase**           ✅       N/A      ✅       ✅
 **Eric (Ovid)**      ✅*      N/A      N/A      N/A
+**OpenAlex**         ✅       N/A      ✅       N/A
 **Psychinfo (Ovid)** ✅*      N/A      N/A      N/A
 **Pubmed**           X        N/A      X        N/A
 **Scopus**           ✅       N/A      ✅       N/A


### PR DESCRIPTION
I added OpenAlex to the table containing search engines, as it can export datasets directly in .ris and .csv formats.
![Screenshot 2025-02-17 182412](https://github.com/user-attachments/assets/b094e415-e6ef-42ac-bff4-86f34b629dc0)
![Zotero - OpenAlex dataset export](https://github.com/user-attachments/assets/9986299b-10cf-473e-b2e6-e19389070450)

Rens had me check the resulting dataset exported by ASReview as well. It is fully functional in Zotero.