### PR TITLE
Introduce Full-Text View Popup - PR 1

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -1,4 +1,8 @@
-import { Link as LinkIcon } from "@mui/icons-material";
+import {
+  Link as LinkIcon,
+  Close as CloseIcon,
+  Visibility as VisibilityIcon,
+} from "@mui/icons-material";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
@@ -6,11 +10,16 @@ import {
   Button,
   Card,
   CardContent,
+  CircularProgress,
   Collapse,
+  Dialog,
   Divider,
   Fade,
   Grid2 as Grid,
+  IconButton,
+  Link,
   Stack,
+  TextField,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -18,142 +27,295 @@ import React from "react";
 
 import { StyledIconButton } from "StyledComponents/StyledButton";
 import { useToggle } from "hooks/useToggle";
-import { DOIIcon } from "icons";
 import { RecordCardLabeler, RecordCardModelTraining } from ".";
 
 import { fontSizeOptions } from "globals.js";
 
-const RecordCardContent = ({ record, fontSize, collapseAbstract }) => {
+const RecordCardContent = ({
+  record,
+  fontSize,
+  collapseAbstract,
+  labelerProps,
+}) => {
   const [readMoreOpen, toggleReadMore] = useToggle();
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [iframeLoading, setIframeLoading] = React.useState(true);
+
+  const handleOpenDialog = () => {
+    setIframeLoading(true);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+  };
+
+  const getDoiUrl = (doi) => {
+    if (!doi) return "";
+    try {
+      new URL(doi);
+      return doi;
+    } catch {
+      return `https://doi.org/${doi}`;
+    }
+  };
+
+  const doiUrl = getDoiUrl(record.doi);
 
   return (
-    <CardContent aria-label="record title abstract" sx={{ m: 1 }}>
-      <Stack spacing={2}>
-        {/* Show the title */}
-        <Typography
-          variant={"h5"}
-          sx={(theme) => ({
-            fontWeight: theme.typography.fontWeightMedium,
-            lineHeight: 1.4,
-          })}
-        >
-          {/* No title, inplace text */}
-          {(record.title === "" || record.title === null) && (
-            <Box
-              className={"fontSize" + fontSizeOptions[fontSize]}
-              fontStyle="italic"
-            >
-              No title available
-            </Box>
-          )}
-
-          {!(record.title === "" || record.title === null) && (
-            <Box className={"fontSize" + fontSizeOptions[fontSize]}>
-              {record.title}
-            </Box>
-          )}
-        </Typography>
-        <Divider />
-        <Stack direction="row" spacing={1}>
-          {!(record.doi === undefined || record.doi === null) && (
-            <Tooltip title="Open DOI">
-              <StyledIconButton
-                className="record-card-icon"
-                href={"https://doi.org/" + record.doi}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <DOIIcon />
-              </StyledIconButton>
-            </Tooltip>
-          )}
-
-          {!(record.url === undefined || record.url === null) && (
-            <Tooltip title="Open URL">
-              <StyledIconButton
-                className="record-card-icon"
-                href={record.url}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <LinkIcon />
-              </StyledIconButton>
-            </Tooltip>
-          )}
-        </Stack>
-        <Box>
-          {(record.abstract === "" || record.abstract === null) && (
-            <Typography
-              className={"fontSize" + fontSize}
-              variant="body1"
-              sx={{
-                fontStyle: "italic",
-                textAlign: "justify",
-              }}
-            >
-              No abstract available
-            </Typography>
-          )}
-
+    <React.Fragment>
+      <CardContent aria-label="record title abstract" sx={{ m: 1 }}>
+        <Stack spacing={2}>
+          {/* Show the title */}
           <Typography
-            className={"fontSize" + fontSizeOptions[fontSize]}
-            variant="body1"
-            sx={{
-              whiteSpace: "pre-line",
-              textAlign: "justify",
-              hyphens: "auto",
-              lineHeight: 1.6,
-            }}
+            variant={"h5"}
+            sx={(theme) => ({
+              fontWeight: theme.typography.fontWeightMedium,
+              lineHeight: 1.4,
+            })}
           >
-            {!(record.abstract === "" || record.abstract === null) &&
-            collapseAbstract &&
-            record.abstract.length > 500 ? (
-              <>
-                {!readMoreOpen ? (
-                  <>
-                    {record.abstract.substring(0, 500)}...
-                    <Button
-                      onClick={toggleReadMore}
-                      startIcon={<ExpandMoreIcon />}
-                      color="primary"
-                      sx={{ textTransform: "none" }}
-                    >
-                      show more
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    {record.abstract}
-                    <Button
-                      onClick={toggleReadMore}
-                      startIcon={<ExpandLessIcon />}
-                      color="primary"
-                      sx={{ textTransform: "none" }}
-                    >
-                      show less
-                    </Button>
-                  </>
-                )}
-              </>
-            ) : (
-              record.abstract
+            {/* No title, inplace text */}
+            {(record.title === "" || record.title === null) && (
+              <Box
+                className={"fontSize" + fontSizeOptions[fontSize]}
+                fontStyle="italic"
+              >
+                No title available
+              </Box>
+            )}
+
+            {!(record.title === "" || record.title === null) && (
+              <Box className={"fontSize" + fontSizeOptions[fontSize]}>
+                {record.title}
+              </Box>
             )}
           </Typography>
-        </Box>
-        {record.keywords && (
-          <Box sx={{ pt: 1 }}>
-            <Typography sx={{ color: "text.secondary", fontWeight: "bold" }}>
-              {record.keywords.map((keyword, index) => (
-                <span key={index}>
-                  {index > 0 && " • "}
-                  {keyword}
-                </span>
-              ))}
+          <Divider />
+          <Stack direction="row" spacing={1}>
+            {!(record.doi === undefined || record.doi === null) && (
+              <Tooltip title="View content">
+                <StyledIconButton
+                  className="record-card-icon"
+                  onClick={handleOpenDialog}
+                >
+                  <VisibilityIcon />
+                </StyledIconButton>
+              </Tooltip>
+            )}
+
+            {!(record.url === undefined || record.url === null) && (
+              <Tooltip title="Open URL">
+                <StyledIconButton
+                  className="record-card-icon"
+                  href={record.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <LinkIcon />
+                </StyledIconButton>
+              </Tooltip>
+            )}
+          </Stack>
+          <Box>
+            {(record.abstract === "" || record.abstract === null) && (
+              <Typography
+                className={"fontSize" + fontSize}
+                variant="body1"
+                sx={{
+                  fontStyle: "italic",
+                  textAlign: "justify",
+                }}
+              >
+                No abstract available
+              </Typography>
+            )}
+
+            <Typography
+              className={"fontSize" + fontSizeOptions[fontSize]}
+              variant="body1"
+              sx={{
+                whiteSpace: "pre-line",
+                textAlign: "justify",
+                hyphens: "auto",
+                lineHeight: 1.6,
+              }}
+            >
+              {!(record.abstract === "" || record.abstract === null) &&
+              collapseAbstract &&
+              record.abstract.length > 500 ? (
+                <>
+                  {!readMoreOpen ? (
+                    <>
+                      {record.abstract.substring(0, 500)}...
+                      <Button
+                        onClick={toggleReadMore}
+                        startIcon={<ExpandMoreIcon />}
+                        color="primary"
+                        sx={{ textTransform: "none" }}
+                      >
+                        show more
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {record.abstract}
+                      <Button
+                        onClick={toggleReadMore}
+                        startIcon={<ExpandLessIcon />}
+                        color="primary"
+                        sx={{ textTransform: "none" }}
+                      >
+                        show less
+                      </Button>
+                    </>
+                  )}
+                </>
+              ) : (
+                record.abstract
+              )}
             </Typography>
           </Box>
-        )}
-      </Stack>
-    </CardContent>
+          {record.keywords && (
+            <Box sx={{ pt: 1 }}>
+              <Typography sx={{ color: "text.secondary", fontWeight: "bold" }}>
+                {record.keywords.map((keyword, index) => (
+                  <span key={index}>
+                    {index > 0 && " • "}
+                    {keyword}
+                  </span>
+                ))}
+              </Typography>
+            </Box>
+          )}
+        </Stack>
+      </CardContent>
+      <Dialog
+        onClose={handleCloseDialog}
+        open={dialogOpen}
+        fullWidth
+        maxWidth={false}
+        PaperProps={{
+          sx: {
+            height: "95vh",
+            width: "95vw",
+            display: "flex",
+            flexDirection: "column",
+            bgcolor: "#fff",
+          },
+        }}
+      >
+        <Box sx={{ flexGrow: 1, display: "flex", overflow: "hidden" }}>
+          <Box
+            sx={{
+              flexGrow: 1,
+              height: "100%",
+              overflow: "hidden",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <Box
+              sx={{
+                p: 1,
+                borderBottom: 1,
+                borderColor: "divider",
+                bgcolor: "#fff",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <IconButton
+                  aria-label="close"
+                  onClick={handleCloseDialog}
+                  size="small"
+                >
+                  <CloseIcon />
+                </IconButton>
+                <TextField
+                  fullWidth
+                  variant="outlined"
+                  size="small"
+                  value={doiUrl}
+                  InputProps={{
+                    readOnly: true,
+                  }}
+                  sx={{
+                    "& .MuiOutlinedInput-root": {
+                      borderRadius: "20px",
+                      color: "black",
+                      "& .MuiOutlinedInput-notchedOutline": {
+                        borderColor: "black",
+                      },
+                    },
+                  }}
+                />
+              </Box>
+              <Typography
+                variant="body2"
+                sx={{ textAlign: "center", color: "text.secondary", pt: 1 }}
+              >
+                Trouble loading?{" "}
+                <Link
+                  href={doiUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="always"
+                  sx={{ color: "text.secondary" }}
+                >
+                  Open in a new tab
+                </Link>
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                position: "relative",
+                flexGrow: 1,
+                overflow: "hidden",
+                bgcolor: "#fff",
+              }}
+            >
+              {iframeLoading && (
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              )}
+              <iframe
+                onLoad={() => setIframeLoading(false)}
+                src={doiUrl}
+                title={record.title}
+                width="100%"
+                height="100%"
+                style={{
+                  border: 0,
+                  visibility: iframeLoading ? "hidden" : "visible",
+                }}
+              />
+            </Box>
+          </Box>
+
+          <Box
+            sx={(theme) => ({
+              width: 400,
+              height: "100%",
+              overflowY: "auto",
+              bgcolor: theme.palette.background.paper,
+            })}
+          >
+            <RecordCardLabeler {...labelerProps} compact />
+          </Box>
+        </Box>
+      </Dialog>
+    </React.Fragment>
   );
 };
 
@@ -174,6 +336,62 @@ const RecordCard = ({
   changeDecision = true,
 }) => {
   const [open, setOpen] = React.useState(true);
+
+  const [tags, setTags] = React.useState(null);
+
+  React.useEffect(() => {
+    let stateData = record.state?.tags
+      ? structuredClone(record.state.tags)
+      : structuredClone(record.tags_form);
+
+    // Reconciles the record's saved tags with current project settings to prevent crashes.
+    if (record.tags_form) {
+      record.tags_form.forEach((formGroup) => {
+        let stateGroup = stateData.find((g) => g.id === formGroup.id);
+        if (!stateGroup) {
+          stateData.push(structuredClone(formGroup));
+        } else {
+          formGroup.values.forEach((formValue) => {
+            let stateValue = stateGroup.values.find(
+              (v) => v.id === formValue.id,
+            );
+            if (!stateValue) {
+              stateGroup.values.push(structuredClone(formValue));
+            }
+          });
+        }
+      });
+    }
+
+    setTags(stateData);
+  }, [record.record_id, record.tags_form, record.state?.tags]);
+
+  const handleTagsChange = (newTags) => {
+    setTags(newTags);
+  };
+
+  if (!tags && record.tags_form) {
+    return null;
+  }
+
+  const labelerProps = {
+    project_id: project_id,
+    record_id: record.record_id,
+    label: record.state?.label,
+    labelFromDataset: record.included,
+    onDecisionClose: transitionType ? () => setOpen(false) : afterDecision,
+    retrainAfterDecision: retrainAfterDecision,
+    note: record.state?.note,
+    labelTime: record.state?.time,
+    user: record.state?.user,
+    showNotes: showNotes,
+    tagsForm: record.tags_form,
+    tagValues: tags,
+    onTagChange: handleTagsChange,
+    landscape: landscape,
+    hotkeys: hotkeys,
+    changeDecision: changeDecision,
+  };
 
   const styledRepoCard = (
     <Box>
@@ -201,36 +419,11 @@ const RecordCard = ({
               record={record}
               fontSize={fontSize}
               collapseAbstract={collapseAbstract}
+              labelerProps={labelerProps}
             />
           </Grid>
           <Grid size={landscape ? 2 : 5}>
-            <RecordCardLabeler
-              key={
-                "record-card-labeler-" +
-                project_id +
-                "-" +
-                record?.record_id +
-                "-" +
-                record?.state?.note
-              }
-              project_id={project_id}
-              record_id={record.record_id}
-              label={record.state?.label}
-              labelFromDataset={record.included}
-              onDecisionClose={
-                transitionType ? () => setOpen(false) : afterDecision
-              }
-              retrainAfterDecision={retrainAfterDecision}
-              note={record.state?.note}
-              labelTime={record.state?.time}
-              user={record.state?.user}
-              showNotes={showNotes}
-              tagsForm={record.tags_form}
-              tagValues={record.state?.tags}
-              landscape={landscape}
-              hotkeys={hotkeys}
-              changeDecision={changeDecision}
-            />
+            <RecordCardLabeler {...labelerProps} />
           </Grid>
         </Grid>
       </Card>

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
@@ -132,7 +132,8 @@ const RecordCardLabeler = ({
   label,
   labelFromDataset = null,
   tagsForm,
-  tagValues = null,
+  tagValues,
+  onTagChange,
   note = null,
   showNotes = true,
   labelTime = null,
@@ -142,12 +143,10 @@ const RecordCardLabeler = ({
   landscape = false,
   retrainAfterDecision = true,
   changeDecision = true,
+  compact = false,
 }) => {
   const [editState] = useToggle(!(label === 1 || label === 0));
   const [showNotesDialog, toggleShowNotesDialog] = useToggle(false);
-  const [tagValuesState, setTagValuesState] = React.useState(
-    tagValues ? tagValues : structuredClone(tagsForm),
-  );
 
   const { error, isError, isLoading, mutate, isSuccess } = useMutation(
     ProjectAPI.mutateClassification,
@@ -161,15 +160,15 @@ const RecordCardLabeler = ({
   );
 
   const handleTagValueChange = (isChecked, groupId, tagId) => {
-    let groupI = tagValuesState.findIndex((group) => group.id === groupId);
-    let tagI = tagValuesState[groupI].values.findIndex(
-      (tag) => tag.id === tagId,
-    );
+    if (!onTagChange) return;
 
-    let tagValuesCopy = structuredClone(tagValuesState);
+    let groupI = tagValues.findIndex((group) => group.id === groupId);
+    let tagI = tagValues[groupI].values.findIndex((tag) => tag.id === tagId);
+
+    let tagValuesCopy = structuredClone(tagValues);
     tagValuesCopy[groupI].values[tagI]["checked"] = isChecked;
 
-    setTagValuesState(tagValuesCopy);
+    onTagChange(tagValuesCopy);
   };
 
   const makeDecision = (label) => {
@@ -177,7 +176,7 @@ const RecordCardLabeler = ({
       project_id: project_id,
       record_id: record_id,
       label: label,
-      tagValues: tagValuesState,
+      tagValues: tagValues,
       retrain_model: retrainAfterDecision,
       post: editState,
     });
@@ -236,7 +235,7 @@ const RecordCardLabeler = ({
                             control={
                               <Checkbox
                                 checked={
-                                  tagValuesState[i]?.values[j]?.checked || false
+                                  tagValues?.[i]?.values[j]?.checked || false
                                 }
                                 onChange={(e) => {
                                   handleTagValueChange(
@@ -265,7 +264,7 @@ const RecordCardLabeler = ({
         )}
       </Box>
       <Box>
-        {(note !== null || labelFromDataset !== null) && (
+        {(note !== null || (labelFromDataset !== null && !compact)) && (
           <>
             <Divider />
             <CardContent>
@@ -285,7 +284,7 @@ const RecordCardLabeler = ({
                   <Typography sx={{ mt: 1 }}>{note}</Typography>
                 </Paper>
               )}
-              {labelFromDataset === 0 && (
+              {labelFromDataset === 0 && !compact && (
                 <Paper
                   elevation={0}
                   sx={{
@@ -302,7 +301,7 @@ const RecordCardLabeler = ({
                   </Typography>
                 </Paper>
               )}
-              {labelFromDataset === 1 && (
+              {labelFromDataset === 1 && !compact && (
                 <Paper
                   elevation={0}
                   sx={{
@@ -340,7 +339,7 @@ const RecordCardLabeler = ({
                   : null,
           })}
         >
-          {editState && (
+          {editState && !compact && (
             <>
               <Tooltip
                 title="Label as relevant (keyboard shortcut: R)"
@@ -383,7 +382,7 @@ const RecordCardLabeler = ({
               </Tooltip>
             </>
           )}
-          {(label === 1 || label === 0) && (
+          {(label === 1 || label === 0) && !compact && (
             <>
               {!landscape && (
                 <Typography


### PR DESCRIPTION
### Description

This PR introduces a **Full-Text View Popup** on the review screen to streamline the extraction workflow. It allows users to view a record's source content side-by-side with the labeling interface, eliminating the need to switch browser tabs.

Clicking the new "View content" icon on a record card opens a dialog containing an `iframe` that loads the record's source.

### Changes

*   **Adds a Full-Text Dialog**: A large dialog that houses the `iframe` and a compact version of the labeling component.
*   **Fallback Link**: A "Trouble loading? Open in a new tab" link is provided as a fallback.
*   **State Refactoring**: Lifted `tags` state from `RecordCardLabeler` to `RecordCard` to account for tagging in the browser mode.

### Limitations

*   **`iframe` Restrictions**: Many websites (especially academic publishers) use `X-Frame-Options` or other security policies that block them from being embedded in an `iframe`. These sites will appear as blank pages. The "Open in a new tab" link is the designed workaround for this limitation for now.
*   **Authentication**: Institutional logins within the `iframe` will likely fail due to third-party cookie restrictions in modern browsers.

### Future Work

* Aim to open the PDF directly instead of directing the user to the website. An OpenAlex implementation will be tested.
* Full-text labeling might need a slightly different user journey. It can be as simple as a tag titled 'Ful-text label', or something else. Should be discussed after implementing the functionality.