### PR TITLE
Feat (admin): added origin field in UserCard

### DIFF
--- a/asreview/webapp/src/AdminComponents/UserFormDialog.js
+++ b/asreview/webapp/src/AdminComponents/UserFormDialog.js
@@ -203,7 +203,7 @@ const UserFormDialog = ({
           {/* Show origin field in edit mode only (read-only) */}
           {isEditMode && (
             <TextField
-              label="Origin (authentication source, cannot be changed)"
+              label="Authentication source (read only)"
               value={detailedUser?.user?.origin || user?.origin || ""}
               fullWidth
               slotProps={{


### PR DESCRIPTION
Admin needs to see what the origin of the account is (OAuth: Github, Google, Orcid), or standard "asreview". This field is non-editable.