### PR TITLE
Fix invitation token parsing bug with binary HMAC signatures

### DIFF
--- a/asreview/webapp/_api/team.py
+++ b/asreview/webapp/_api/team.py
@@ -36,14 +36,24 @@ def validate_invitation_token(encoded_token):
         # Decode the base64-encoded token
         decoded = base64.urlsafe_b64decode(encoded_token.encode("utf-8"))
 
-        # Split payload and signature
-        if b"." not in decoded:
+        # Split payload and signature based on position
+        # SHA256 signature is always 32 bytes at the end, preceded by a 1-byte separator
+        if len(decoded) < 34:  # At least 1 byte payload + separator + 32 byte signature
             return None, (
                 jsonify({"message": "Token is not valid."}),
                 400,
             )
 
-        payload_bytes, signature = decoded.rsplit(b".", 1)
+        signature = decoded[-32:]
+        separator = decoded[-33:-32]
+        payload_bytes = decoded[:-33]
+
+        # Verify separator is a dot
+        if separator != b".":
+            return None, (
+                jsonify({"message": "Token is not valid."}),
+                400,
+            )
 
         # Verify HMAC signature
         secret_key = current_app.config.get("SECRET_KEY", "").encode("utf-8")

--- a/asreview/webapp/tests/test_api/test_projects.py
+++ b/asreview/webapp/tests/test_api/test_projects.py
@@ -662,9 +662,14 @@ def test_generate_invitation_link(client_auth, project):
     # Decode the base64 encoded token
     decoded_bytes = base64.urlsafe_b64decode(encoded_token.encode("utf-8"))
 
-    # Split payload and signature (separated by b".")
-    assert b"." in decoded_bytes
-    payload_bytes, signature = decoded_bytes.rsplit(b".", 1)
+    # Split payload and signature based on position
+    # SHA256 signature is always 32 bytes at the end, preceded by a 1-byte separator
+    signature = decoded_bytes[-32:]
+    separator = decoded_bytes[-33:-32]
+    payload_bytes = decoded_bytes[:-33]
+
+    # Verify separator is a dot
+    assert separator == b"."
 
     # Decode payload to string
     payload = payload_bytes.decode("utf-8")


### PR DESCRIPTION
Fixes a critical bug where invitation tokens could be randomly rejected if the binary HMAC signature contained a randomly generated dot byte (0x2E). The previous implementation used rsplit(b".", 1) which could split at the wrong position within the signature instead of at the separator. Now splits based on known positions since SHA256 signatures are always 32 bytes.