### PR TITLE
Resolve IndexError for older versions of Pandas

### DIFF
--- a/asreview/webapp/_tasks.py
+++ b/asreview/webapp/_tasks.py
@@ -76,7 +76,7 @@ def run_model(project):
 
         if cycle.classifier is not None:
             cycle.fit(
-                fm[labeled["record_id"].astype(int).values],
+                fm[labeled["record_id"].values],
                 labeled["label"].values,
             )
 

--- a/asreview/webapp/_tasks.py
+++ b/asreview/webapp/_tasks.py
@@ -76,7 +76,7 @@ def run_model(project):
 
         if cycle.classifier is not None:
             cycle.fit(
-                fm[labeled["record_id"].values],
+                fm[labeled["record_id"].astype(int).values],
                 labeled["label"].values,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 license = "Apache-2.0"
 dependencies = [
     "numpy",
-    "pandas>=2,<3",
+    "pandas>=2.2,<3",
     "scikit-learn>=1.5",
     "rispy~=0.9.0",
     "flask>=2.3.0",


### PR DESCRIPTION
For older versions of Pandas, we would get an index error when trying to index an `np.ndarray` with a `pandas.core.arrays.integer.IntegerArray`. This change ensures that we always index with an `np.ndarray`.