### PR TITLE
Fix NULL out `prior` in migrate

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -134,6 +134,7 @@ class BaseReader(ABC):
             List of records.
         """
         columns_present = set(df.columns).intersection(set(record_cls.get_columns()))
+        columns_present.discard("record_id")
         return [
             record_cls(dataset_row=idx, dataset_id=dataset_id, **row)
             for idx, row in df[list(columns_present)].iterrows()

--- a/asreview/migrate.py
+++ b/asreview/migrate.py
@@ -69,6 +69,7 @@ def _project_state_converter_v1_v2(review_path):
         // int(1e3)
         / int(1e6)
     )
+    df_results["querier"] = df_results["querier"].replace("prior", None)
     del df_results["labeling_time"]
     sqlstate._replace_results_from_df(df_results)
 


### PR DESCRIPTION
When migrating an ASReview file from version 1 to version 2, in the results table the value `prior` is now replaced with `None`.