### PR TITLE
Prevent implicit bool conversion on classifier instances

### DIFF
--- a/asreview/webapp/_tasks.py
+++ b/asreview/webapp/_tasks.py
@@ -74,7 +74,7 @@ def run_model(project):
             cycle = asr.ActiveLearningCycle.from_meta(cycle_data)
             fm = project.data_store.get_df().values
 
-        if cycle.classifier:
+        if cycle.classifier is not None:
             cycle.fit(
                 fm[labeled["record_id"].values],
                 labeled["label"].values,


### PR DESCRIPTION
Fixes a bug where Random Forest and AdaBoost were implicitly casted to bool. This casting only works for these models when the model is fit. At this point in the code the models are only initialized, not fitted, hence the error.