### PR TITLE
Fix migration of projects with training errors

### DIFF
--- a/asreview/project/migrate.py
+++ b/asreview/project/migrate.py
@@ -37,6 +37,10 @@ def _project_config_converter_v1_v2(project_json):
         except KeyError:
             pass
 
+        # fix projects with training errors
+        if project_json["reviews"][i]["status"] == "error":
+            project_json["reviews"][i]["status"] = "review"
+
     return project_json
 
 

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectCard.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectCard.js
@@ -152,7 +152,8 @@ const ProjectCard = ({ project, mode, showSimulatingSpinner = true }) => {
           </ButtonBase>
         </Grid>
         {mode === projectModes.ORACLE &&
-          review?.status === projectStatuses.REVIEW &&
+          (review?.status === projectStatuses.REVIEW ||
+            review?.status === "error") &&
           largeScreen && (
             <Grid size={"auto"}>
               <Button

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectsOverview.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProjectsOverview.js
@@ -45,7 +45,8 @@ const ProjectsOverview = ({ mode }) => {
   const inReviewProjects = data?.result.filter(
     (project) =>
       project.reviews[0]?.status === projectStatuses.REVIEW ||
-      project.reviews[0]?.status === projectStatuses.SETUP,
+      project.reviews[0]?.status === projectStatuses.SETUP ||
+      project.reviews[0]?.status === "error", // backwards compatibility fix for migration file
   );
   const finishedProjects = data?.result.filter(
     (project) => project.reviews[0]?.status === projectStatuses.FINISHED,


### PR DESCRIPTION
In version 2, projects can't have the "error" status, as training the model is no longer mandatory for creating a project. In the current version, error projects are converted correctly, but not displayed. This PR addresses the issue and makes it backward compatible with versions 2.0.1 and 2.0.