### PR TITLE
Replace 'learn more' link in model card 

### DIFF
--- a/asreview/webapp/src/ProjectComponents/SetupComponents/ModelCard.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/ModelCard.js
@@ -822,7 +822,7 @@ const ModelCard = ({ mode = null, trainNewModel = false, editable = true }) => {
 
             <Box>
               <Button
-                href="https://asreview.readthedocs.io/en/latest/guides/activelearning.html"
+                href="https://asreview.nl/blog/asreview-model-selection-guide/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
The link now directs to [model selection guide](https://asreview.nl/blog/asreview-model-selection-guide/)