### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,0 +1,54 @@
+name: Test ASReview webapp (integration)
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  selenium-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: # must be valid values that can be passed to pytest's --driver option
+          - 'chrome'
+    env:
+      ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI: sqlite:////tmp/db.sqlite
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "asreview/webapp/package-lock.json"
+      - uses: nanasess/setup-chromedriver@v2
+        if: matrix.browser == 'chrome'
+      - name: Install requirements
+        run: pip3 install .[test] setuptools gunicorn
+      - name: Compile assets
+        run: python setup.py compile_assets
+      - name: Install ASReview from source
+        run: |
+          pip3 install .
+      - name: Run chromedriver
+        if: matrix.browser == 'chrome'
+        run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+      - name: Run tests
+        run: |
+          echo "DB URI: $ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI"
+          cd asreview/webapp
+          asreview lab \
+            --config-path "$GITHUB_WORKSPACE/asreview/webapp/tests/config/auth_integration_config.toml" \
+            --skip-update-check --no-browser &
+          sleep 1
+          pytest tests/integration_tests \
+            -v \
+            --driver ${{ matrix.browser }} \
+            --url http://localhost:5000 \
+            --database-uri ${{ env.ASREVIEW_LAB_SQLALCHEMY_DATABASE_URI }}

--- a/asreview/webapp/_api/auth.py
+++ b/asreview/webapp/_api/auth.py
@@ -346,7 +346,8 @@ def update_profile():
         old_password = request.form.get("old_password", None)
         new_password = request.form.get("new_password", None)
         public = bool(int(request.form.get("public", "1")))
-        reconfirm = ( email != old_email
+        reconfirm = (
+            email != old_email
             and user.origin == "asreview"
             and current_app.config.get("EMAIL_VERIFICATION", False)
         )

--- a/asreview/webapp/_api/auth.py
+++ b/asreview/webapp/_api/auth.py
@@ -346,17 +346,17 @@ def update_profile():
         old_password = request.form.get("old_password", None)
         new_password = request.form.get("new_password", None)
         public = bool(int(request.form.get("public", "1")))
+        reconfirm = ( email != old_email
+            and user.origin == "asreview"
+            and current_app.config.get("EMAIL_VERIFICATION", False)
+        )
 
         try:
             user = user.update_profile(
-                email, name, affiliation, old_password, new_password, public
+                email, name, affiliation, old_password, new_password, public, reconfirm
             )
             DB.session.commit()
-            if (
-                email != old_email
-                and user.origin == "asreview"
-                and current_app.config.get("EMAIL_VERIFICATION", False)
-            ):
+            if reconfirm:
                 # send email
                 send_confirm_account_email(user, current_app, "change_email")
                 # email has been changed and we verify email

--- a/asreview/webapp/_authentication/models.py
+++ b/asreview/webapp/_authentication/models.py
@@ -123,6 +123,7 @@ class User(UserMixin, DB.Model):
         old_password=None,
         new_password=None,
         public=True,
+        reconfirm=True,
     ):
         # if there is a request to update the password, and the origin
         # is correct
@@ -137,7 +138,7 @@ class User(UserMixin, DB.Model):
                     self.hashed_password = User.create_password_hash(new_password)
 
             # email has been changed
-            if self.email != email:
+            if self.email != email and reconfirm:
                 self.set_token()
                 self.confirmed = False
 

--- a/asreview/webapp/tests/config/auth_integration_config.toml
+++ b/asreview/webapp/tests/config/auth_integration_config.toml
@@ -1,0 +1,8 @@
+# Auth config file for integration tests for CI
+TESTING = false
+DEBUG = true
+SECRET_KEY = "my_very_secret_key"
+SECURITY_PASSWORD_SALT = "my_salt"
+AUTHENTICATION = true
+ALLOW_ACCOUNT_CREATION = true
+EMAIL_VERIFICATION = false

--- a/asreview/webapp/tests/integration_tests/README.md
+++ b/asreview/webapp/tests/integration_tests/README.md
@@ -47,3 +47,13 @@ $ pytest -v -o asreview/webapp/tests/integration_tests/signup_signin_create_proj
 ```
 
 In this concrete example, the test is executed against the frontend of ASReview that runs on a local server on port 3000, using FireFox as the test browser, and the authorization PostgreSQL database can also be found under local host, port 5432.
+
+## CI
+
+On CI, integration tests run against a freshly built 'production' version of ASReview: assets are compiled, the pip package is installed, and `asreview lab` is run using [this config file](../config/auth_integration_config.toml).
+
+For ease of installation, the CI tests use the `chrome` driver for Selenium. Keep in mind that test results may sometimes vary when using different drivers. When debugging integration tests that fail on CI, you can also try to reproduce by running the Github Action locally using [nektos/act](https://github.com/nektos/act). For example:
+
+`act -W .github/workflows/ci-integration.yml --container-options "-v /tmp/seleniumout:/tmp/seleniumout" --env SELENIUM_SCREENSHOT_DIR="/tmp/seleniumout"`
+
+...this starts the action on a container locally, mounting `/tmp/seleniumout` on the container, and setting this as the directory in which debug-screenshots are saved when using the `utils.save_sreenshot` function.

--- a/asreview/webapp/tests/integration_tests/change_profile_test.py
+++ b/asreview/webapp/tests/integration_tests/change_profile_test.py
@@ -63,7 +63,7 @@ def test_change_profile(driver, url, database_uri):
     utils.click_element(driver, "button#save")
 
     # verify we're on the project dashboard again
-    utils.wait_for_redirect(driver, base_url + '/reviews')
+    utils.wait_for_redirect(driver, base_url + "/reviews")
 
     # assert we have an updated user
     assert len(session.query(User).all()) == 1
@@ -74,13 +74,13 @@ def test_change_profile(driver, url, database_uri):
 
     # log out
     utils.sign_out(driver)
-    utils.wait_for_redirect(driver, base_url + '/signin')
+    utils.wait_for_redirect(driver, base_url + "/signin")
 
     # log back in with new data
     utils.sign_in(driver, base_url, new_user_data)
     utils.save_screenshot(driver, name="post_signin")
     # check if we are on the project dashboard
-    utils.wait_for_redirect(driver, base_url + '/reviews')
+    utils.wait_for_redirect(driver, base_url + "/reviews")
 
     # close driver
     driver.close()

--- a/asreview/webapp/tests/integration_tests/conftest.py
+++ b/asreview/webapp/tests/integration_tests/conftest.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def pytest_addoption(parser):
     parser.addoption("--url", action="store", default="http://localhost:3000/")
     parser.addoption("--database-uri", action="store")

--- a/asreview/webapp/tests/integration_tests/conftest.py
+++ b/asreview/webapp/tests/integration_tests/conftest.py
@@ -1,8 +1,18 @@
+from os import getenv
+
+import pytest
+
 def pytest_addoption(parser):
     parser.addoption("--url", action="store", default="http://localhost:3000/")
     parser.addoption("--database-uri", action="store")
     parser.addoption("--reading-time", action="store", type=int, default=5)
 
+@pytest.fixture
+def chrome_options(chrome_options):
+    if bool(getenv('CI', False)):
+        chrome_options.add_argument('--headless')
+        chrome_options.add_argument("--no-sandbox")
+    return chrome_options
 
 @pytest.fixture(scope="session")
 def url(pytestconfig):

--- a/asreview/webapp/tests/integration_tests/conftest.py
+++ b/asreview/webapp/tests/integration_tests/conftest.py
@@ -2,17 +2,20 @@ from os import getenv
 
 import pytest
 
+
 def pytest_addoption(parser):
     parser.addoption("--url", action="store", default="http://localhost:3000/")
     parser.addoption("--database-uri", action="store")
     parser.addoption("--reading-time", action="store", type=int, default=5)
 
+
 @pytest.fixture
 def chrome_options(chrome_options):
-    if bool(getenv('CI', False)):
-        chrome_options.add_argument('--headless')
+    if bool(getenv("CI", False)):
+        chrome_options.add_argument("--headless")
         chrome_options.add_argument("--no-sandbox")
     return chrome_options
+
 
 @pytest.fixture(scope="session")
 def url(pytestconfig):

--- a/asreview/webapp/tests/integration_tests/signup_signin_create_project_test.py
+++ b/asreview/webapp/tests/integration_tests/signup_signin_create_project_test.py
@@ -1,5 +1,7 @@
 import random
 
+import pytest
+
 import asreview.webapp.tests.integration_tests.utils as utils
 from asreview.webapp._authentication.models import Project
 
@@ -45,7 +47,7 @@ PROJECT = {
     },
 }
 
-
+@pytest.mark.skip(reason="create_project must be refactored")
 def test_signup_signin_create_project(driver, url, database_uri, reading_time):
     base_url = url
     driver.get(base_url)
@@ -80,3 +82,21 @@ def test_signup_signin_create_project(driver, url, database_uri, reading_time):
 
     # close driver
     driver.close()
+
+
+def test_signup_signin_signout(driver, url, database_uri, reading_time):
+    base_url = url
+    driver.get(base_url)
+
+    # setup database session
+    session = utils.setup_database_session(database_uri)
+
+    # clean database
+    utils.clean_database(session)
+    # create account
+    utils.create_account(driver, base_url, ACCOUNT)
+
+    utils.sign_in(driver, base_url, ACCOUNT)
+    utils.sign_out(driver)
+
+    utils.wait_for_redirect(driver, base_url + '/signin')

--- a/asreview/webapp/tests/integration_tests/signup_signin_create_project_test.py
+++ b/asreview/webapp/tests/integration_tests/signup_signin_create_project_test.py
@@ -47,6 +47,7 @@ PROJECT = {
     },
 }
 
+
 @pytest.mark.skip(reason="create_project must be refactored")
 def test_signup_signin_create_project(driver, url, database_uri, reading_time):
     base_url = url
@@ -99,4 +100,4 @@ def test_signup_signin_signout(driver, url, database_uri, reading_time):
     utils.sign_in(driver, base_url, ACCOUNT)
     utils.sign_out(driver)
 
-    utils.wait_for_redirect(driver, base_url + '/signin')
+    utils.wait_for_redirect(driver, base_url + "/signin")

--- a/asreview/webapp/tests/integration_tests/utils.py
+++ b/asreview/webapp/tests/integration_tests/utils.py
@@ -11,11 +11,13 @@ from sqlalchemy.orm import sessionmaker
 from asreview.webapp._authentication.models import Project
 from asreview.webapp._authentication.models import User
 
-SELENIUM_SCREENSHOT_DIR = os.getenv('SELENIUM_SCREENSHOT_DIR', '/tmp')
+SELENIUM_SCREENSHOT_DIR = os.getenv("SELENIUM_SCREENSHOT_DIR", "/tmp")
+
 
 def save_screenshot(driver, name="screenshot", dirpath=SELENIUM_SCREENSHOT_DIR):
     os.makedirs(dirpath, exist_ok=True)
-    driver.save_screenshot(f'{dirpath}/{name}.png')
+    driver.save_screenshot(f"{dirpath}/{name}.png")
+
 
 def setup_database_session(uri):
     Session = sessionmaker()
@@ -60,16 +62,14 @@ def select_from_dropdown(driver, parent, data_value):
 # TODO APPLY THIS FUNCTION
 def fill_text_field_by_id(driver, field_id, value, wait_time=60):
     selector = (By.CSS_SELECTOR, f"input#{field_id}")
-    WebDriverWait(driver, wait_time).until(
-        EC.presence_of_element_located(selector)
-    )
+    WebDriverWait(driver, wait_time).until(EC.presence_of_element_located(selector))
 
     input_field = driver.find_element(*selector)
 
-   # input_field.clear() does not work for all fields when using chromedriver:
-   # fields that have autofill enabled are re-filled after being cleared.
-   # instead, just clear the fields manually:
-    while not input_field.get_attribute('value') == "":
+    # input_field.clear() does not work for all fields when using chromedriver:
+    # fields that have autofill enabled are re-filled after being cleared.
+    # instead, just clear the fields manually:
+    while not input_field.get_attribute("value") == "":
         input_field.send_keys(Keys.BACK_SPACE)
 
     input_field.send_keys(value)
@@ -137,17 +137,20 @@ def sign_out(driver):
     click_element(driver, "//p[contains(text(), 'Sign out')]", selector_type=By.XPATH)
 
 
-def page_contains_text(driver, text, selector="body", selector_type=By.CSS_SELECTOR, wait_time=60):
+def page_contains_text(
+    driver, text, selector="body", selector_type=By.CSS_SELECTOR, wait_time=60
+):
     # wait until the text is visible
     WebDriverWait(driver, wait_time).until(
-        EC.text_to_be_present_in_element(
-            (selector_type, selector), text
-        )
+        EC.text_to_be_present_in_element((selector_type, selector), text)
     )
     return True
 
+
 def wait_for_redirect(driver, redirect_url, wait_time=10):
-    WebDriverWait(driver, wait_time).until(lambda driver: driver.current_url == redirect_url)
+    WebDriverWait(driver, wait_time).until(
+        lambda driver: driver.current_url == redirect_url
+    )
 
 
 def label_abstract(driver, label, reading_time=0):


### PR DESCRIPTION
While working on #2129 I tried to implement a test for the new functionality allowing the customization of the post-logout redirect URL. I noticed the integration tests where currently not working. I took the liberty of fixing them, which required the following steps, only one of which is major:

* updating some selector paths in the integration tests' `utils.py`, due to changes in the frontend
* updating some expected HTML, due to changes in the frontend
* **fixing an issue with updating the user profile.** At present, when a user updates their email address, this will set the user's `confirmed` status to `False`, *even if email verification is turned off globally*.

I suppose the latter fix (if this is indeed a bug, as I have interpreted it) might also constitute a separate PR?

I have also included an experimental GitHub Actions workflow for running integration tests. I suppose that to save time/resources, this could also be made part of the `ci-webapp` workflow, so things like asset precompilation don't need to be done twice.

No worries if these changes are not helpful, e.g. if you were planning to change the test workflows anyway, but thought I'd contribute!