### PR TITLE
auth_tool: allow adding users with non-standard origin

### DIFF
--- a/asreview/webapp/_entry_points/auth_tool.py
+++ b/asreview/webapp/_entry_points/auth_tool.py
@@ -148,6 +148,7 @@ def insert_user(session, entry):
     into the database."""
     # create a user object
     user = User(
+        entry.get("origin", "asreview").lower(),
         entry["email"].lower(),
         email=entry["email"].lower(),
         name=entry["name"],


### PR DESCRIPTION
Currently `asreview auth-tool` assumes users added using the `--json` option have `asreview` as their `origin` attribute. That means users must have a valid email and a password.

However, for remote authentication mechanisms, we might want to create users that do not meet this criteria. In particular, we may want to pre-add valid users to the database when using Remote User auth, so that valid users are already visible in the app *before* they are created when they first login.

This PR allows setting the `origin` attribute in the JSON data passed along with the `--json` option.