### PR TITLE
Fix socket reuse on Windows

### DIFF
--- a/asreview/webapp/_task_manager/task_manager.py
+++ b/asreview/webapp/_task_manager/task_manager.py
@@ -292,10 +292,11 @@ class TaskManager:
     def _bind_server_socket(self, mp_start_event=None):
         """Bind the server socket to the configured host and port."""
         self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             self.server_socket.bind((self.host, self.port))
         except OSError as e:
-            if e.errno in (48, 98):
+            if e.errno in (48, 98, 10048):
                 if self.server_socket:
                     self.server_socket.close()
                     self.server_socket = None


### PR DESCRIPTION
```
Make regular backups of the ASReview projects folder to prevent data loss.


Press Ctrl+C to exit.


INFO:asreview.task_manager:Starting task server on localhost:5101
ERROR:asreview.task_manager:Failed to bind socket: [WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted
Traceback (most recent call last):
  File "C:\Users\xyz\AppData\Local\Programs\Python\Python312\Lib\site-packages\asreview\webapp\_task_manager\task_manager.py", line 296, in _bind_server_socket
    self.server_socket.bind((self.host, self.port))
OSError: [WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted


Error: unable to startup the task server.
```