### PR TITLE
Fixing ORCID OAuth

### DIFF
--- a/asreview/webapp/_authentication/oauth_handler.py
+++ b/asreview/webapp/_authentication/oauth_handler.py
@@ -80,7 +80,7 @@ class OAuthHandler:
             raise ValueError(f"Could not find provider {provider}")
         return result
 
-    def __generate_default_email(self, name=""):
+    def __generate_mock_email_address(self, name=""):
         return f"#{name}_{uuid.uuid4()}@asreview.app"
 
     def __handle_orcid(self, code):
@@ -106,7 +106,7 @@ class OAuthHandler:
 
         # set email to an initial default address since the
         # next step might leave us empty-handed
-        email = self.__generate_default_email(name)
+        email = self.__generate_mock_email_address(name)
 
         # Now, let's try to obtain an email address.
         if not orcid_id is None:
@@ -165,7 +165,7 @@ class OAuthHandler:
         response = response.json()
         id = response["id"]
         name = response["name"] or response["login"] or response["id"] or "Name"
-        email = response.get("email", self.__generate_default_email(name))
+        email = response.get("email", self.__generate_mock_email_address(name))
 
         return (id, email, name)
 
@@ -195,5 +195,5 @@ class OAuthHandler:
         name = (
             response.get("name", False) or response.get("family_name", False) or "Name"
         )
-        email = response.get("email", self.__generate_default_email(name))
+        email = response.get("email", self.__generate_mock_email_address(name))
         return (id, email, name)

--- a/asreview/webapp/_authentication/oauth_handler.py
+++ b/asreview/webapp/_authentication/oauth_handler.py
@@ -133,8 +133,8 @@ class OAuthHandler:
                     f"https://pub{orcid_env}.orcid.org/v3.0/{orcid_id}/email",
                     headers={
                         "Accept": "application/json",
-                        "Authorization": f"Bearer {token}"
-                    }
+                        "Authorization": f"Bearer {token}",
+                    },
                 ).json()
                 # get first available email when present
                 if "email" in response.keys() and len(response["email"]) > 0:
@@ -166,7 +166,7 @@ class OAuthHandler:
         id = response["id"]
         name = response["name"] or response["login"] or response["id"] or "Name"
         email = response.get("email", self.__generate_default_email(name))
-        
+
         return (id, email, name)
 
     def __handle_google(self, code, redirect_uri):

--- a/asreview/webapp/_authentication/oauth_handler.py
+++ b/asreview/webapp/_authentication/oauth_handler.py
@@ -109,7 +109,7 @@ class OAuthHandler:
         email = self.__generate_mock_email_address(name)
 
         # Now, let's try to obtain an email address.
-        if not orcid_id is None:
+        if orcid_id is not None:
             # we need a another token to obtain the email address.
             response = requests.post(
                 params["token_url"],
@@ -125,7 +125,7 @@ class OAuthHandler:
             # get token from response
             token = response.get("access_token", None)
 
-            if not token is None:
+            if token is not None:
                 # check if we are working in the sandbox or not
                 orcid_env = ".sandbox" if "sandbox" in params["token_url"] else ""
                 # get request to obtain user data

--- a/docs/source/server/configuration.rst
+++ b/docs/source/server/configuration.rst
@@ -99,7 +99,7 @@ secure way (https).
 
 Not that the SCOPE parameter is missing for Orcid: to retrieve user data from
 Orcid, multiple calls have to be made with different scopes. Therefor the
-scopes are hard-coded in our repository.
+scopes are hard-coded.
 
 Store the TOML file on the server and start the ASReview application from the
 CLI with the ``--config-path`` parameter:

--- a/docs/source/server/configuration.rst
+++ b/docs/source/server/configuration.rst
@@ -89,7 +89,6 @@ secure way (https).
             TOKEN_URL = "https://sandbox.orcid.org/oauth/token"
             CLIENT_ID = "<Orcid client ID>"
             CLIENT_SECRET = "<Orcid client secret>"
-            SCOPE = "/authenticate"
 
             [OAUTH.Google]
             AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/auth"
@@ -97,6 +96,10 @@ secure way (https).
             CLIENT_ID = "<Google client ID>"
             CLIENT_SECRET = "<Google client secret>"
             SCOPE = "profile email"
+
+Not that the SCOPE parameter is missing for Orcid: to retrieve user data from
+Orcid, multiple calls have to be made with different scopes. Therefor the
+scopes are hard-coded in our repository.
 
 Store the TOML file on the server and start the ASReview application from the
 CLI with the ``--config-path`` parameter:


### PR DESCRIPTION
This PR fixes the problems we have with ORCID's OAuth. We now make an effort to obtain a user's public email address from ORCID. If that email address is not public, a unique mock email address is stored in the database to avoid duplication problems in the email column.

For all other OAuth services (Github and Google), the same behaviour is implemented: when it is impossible to obtain an email address, a unique mock address is generated since we don't need an actual email address for OAuth users. 

This also fixes the bug that causes the profile page to get stuck (the former email address was "email-unknown" which is not a proper formatted email address).