### PR TITLE
Fix email constraints when accounts are not created by signup

### DIFF
--- a/asreview/webapp/_api/auth.py
+++ b/asreview/webapp/_api/auth.py
@@ -340,9 +340,9 @@ def update_profile():
     old_email = user.email
 
     if user:
-        email = request.form.get("email", "").strip()
-        name = request.form.get("name", "").strip()
-        affiliation = request.form.get("affiliation", "").strip()
+        email = request.form.get("email", None)
+        name = request.form.get("name", None)
+        affiliation = request.form.get("affiliation", None)
         old_password = request.form.get("old_password", None)
         new_password = request.form.get("new_password", None)
         public = bool(int(request.form.get("public", "1")))

--- a/asreview/webapp/_authentication/models.py
+++ b/asreview/webapp/_authentication/models.py
@@ -44,7 +44,7 @@ class User(UserMixin, DB.Model):
     id = Column(Integer, primary_key=True)
     identifier = Column(String(100), nullable=False, unique=True)
     origin = Column(String(100), nullable=False)
-    email = Column(String(100), unique=True)
+    email = Column(String(100), nullable=True, unique=True)
     name = Column(String(100))
     affiliation = Column(String(100))
     hashed_password = Column(String(500))

--- a/asreview/webapp/_authentication/models.py
+++ b/asreview/webapp/_authentication/models.py
@@ -127,7 +127,6 @@ class User(UserMixin, DB.Model):
         # if there is a request to update the password, and the origin
         # is correct
         if self.origin == "asreview":
-
             if bool(old_password) and bool(new_password):
                 # verify the old password
                 if not self.verify_password(old_password):

--- a/asreview/webapp/_authentication/models.py
+++ b/asreview/webapp/_authentication/models.py
@@ -126,18 +126,21 @@ class User(UserMixin, DB.Model):
     ):
         # if there is a request to update the password, and the origin
         # is correct
-        if bool(old_password) and bool(new_password) and self.origin == "asreview":
-            # verify the old password
-            if not self.verify_password(old_password):
-                raise ValueError("Provided old password is incorrect.")
-            else:
-                # old password is verified. The following line will raise
-                # a ValueError if the new password is wrong
-                self.hashed_password = User.create_password_hash(new_password)
+        if self.origin == "asreview":
 
-        if self.email != email:
-            self.set_token()
-            self.confirmed = False
+            if bool(old_password) and bool(new_password):
+                # verify the old password
+                if not self.verify_password(old_password):
+                    raise ValueError("Provided old password is incorrect.")
+                else:
+                    # old password is verified. The following line will raise
+                    # a ValueError if the new password is wrong
+                    self.hashed_password = User.create_password_hash(new_password)
+
+            # email has been changed
+            if self.email != email:
+                self.set_token()
+                self.confirmed = False
 
         self.email = email
         self.name = name

--- a/asreview/webapp/_authentication/oauth_handler.py
+++ b/asreview/webapp/_authentication/oauth_handler.py
@@ -80,9 +80,6 @@ class OAuthHandler:
             raise ValueError(f"Could not find provider {provider}")
         return result
 
-    def __generate_mock_email_address(self, name=""):
-        return f"#{name}_{uuid.uuid4()}@asreview.app"
-
     def __handle_orcid(self, code):
         """Handles OAuth roundtrip for Orcid"""
         # request token
@@ -104,9 +101,8 @@ class OAuthHandler:
         orcid_id = response.get("orcid", None)
         name = response.get("name", None)
 
-        # set email to an initial default address since the
-        # next step might leave us empty-handed
-        email = self.__generate_mock_email_address(name)
+        # set email to None
+        email = None
 
         # Now, let's try to obtain an email address.
         if orcid_id is not None:
@@ -165,7 +161,7 @@ class OAuthHandler:
         response = response.json()
         id = response["id"]
         name = response["name"] or response["login"] or response["id"] or "Name"
-        email = response.get("email", self.__generate_mock_email_address(name))
+        email = response.get("email", None)
 
         return (id, email, name)
 
@@ -195,5 +191,5 @@ class OAuthHandler:
         name = (
             response.get("name", False) or response.get("family_name", False) or "Name"
         )
-        email = response.get("email", self.__generate_mock_email_address(name))
+        email = response.get("email", None)
         return (id, email, name)

--- a/asreview/webapp/_authentication/oauth_handler.py
+++ b/asreview/webapp/_authentication/oauth_handler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import requests
-import uuid
 
 
 class OAuthHandler:

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -30,8 +30,12 @@ import * as Yup from "yup";
 const SignupSchema = Yup.object().shape({
   email: Yup.string()
     .email("Invalid email")
-    .required("Email is required")
-    .nullable(),
+    .nullable()
+    .when("$window.allowAccountCreation", {
+      is: true,
+      then: (schema) => schema.required("Email is required"),
+      otherwise: (schema) => schema.optional(),
+    }),
   name: Yup.string().required("Full name is required").nullable(),
   affiliation: Yup.string(),
   oldPassword: Yup.string(),

--- a/asreview/webapp/src/api/AuthAPI.js
+++ b/asreview/webapp/src/api/AuthAPI.js
@@ -123,11 +123,12 @@ class AuthAPI {
 
   static updateProfile(variables) {
     let body = new FormData();
-    body.set("old_password", variables.oldPassword ?? "");
-    body.set("new_password", variables.newPassword ?? "");
-    body.set("name", variables.name);
-    body.set("affiliation", variables.affiliation);
-    body.set("email", variables.email);
+
+    if (variables.oldPassword) body.set("old_password", variables.oldPassword);
+    if (variables.newPassword) body.set("new_password", variables.newPassword);
+    if (variables.name) body.set("name", variables.name);
+    if (variables.affiliation) body.set("affiliation", variables.affiliation);
+    if (variables.email) body.set("email", variables.email);
     body.set("public", variables.publicAccount === true ? 1 : 0);
 
     const url = auth_url + `update_profile`;

--- a/asreview/webapp/tests/test_database_and_models/test_user_model.py
+++ b/asreview/webapp/tests/test_database_and_models/test_user_model.py
@@ -65,7 +65,7 @@ def test_user_must_have_name(setup_teardown):
 # test if email can not be blank if origin is "asreview"
 def test_email_validation_1(setup_teardown):
     with pytest.raises(ValueError, match="Email is required when origin is 'asreview'"):
-        user = User(
+        User(
             identifier="identifier_1",
             email=None,
             name="Test User",
@@ -77,7 +77,7 @@ def test_email_validation_1(setup_teardown):
 # test if email can not be empty if origin is "asreview"
 def test_email_validation_2(setup_teardown):
     with pytest.raises(ValueError, match="Email is required when origin is 'asreview'"):
-        user = User(
+        User(
             identifier="identifier_1",
             email="",
             name="Test User",
@@ -153,30 +153,6 @@ def test_ext_multiple_account_creation_no_email(setup_teardown):
     )
     crud.create_user(DB, user2)
     assert crud.count_users() == 2
-
-
-# verify that identifiers must be unique for externally
-# created accounts
-def test_ext_multiple_account_creation_no_email(setup_teardown):
-    assert crud.count_users() == 0
-    user1 = User(
-        identifier="identifier_1",
-        email=None,
-        name="Test User",
-        origin="orcid",
-        password=None
-    )
-    crud.create_user(DB, user1)
-    assert crud.count_users() == 1
-    user2 = User(
-        identifier="identifier_1",
-        email=None,
-        name="Test User",
-        origin="orcid",
-        password=None
-    )
-    with pytest.raises(IntegrityError):
-        crud.create_user(DB, user2)
 
 
 # test if all fails when password doesn't meet requirements

--- a/asreview/webapp/tests/test_database_and_models/test_user_model.py
+++ b/asreview/webapp/tests/test_database_and_models/test_user_model.py
@@ -157,7 +157,7 @@ def test_ext_multiple_account_creation_no_email(setup_teardown):
 
 # verify that identifiers must be unique for externally
 # created accounts
-def test_ext_multiple_account_creation_no_email(setup_teardown):
+def test_ext_multiple_account_no_email_same_identifiers(setup_teardown):
     assert crud.count_users() == 0
     user1 = User(
         identifier="identifier_1",


### PR DESCRIPTION
When accounts are created by using an external service (for instance OAuth)  we might not receive an email address of the user. The User model needs to be flexible enough to handle missing email addresses when accounts are not created by signup, but must verify email-address uniqueness when accounts are created by signup. 