### PR TITLE
Use email as identifier when creating users with remote user auth

### DIFF
--- a/asreview/webapp/_authentication/decorators.py
+++ b/asreview/webapp/_authentication/decorators.py
@@ -162,8 +162,10 @@ def login_remote_user(f):
                     user_info = remote_user_handler.handle_request(request.environ)
                 except HTTPException as e:
                     return jsonify({"message": e.description}), 401
+                except ValueError:
+                    user_info = None
 
-                if user_info["identifier"]:
+                if user_info:
                     user = User.query.filter(
                         User.identifier == user_info["identifier"]
                     ).one_or_none()

--- a/asreview/webapp/_authentication/remote_user_handler.py
+++ b/asreview/webapp/_authentication/remote_user_handler.py
@@ -46,6 +46,8 @@ class RemoteUserHandler:
             raise RemoteUserNotAllowed
 
         identifier = env_headers.get(self.user_identifier_header, "")
+        if len(identifier) == 0:
+            raise ValueError(f"RemoteUserHandler has insufficient data: identifier not provided.")
         identifier_parts = identifier.split("@")
         username = identifier_parts[
             0
@@ -61,7 +63,7 @@ class RemoteUserHandler:
             email = f"{username}@{self.default_email_domain}"
 
         return {
-            "identifier": identifier if identifier else None,
+            "identifier": email,
             "name": env_headers.get(self.user_name_header, username),
             "email": email,
             "affiliation": env_headers.get(

--- a/asreview/webapp/_authentication/remote_user_handler.py
+++ b/asreview/webapp/_authentication/remote_user_handler.py
@@ -48,7 +48,7 @@ class RemoteUserHandler:
         identifier = env_headers.get(self.user_identifier_header, "")
         if len(identifier) == 0:
             raise ValueError(
-                f"RemoteUserHandler has insufficient data: identifier not provided."
+                "RemoteUserHandler has insufficient data: identifier not provided."
             )
         identifier_parts = identifier.split("@")
         username = identifier_parts[

--- a/asreview/webapp/_authentication/remote_user_handler.py
+++ b/asreview/webapp/_authentication/remote_user_handler.py
@@ -47,7 +47,9 @@ class RemoteUserHandler:
 
         identifier = env_headers.get(self.user_identifier_header, "")
         if len(identifier) == 0:
-            raise ValueError(f"RemoteUserHandler has insufficient data: identifier not provided.")
+            raise ValueError(
+                f"RemoteUserHandler has insufficient data: identifier not provided."
+            )
         identifier_parts = identifier.split("@")
         username = identifier_parts[
             0

--- a/asreview/webapp/tests/test_api/test_remote_auth.py
+++ b/asreview/webapp/tests/test_api/test_remote_auth.py
@@ -12,7 +12,7 @@ from asreview.webapp.tests.utils.misc import custom_remote_auth_headers
 @pytest.mark.parametrize("uri", ["/", "/signup"])
 def test_no_login_without_header(client_remote_auth, uri):
     custom_headers = custom_remote_auth_headers(
-        identifier=""
+        remote_user=""
     )  # setup the REMOTE_AUTH_SECRET header
     r = client_remote_auth.get(uri, **custom_headers)
     assert r.status_code == 302
@@ -20,7 +20,7 @@ def test_no_login_without_header(client_remote_auth, uri):
 
 
 def test_no_login_without_secret(client_remote_auth, uri="/"):
-    custom_headers = custom_remote_auth_headers(identifier="foo", secret=None)
+    custom_headers = custom_remote_auth_headers(remote_user="foo", secret=None)
 
     response = client_remote_auth.get(uri, follow_redirects=True, **custom_headers)
     assert "REMOTE_AUTH_SECRET did not match" in response.get_json()["message"]
@@ -34,8 +34,8 @@ def test_no_login_without_secret(client_remote_auth, uri="/"):
 
 @pytest.mark.parametrize("uri", ["/", "/signup"])
 def test_login_with_header(client_remote_auth, uri):
-    user_identifier = "foo"
-    custom_headers = custom_remote_auth_headers(identifier=user_identifier)
+    user_identifier = "foo@dev.bar"
+    custom_headers = custom_remote_auth_headers(remote_user=user_identifier)
 
     def get_uri(path):
         return client_remote_auth.get(uri, follow_redirects=True, **custom_headers)
@@ -69,7 +69,7 @@ def test_api_returns_401_without_header(client_remote_auth):
 
 
 def test_api_returns_user_with_header(client_remote_auth):
-    custom_headers = custom_remote_auth_headers(identifier="foo@dev.bar")
+    custom_headers = custom_remote_auth_headers(remote_user="foo@dev.bar")
 
     r = client_remote_auth.get("/auth/user", **custom_headers)
     user_info = r.get_json()

--- a/asreview/webapp/tests/utils/misc.py
+++ b/asreview/webapp/tests/utils/misc.py
@@ -12,7 +12,7 @@ from asreview.webapp.utils import asreview_path
 
 
 def custom_remote_auth_headers(
-    identifier="foo",
+    remote_user="foo",
     affiliation="UU",
     email="foo@dev.bar",
     name="Foo Bar",
@@ -20,7 +20,7 @@ def custom_remote_auth_headers(
 ):
     return {
         "environ_base": {
-            "REMOTE_USER": identifier,
+            "REMOTE_USER": remote_user,
             "REMOTE_USER_EMAIL": email,
             "REMOTE_USER_AFFILIATION": affiliation,
             "REMOTE_AUTH_SECRET": secret,


### PR DESCRIPTION
I ran into a bug when using `asreview auth-tool` to periodically add users to ASReview on ResearchCloud:

1. When users are created with auth-tool, `email` (not `username`) is used as the user's identifier
2. But the remote user auth mechanism now checks for the pre-existence of a user using `username` as an identifier

So after user `foo` is created with auth-tool, and when logging in `foo` for the first time (using remote auth):

1. ASReview checks to see if there is already a user with identifier `foo` (no, because auth-tool created a user with identifier `foo@localhost`)
2. ASReview attempts to create a new user with username `foo` and identifier `foo`. This fails, because a user with those attributes already exists.

To make things more robust, this PR changes the user creation mechanism for remote user auth to use `email` as an identifier. I think this is preferred anyway, looking at other authentication implementations?