### PR TITLE
Use metadata for quick loading of model labels

### DIFF
--- a/asreview/models/_metadata.py
+++ b/asreview/models/_metadata.py
@@ -1,0 +1,49 @@
+MODEL_METADATA = {
+    "balancers": {
+        "balanced": {
+            "label": "Balanced Sample Weight",
+        },
+    },
+    "classifiers": {
+        "rf": {
+            "label": "Random forest",
+        },
+        "logistic": {
+            "label": "Logistic regression",
+        },
+        "svm": {
+            "label": "Support vector machine",
+        },
+        "nb": {
+            "label": "Naive Bayes",
+        },
+    },
+    "feature_extractors": {
+        "tfidf": {
+            "label": "TF-IDF",
+        },
+        "onehot": {
+            "label": "OneHot",
+        },
+    },
+    "queriers": {
+        "random": {
+            "label": "Random",
+        },
+        "uncertainty": {
+            "label": "Uncertainty",
+        },
+        "max": {
+            "label": "Maximum",
+        },
+        "max_uncertainty": {
+            "label": "Mixed (95% Maximum and 5% Uncertainty)",
+        },
+        "max_random": {
+            "label": "Mixed (95% Maximum and 5% Random)",
+        },
+        "top_down": {
+            "label": "Top-down",
+        },
+    },
+}

--- a/asreview/webapp/_api/utils.py
+++ b/asreview/webapp/_api/utils.py
@@ -50,7 +50,13 @@ def get_dist_extensions_metadata():
                 raise TypeError(
                     f"Metadata for {e.name} is not a dictionary: {type(metadata)}"
                 )
-            all_metadata.update(metadata)
+
+            for key, value in metadata.items():
+                if key in all_metadata and isinstance(all_metadata[key], dict):
+                    all_metadata[key].update(value)
+                else:
+                    all_metadata[key] = value
+
         except Exception:
             continue
 

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardModelTraining.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardModelTraining.js
@@ -52,14 +52,14 @@ const ModelFlowChart = ({ record }) => {
     },
   );
 
-  const classifierName = data?.models?.classifier.filter(
+  const classifierName = data?.models?.classifiers.filter(
     (classifier) => classifier.name === record.state.classifier,
   )[0]?.label;
-  const featureExtractionName = data?.models?.feature_extractor.filter(
+  const featureExtractionName = data?.models?.feature_extractors.filter(
     (feature_extractor) =>
       feature_extractor.name === record.state.feature_extractor,
   )[0]?.label;
-  const queryStrategyName = data?.models?.querier.filter(
+  const queryStrategyName = data?.models?.queriers.filter(
     (querier) => querier.name === record.state.querier,
   )[0]?.label;
 

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/ModelCard.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/ModelCard.js
@@ -420,7 +420,7 @@ const ModelCard = ({ mode = null, trainNewModel = false }) => {
                           <ModelComponentSelect
                             name="querier"
                             label="Querier"
-                            items={learnerOptions?.models?.querier}
+                            items={learnerOptions?.models?.queriers}
                             value={modelConfig.current_value?.querier}
                             required={true}
                             onChange={(event) => {
@@ -437,7 +437,7 @@ const ModelCard = ({ mode = null, trainNewModel = false }) => {
                           <ModelComponentSelect
                             name="feature_extractor"
                             label="Feature extractor"
-                            items={learnerOptions?.models?.feature_extractor}
+                            items={learnerOptions?.models?.feature_extractors}
                             value={
                               modelConfig?.current_value?.feature_extractor
                             }
@@ -455,7 +455,7 @@ const ModelCard = ({ mode = null, trainNewModel = false }) => {
                           <ModelComponentSelect
                             name="classifier"
                             label="Classifier"
-                            items={learnerOptions?.models?.classifier}
+                            items={learnerOptions?.models?.classifiers}
                             value={modelConfig.current_value?.classifier}
                             onChange={(event) => {
                               mutate({
@@ -471,7 +471,7 @@ const ModelCard = ({ mode = null, trainNewModel = false }) => {
                           <ModelComponentSelect
                             name="balancer"
                             label="Balancer"
-                            items={learnerOptions?.models?.balancer}
+                            items={learnerOptions?.models?.balancers}
                             value={modelConfig.current_value?.balancer}
                             onChange={(event) => {
                               mutate({

--- a/asreview/webapp/tests/test_api/test_projects.py
+++ b/asreview/webapp/tests/test_api/test_projects.py
@@ -294,10 +294,10 @@ def test_list_learners(client, user):
     r = au.get_project_algorithms_options(client)
     assert r.status_code == 200
     expected_keys = [
-        "balancer",
-        "classifier",
-        "feature_extractor",
-        "querier",
+        "balancers",
+        "classifiers",
+        "feature_extractors",
+        "queriers",
     ]
     for key in expected_keys:
         assert key in r.json["models"].keys()

--- a/asreview/webapp/tests/test_utils.py
+++ b/asreview/webapp/tests/test_utils.py
@@ -1,4 +1,15 @@
 from asreview.webapp._api.utils import get_all_model_components
+from asreview.webapp._api.utils import get_dist_extensions_metadata
+
+
+def test_get_dist_extensions_metadata():
+    assert "balancers" in get_dist_extensions_metadata()
+    assert "classifiers" in get_dist_extensions_metadata()
+    assert "feature_extractors" in get_dist_extensions_metadata()
+    assert "queriers" in get_dist_extensions_metadata()
+
+    assert "balanced" in get_dist_extensions_metadata()["balancers"]
+    assert "label" in get_dist_extensions_metadata()["balancers"]["balanced"]
 
 
 def test_get_all_model_components():
@@ -6,13 +17,15 @@ def test_get_all_model_components():
     result = get_all_model_components()
 
     # Assert the result structure
-    assert "balancer" in result
-    assert "classifier" in result
-    assert "feature_extractor" in result
-    assert "querier" in result
+    assert "balancers" in result
+    assert "classifiers" in result
+    assert "feature_extractors" in result
+    assert "queriers" in result
 
     # Assert the mocked components are added correctly
-    assert {"name": "balanced", "label": "Balanced Sample Weight"} in result["balancer"]
-    assert len(result["classifier"]) >= 1
-    assert len(result["feature_extractor"]) >= 1
-    assert len(result["querier"]) >= 1
+    assert {"name": "balanced", "label": "Balanced Sample Weight"} in result[
+        "balancers"
+    ]
+    assert len(result["classifiers"]) >= 1
+    assert len(result["feature_extractors"]) >= 1
+    assert len(result["queriers"]) >= 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ synergy = "asreview.datasets:SynergyDataGroup"
 [project.entry-points."asreview.models"]
 _metadata = "asreview.models._metadata:MODEL_METADATA"
 
-
 [project.entry-points."asreview.models.classifiers"]
 svm = "asreview.models.classifiers:SVM"
 nb = "asreview.models.classifiers:NaiveBayes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ task-manager = "asreview.webapp._entry_points.task_manager:main"
 [project.entry-points."asreview.datasets"]
 synergy = "asreview.datasets:SynergyDataGroup"
 
+[project.entry-points."asreview.models"]
+_metadata = "asreview.models._metadata:MODEL_METADATA"
+
+
 [project.entry-points."asreview.models.classifiers"]
 svm = "asreview.models.classifiers:SVM"
 nb = "asreview.models.classifiers:NaiveBayes"


### PR DESCRIPTION
Instant regret #2188. I knew it.

This PR proposes to implement a metadata entry point for model metadata. If there is no metadata, the name of the entry point is used. See below:

<img width="789" alt="Screenshot 2025-05-07 at 13 42 21" src="https://github.com/user-attachments/assets/5f5da9e1-a581-441d-85ea-97ff8533e780" />

This PR allows you to skip the label completely. 
