### PR TITLE
Fix migration for datasets with empty columns

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -2,6 +2,7 @@ from abc import ABC
 from abc import abstractmethod
 
 import pandas as pd
+import numpy as np
 
 from asreview.data.record import Record
 from asreview.data.utils import convert_to_list
@@ -63,6 +64,7 @@ class BaseReader(ABC):
     @classmethod
     def read_records(cls, fp, dataset_id, record_cls=Record, *args, **kwargs):
         df = cls.read_data(fp, *args, **kwargs)
+        df.replace([pd.NA, np.nan], cls.__fillna_default__[0], inplace=True)
         df = cls.clean_data(df)
         return cls.to_records(df, dataset_id=dataset_id, record_cls=record_cls)
 
@@ -113,7 +115,7 @@ class BaseReader(ABC):
                 for cleaning_method in cleaning_methods:
                     df[column] = df[column].apply(cleaning_method)
         if cls.__fillna_default__ is not None:
-            df = df.fillna(pd.NA).replace([pd.NA], cls.__fillna_default__)
+            df.replace([pd.NA, np.nan], cls.__fillna_default__[0], inplace=True)
         return df
 
     @classmethod

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -208,6 +208,21 @@ def test_duplicate_of(store):
     assert duplicate_record.duplicate_of is None
 
 
+def test_load_dataset_no_abstracts(tmpdir):
+    test_fp = tmpdir / "no_abstracts.csv"
+    df = pd.DataFrame(
+        {
+            "title": ["Title 1", "Title 2"],
+            "authors": ["Author A", "Author B"],
+            "abstract": [None, None],
+        }
+    )
+    df.to_csv(test_fp, index=False)
+    ds = load_dataset(test_fp, dataset_id="foo")
+
+    assert ds.get_df()["abstract"].replace("", None).isnull().all()
+
+
 @pytest.mark.parametrize(
     "file_name,n_lines",
     [


### PR DESCRIPTION
For example, the abstract column exists but is empty. 