### PR TITLE
Remove record_id when reading data

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -134,6 +134,7 @@ class BaseReader(ABC):
             List of records.
         """
         columns_present = set(df.columns).intersection(set(record_cls.get_columns()))
+        columns_present.discard("record_id")
         return [
             record_cls(dataset_row=idx, dataset_id=dataset_id, **row)
             for idx, row in df[list(columns_present)].iterrows()


### PR DESCRIPTION
When reading a dataset into the data store, we were reading the column `record_id` if that was present. However, we make the `record_id` internally, so we should skip this column when reading.