### PR TITLE
Quickfix file type MIME type selection

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ImportProject.js
+++ b/asreview/webapp/src/ProjectComponents/ImportProject.js
@@ -70,7 +70,7 @@ const ImportProjectCard = ({ mutate, isLoading, isError, error }) => {
     multiple: false,
     noClick: true,
     accept: {
-      "application/zip": [".asreview"],
+      "application/asreview": [".asreview"],
     },
   });
 

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/DataUploadComponents/DatasetFromFile.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/DataUploadComponents/DatasetFromFile.js
@@ -83,12 +83,16 @@ const DatasetFromFile = ({ project_id, mode, setSetupProjectId }) => {
     },
   );
 
-  let acceptedFileTypes = "";
-  if (readers?.result) {
-    acceptedFileTypes = readers.result
-      .map((reader) => reader.extension)
-      .join(", ");
-  }
+  // Use showOpenFilePicker() style accept object for cross-platform compatibility
+  const acceptedFileTypes = {
+    "text/csv": [".csv"],
+    "text/tab-separated-values": [".tsv", ".tab"],
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+      ".xlsx",
+    ],
+    "application/x-research-info-systems": [".ris"],
+    "text/plain": [".ris", ".tsv", ".tab"], // fallback for some platforms
+  };
 
   const {
     getRootProps,
@@ -110,6 +114,10 @@ const DatasetFromFile = ({ project_id, mode, setSetupProjectId }) => {
     ...(isDragAccept ? acceptStyle : {}),
     ...(isDragReject ? rejectStyle : {}),
   };
+
+  const acceptedExtensions = [
+    ...new Set(Object.values(acceptedFileTypes).flat()),
+  ].join(", ");
 
   return (
     <Stack
@@ -168,7 +176,7 @@ const DatasetFromFile = ({ project_id, mode, setSetupProjectId }) => {
                   }dataset here`}
             </Typography>
             <Typography fontSize="1rem">
-              Accepted files: {acceptedFileTypes}
+              Accepted files: {acceptedExtensions}
             </Typography>
           </Stack>
         </ButtonBase>


### PR DESCRIPTION
This avoids uploading files in the wrong place (file vs import).

The downside of this method is that custom readers are no longer working cc @PeterLombaers. We need a permanent solution to that (update the readers). 
