### PR TITLE
Add option to delete your account from the server

### DIFF
--- a/asreview/webapp/_api/admin.py
+++ b/asreview/webapp/_api/admin.py
@@ -19,8 +19,8 @@ from pathlib import Path
 from flask import Blueprint
 from flask import jsonify
 from flask import request
-from sqlalchemy import select
 from sqlalchemy import or_
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -484,8 +484,9 @@ def add_project_member(project_id):
         DB.session.commit()
 
         # Import here to avoid circular imports
-        from asreview.webapp._api.team import get_user_project_properties
         from flask_login import current_user
+
+        from asreview.webapp._api.team import get_user_project_properties
 
         user_props = get_user_project_properties(user, project, current_user)
 

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -2,6 +2,11 @@ import {
   Button,
   Checkbox,
   Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormHelperText as FHT,
   FormControl,
   FormControlLabel,
@@ -62,6 +67,8 @@ const ProfilePage = (props) => {
   const [showPasswordFields, setShowPasswordFields] = React.useState(false);
   const [searchParams] = useSearchParams();
   const showFirstTimeMessage = searchParams.get("first_time");
+  const [openDeleteDialog, setOpenDeleteDialog] = React.useState(false);
+  const [deleteError, setDeleteError] = React.useState(null);
 
   const { error, isError, mutate } = useMutation(AuthAPI.updateProfile, {
     onSuccess: (data) => {
@@ -78,6 +85,30 @@ const ProfilePage = (props) => {
       console.log(err);
     },
   });
+
+  const { mutate: deleteAccount } = useMutation(AuthAPI.deleteAccount, {
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      navigate("/signin");
+    },
+    onError: (err) => {
+      setDeleteError(err.message);
+      handleCloseDeleteDialog();
+    },
+  });
+
+  const handleClickOpenDeleteDialog = () => {
+    setDeleteError(null);
+    setOpenDeleteDialog(true);
+  };
+
+  const handleCloseDeleteDialog = () => {
+    setOpenDeleteDialog(false);
+  };
+
+  const handleDeleteAccount = () => {
+    deleteAccount();
+  };
 
   const handleSubmit = () => {
     if (formik.isValid) {
@@ -376,6 +407,50 @@ const ProfilePage = (props) => {
               Reset
             </Button>
           </Stack>
+
+          <Stack spacing={1} sx={{ mt: 4 }}>
+            <Typography variant="h6">Delete account</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Once you delete your account, there is no going back. Please be
+              certain.
+            </Typography>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={handleClickOpenDeleteDialog}
+              sx={{ width: "fit-content" }}
+            >
+              Delete your account
+            </Button>
+            {deleteError && (
+              <FHT>
+                <InlineErrorHandler message={deleteError} />
+              </FHT>
+            )}
+          </Stack>
+
+          <Dialog
+            open={openDeleteDialog}
+            onClose={handleCloseDeleteDialog}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+          >
+            <DialogTitle id="alert-dialog-title">
+              {"Delete your account?"}
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText id="alert-dialog-description">
+                Are you sure you want to delete your account? This action cannot
+                be undone.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleCloseDeleteDialog}>Cancel</Button>
+              <Button onClick={handleDeleteAccount} color="error" autoFocus>
+                Delete
+              </Button>
+            </DialogActions>
+          </Dialog>
         </>
       )}
     </Container>

--- a/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
+++ b/asreview/webapp/src/HomeComponents/DashboardComponents/ProfilePage.js
@@ -70,6 +70,10 @@ const ProfilePage = (props) => {
   const [openDeleteDialog, setOpenDeleteDialog] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState(null);
 
+  // Hide delete button for new OAuth users completing their profile
+  const shouldHideDeleteButton =
+    window.oAuthData !== "false" && showFirstTimeMessage;
+
   const { error, isError, mutate } = useMutation(AuthAPI.updateProfile, {
     onSuccess: (data) => {
       if (data.email_changed && data.user_id) {
@@ -408,26 +412,28 @@ const ProfilePage = (props) => {
             </Button>
           </Stack>
 
-          <Stack spacing={1} sx={{ mt: 4 }}>
-            <Typography variant="h6">Delete account</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Once you delete your account, there is no going back. Please be
-              certain.
-            </Typography>
-            <Button
-              variant="contained"
-              color="error"
-              onClick={handleClickOpenDeleteDialog}
-              sx={{ width: "fit-content" }}
-            >
-              Delete your account
-            </Button>
-            {deleteError && (
-              <FHT>
-                <InlineErrorHandler message={deleteError} />
-              </FHT>
-            )}
-          </Stack>
+          {!shouldHideDeleteButton && (
+            <Stack spacing={1} sx={{ mt: 4 }}>
+              <Typography variant="h6">Delete account</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Once you delete your account, there is no going back. Please be
+                certain.
+              </Typography>
+              <Button
+                variant="contained"
+                color="error"
+                onClick={handleClickOpenDeleteDialog}
+                sx={{ width: "fit-content" }}
+              >
+                Delete your account
+              </Button>
+              {deleteError && (
+                <FHT>
+                  <InlineErrorHandler message={deleteError} />
+                </FHT>
+              )}
+            </Stack>
+          )}
 
           <Dialog
             open={openDeleteDialog}

--- a/asreview/webapp/src/api/AuthAPI.js
+++ b/asreview/webapp/src/api/AuthAPI.js
@@ -148,6 +148,23 @@ class AuthAPI {
     });
   }
 
+  static deleteAccount() {
+    const url = auth_url + "delete_account";
+    return new Promise((resolve, reject) => {
+      axios({
+        method: "delete",
+        url: url,
+        withCredentials: true,
+      })
+        .then((result) => {
+          resolve(result["data"]);
+        })
+        .catch((error) => {
+          reject(axiosErrorHandler(error));
+        });
+    });
+  }
+
   static resetPassword(variables) {
     let body = new FormData();
     body.set("password", variables.password);

--- a/asreview/webapp/tests/test_api/test_auth.py
+++ b/asreview/webapp/tests/test_api/test_auth.py
@@ -658,3 +658,95 @@ def test_must_be_signed_in_to_signout(client_auth, api_call):
         r = api_call(client_auth, {})
     # asserts
     assert r.status_code == 401
+
+
+# ###################
+# DELETE ACCOUNT
+# ###################
+
+
+# Test successful account deletion
+def test_successful_delete_account(client_auth):
+    # create and signin user
+    user = au.create_and_signin_user(client_auth)
+    # delete account
+    r = au.delete_account(client_auth)
+    assert r.status_code == 200
+    assert r.json["message"] == "Account deleted successfully"
+    # verify user is deleted from database - expect NoResultFound exception
+    from sqlalchemy.exc import NoResultFound
+
+    with pytest.raises(NoResultFound):
+        crud.get_user_by_identifier(user.identifier)
+
+
+# Test cannot delete account when user owns projects
+def test_delete_account_blocked_when_owns_projects(client_auth):
+    # create and signin user
+    au.create_and_signin_user(client_auth)
+    # create a project for this user
+    r = au.create_project(
+        client_auth, mode="oracle", benchmark="synergy:van_der_Valk_2021"
+    )
+    assert r.status_code == 201
+    # try to delete account
+    r = au.delete_account(client_auth)
+    assert r.status_code == 400
+    assert "You still own projects" in r.json["message"]
+    assert "transfer ownership or delete them" in r.json["message"]
+
+
+# Test cannot delete the only admin account
+def test_delete_account_blocked_when_only_admin(client_auth):
+    # create and signin user
+    user = au.create_and_signin_user(client_auth)
+    # make user an admin
+    user.role = "admin"
+    crud.update_user(DB, user, "role", "admin")
+    # try to delete account
+    r = au.delete_account(client_auth)
+    assert r.status_code == 400
+    assert "Cannot delete the only admin account" in r.json["message"]
+    assert "create another admin account first" in r.json["message"]
+
+
+# Test admin can delete account when there are multiple admins
+def test_admin_can_delete_when_multiple_admins_exist(client_auth):
+    # create and signin first admin user
+    user1 = au.create_and_signin_user(client_auth, test_user_id=1)
+    user1.role = "admin"
+    crud.update_user(DB, user1, "role", "admin")
+    # signout first user
+    au.signout_user(client_auth)
+    # create and signin second admin user
+    user2 = au.create_and_signin_user(client_auth, test_user_id=2)
+    user2.role = "admin"
+    crud.update_user(DB, user2, "role", "admin")
+    # now first admin should be able to delete their account
+    au.signout_user(client_auth)
+    au.signin_user(client_auth, user1)
+    r = au.delete_account(client_auth)
+    assert r.status_code == 200
+    assert r.json["message"] == "Account deleted successfully"
+
+
+# Test user must be logged in to delete account
+def test_delete_account_requires_login(client_auth):
+    # try to delete account without logging in
+    r = au.delete_account(client_auth)
+    assert r.status_code == 401
+
+
+# Test delete account logs out the user
+def test_delete_account_logs_out_user(client_auth):
+    # create and signin user
+    au.create_and_signin_user(client_auth)
+    # verify user is logged in
+    r = au.user(client_auth)
+    assert r.status_code == 200
+    # delete account
+    r = au.delete_account(client_auth)
+    assert r.status_code == 200
+    # verify user is logged out
+    r = au.user(client_auth)
+    assert r.status_code == 401

--- a/asreview/webapp/tests/utils/api_utils.py
+++ b/asreview/webapp/tests/utils/api_utils.py
@@ -90,6 +90,10 @@ def get_profile(client: FlaskClient):
     return client.get("/auth/get_profile")
 
 
+def delete_account(client: FlaskClient):
+    return client.delete("/auth/delete_account")
+
+
 # ########################
 # Teams API calls
 # ########################


### PR DESCRIPTION
Add an option to delete your profile from the server. 

@cskaandorp this might also be visible during profile setup with OAuth, isn't it? What is an easy way to prevent this?

@dometto Do we need to disable this on your setup, or is it fine when they delete their account? I think that's fine, isn't it?

![localhost_3000_signup(iPad Pro)](https://github.com/user-attachments/assets/c9915e7f-7ffb-4eac-b6d5-5df0de81cbfb)
