### PR TITLE
Hardened the admin UI and made project import retry-safe.

### DIFF
--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -22,6 +22,7 @@ import secrets
 import shutil
 import socket
 import tempfile
+import threading
 import time
 import zipfile
 from dataclasses import asdict
@@ -859,6 +860,41 @@ def api_update_review_status(project):
     return jsonify({"status": status}), 201
 
 
+# In-memory idempotency cache for project imports.
+# Maps (user_id, idempotency_key) -> (response_dict, unix_timestamp).
+# Lets a client safely retry an import (e.g. after an nginx timeout) without
+# creating a duplicate project: same key + same user within the TTL returns
+# the original response.
+_IMPORT_IDEMPOTENCY_TTL_SECONDS = 3600
+_import_idempotency_cache = {}
+_import_idempotency_lock = threading.Lock()
+
+
+def _get_cached_import(user_id, key):
+    if not key:
+        return None
+    with _import_idempotency_lock:
+        entry = _import_idempotency_cache.get((user_id, key))
+        if entry is None:
+            return None
+        response, ts = entry
+        if time.time() - ts > _IMPORT_IDEMPOTENCY_TTL_SECONDS:
+            del _import_idempotency_cache[(user_id, key)]
+            return None
+        return response
+
+
+def _set_cached_import(user_id, key, response):
+    if not key:
+        return
+    with _import_idempotency_lock:
+        _import_idempotency_cache[(user_id, key)] = (response, time.time())
+        cutoff = time.time() - _IMPORT_IDEMPOTENCY_TTL_SECONDS
+        expired = [k for k, (_, ts) in _import_idempotency_cache.items() if ts < cutoff]
+        for k in expired:
+            del _import_idempotency_cache[k]
+
+
 @bp.route("/projects/import", methods=["POST"])
 @login_required
 def api_import_project():
@@ -869,6 +905,14 @@ def api_import_project():
     # raise error if file not given
     if "file" not in request.files:
         return jsonify(message="No ASReview file found to import."), 400
+
+    authenticated = current_app.config.get("AUTHENTICATION", True)
+    user_id = current_user.id if authenticated else None
+    idempotency_key = request.headers.get("Idempotency-Key")
+
+    cached_response = _get_cached_import(user_id, idempotency_key)
+    if cached_response is not None:
+        return jsonify(cached_response)
 
     with zipfile.ZipFile(request.files["file"], "r") as zip_obj:
         try:
@@ -893,28 +937,39 @@ def api_import_project():
         logging.exception(err)
         raise ValueError("Failed to import project.") from err
 
+    # Project.load has already written the new project directory to disk.
+    # If anything below fails (model check, DB commit, ...) we must remove
+    # that directory, otherwise we leak an orphan project on every failure.
     try:
-        ActiveLearningCycle.from_meta(
-            ActiveLearningCycleData(**project.get_model_config())
-        )
-    except ValueError as err:
-        model = get_ai_config()
-        project.update_review(model_name=model["name"], model=model["value"])
-        warnings.append(
-            str(err) + " It might be removed from this version of ASReview LAB or you "
-            "need to install an extension to use this model component."
-        )
-        warnings.append(
-            "The active learning model has been reset to the default model and"
-            " can be changed in the project settings."
-        )
+        try:
+            ActiveLearningCycle.from_meta(
+                ActiveLearningCycleData(**project.get_model_config())
+            )
+        except ValueError as err:
+            model = get_ai_config()
+            project.update_review(model_name=model["name"], model=model["value"])
+            warnings.append(
+                str(err) + " It might be removed from this version of ASReview LAB or you "
+                "need to install an extension to use this model component."
+            )
+            warnings.append(
+                "The active learning model has been reset to the default model and"
+                " can be changed in the project settings."
+            )
 
-    if current_app.config.get("AUTHENTICATION", True):
-        current_user.projects.append(Project(project_id=project.config.get("id")))
-        DB.session.commit()
+        if authenticated:
+            current_user.projects.append(Project(project_id=project.config.get("id")))
+            DB.session.commit()
+    except Exception:
+        if authenticated:
+            DB.session.rollback()
+        shutil.rmtree(project.project_path, ignore_errors=True)
+        raise
 
     project.config["roles"] = {"owner": True}
-    return jsonify({"data": project.config, "warnings": warnings})
+    response = {"data": project.config, "warnings": warnings}
+    _set_cached_import(user_id, idempotency_key, response)
+    return jsonify(response)
 
 
 @bp.route("/projects/<project_id>/tags", methods=["GET"])

--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -949,7 +949,8 @@ def api_import_project():
             model = get_ai_config()
             project.update_review(model_name=model["name"], model=model["value"])
             warnings.append(
-                str(err) + " It might be removed from this version of ASReview LAB or you "
+                str(err)
+                + " It might be removed from this version of ASReview LAB or you "
                 "need to install an extension to use this model component."
             )
             warnings.append(

--- a/asreview/webapp/src/AdminComponents/UserFormDialog.js
+++ b/asreview/webapp/src/AdminComponents/UserFormDialog.js
@@ -231,6 +231,8 @@ const UserFormDialog = ({
           <TextField
             label="Email"
             type="email"
+            name="new-user-email"
+            autoComplete="off"
             value={formData.email}
             onChange={handleChange("email")}
             error={!!errors.email}
@@ -241,6 +243,8 @@ const UserFormDialog = ({
 
           <TextField
             label="Name"
+            name="new-user-name"
+            autoComplete="off"
             value={formData.name}
             onChange={handleChange("name")}
             error={!!errors.name}
@@ -251,6 +255,8 @@ const UserFormDialog = ({
 
           <TextField
             label="Affiliation"
+            name="new-user-affiliation"
+            autoComplete="off"
             value={formData.affiliation}
             onChange={handleChange("affiliation")}
             fullWidth
@@ -261,6 +267,8 @@ const UserFormDialog = ({
             <TextField
               label={isEditMode ? "New Password (optional)" : "Password"}
               type={showPassword ? "text" : "password"}
+              name="new-user-password"
+              autoComplete="new-password"
               value={formData.password}
               onChange={handleChange("password")}
               error={!!errors.password}

--- a/asreview/webapp/src/AdminComponents/UserListItem.js
+++ b/asreview/webapp/src/AdminComponents/UserListItem.js
@@ -90,7 +90,10 @@ const UserListItem = ({
           <IconButton
             size="small"
             color="error"
-            onClick={() => onDelete?.(user)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete?.(user);
+            }}
             disabled={disableDelete}
             sx={{ ml: 1 }}
           >

--- a/asreview/webapp/src/AdminComponents/UsersComponent.js
+++ b/asreview/webapp/src/AdminComponents/UsersComponent.js
@@ -463,6 +463,9 @@ const UsersComponent = () => {
           placeholder="Search users by name, email, identifier, affiliation, or origin (min 3 characters)"
           value={searchTerm}
           onChange={handleSearchChange}
+          name="user-search"
+          type="search"
+          autoComplete="off"
           fullWidth
           variant="outlined"
           size="small"

--- a/asreview/webapp/src/ProjectComponents/TeamComponents/InvitationLink.js
+++ b/asreview/webapp/src/ProjectComponents/TeamComponents/InvitationLink.js
@@ -112,6 +112,7 @@ const InvitationLink = ({ project_id, variant = "card" }) => {
           startIcon={isLoading ? <CircularProgress size={20} /> : <LinkIcon />}
           onClick={() => generateLink()}
           disabled={isLoading}
+          sx={{ alignSelf: "flex-start" }}
         >
           {isLoading ? "Generating..." : "Generate Invitation Link"}
         </Button>
@@ -149,32 +150,38 @@ const InvitationLink = ({ project_id, variant = "card" }) => {
           >
             <QRCode value={invitationLink} size={300} />
           </Box>
-          <Button
-            variant="contained"
-            startIcon={<Download />}
-            onClick={handleDownloadQR}
-            fullWidth
+          <Stack
+            direction="row"
+            spacing={1}
+            flexWrap="wrap"
+            useFlexGap
+            justifyContent="center"
           >
-            Download QR Code
-          </Button>
-          <Stack direction="row" spacing={1}>
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<Download />}
+              onClick={handleDownloadQR}
+            >
+              Download QR Code
+            </Button>
             <Button
               variant="outlined"
+              size="small"
               startIcon={<LinkIcon />}
               onClick={() => generateLink()}
-              fullWidth
             >
               Regenerate Link
             </Button>
             <Button
               variant="outlined"
+              size="small"
               color="error"
               startIcon={
                 isRevoking ? <CircularProgress size={20} /> : <LinkOff />
               }
               onClick={() => revokeLink()}
               disabled={isRevoking}
-              fullWidth
             >
               {isRevoking ? "Revoking..." : "Revoke Link"}
             </Button>

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -424,11 +424,20 @@ class ProjectAPI {
     let body = new FormData();
     body.append("file", variables.file);
 
+    // Stable per-file key so a retry of the same file (e.g. after an nginx
+    // timeout) is recognised by the server as the same import and returns
+    // the original project instead of creating a duplicate.
+    const file = variables.file;
+    const idempotencyKey = `import:${file.name}:${file.size}:${file.lastModified}`;
+
     const config = {
       method: "post",
       url: api_url + `projects/import`,
       data: body,
       withCredentials: true,
+      headers: {
+        "Idempotency-Key": idempotencyKey,
+      },
     };
 
     // Add upload progress callback if provided

--- a/asreview/webapp/tests/test_api/test_projects.py
+++ b/asreview/webapp/tests/test_api/test_projects.py
@@ -181,6 +181,109 @@ def test_import_project_files(client, user, project, fp):
     assert r.json["data"]["id"] in set([f.stem for f in folders])
 
 
+# Two imports of the same file with the same Idempotency-Key must produce
+# only one project on disk + DB; the second response must echo the first.
+# This guards against duplicate projects when a client retries an upload
+# after an upstream timeout (e.g. nginx).
+def test_import_project_idempotency(client, user, project, request):
+    fp = Path(
+        "asreview",
+        "webapp",
+        "tests",
+        "asreview-project-file-archive",
+        "v1.5",
+        "asreview-project-v1-5-startreview.asreview",
+    )
+    key = f"test-{request.node.name}"
+
+    r1 = au.import_project(client, fp, idempotency_key=key)
+    assert r1.status_code == 200
+    first_id = r1.json["data"]["id"]
+
+    r2 = au.import_project(client, fp, idempotency_key=key)
+    assert r2.status_code == 200
+    # Same project id returned -> server short-circuited via the cache.
+    assert r2.json["data"]["id"] == first_id
+    assert r2.json == r1.json
+
+    # Only one new on-disk project (plus the fixture's project = 2 total).
+    folders = set(misc.get_folders_in_asreview_path())
+    assert len(folders) == 2
+    assert first_id in {f.stem for f in folders}
+
+    if client.application.config.get("AUTHENTICATION"):
+        # And exactly one new DB row (fixture project + the imported one).
+        assert crud.count_projects() == 2
+
+
+# Without the Idempotency-Key header the cache is bypassed entirely:
+# repeated imports of the same file create separate projects, matching
+# the original (non-idempotent) behaviour.
+def test_import_project_without_idempotency_key_creates_duplicate(
+    client, user, project
+):
+    fp = Path(
+        "asreview",
+        "webapp",
+        "tests",
+        "asreview-project-file-archive",
+        "v1.5",
+        "asreview-project-v1-5-startreview.asreview",
+    )
+
+    r1 = au.import_project(client, fp)
+    r2 = au.import_project(client, fp)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json["data"]["id"] != r2.json["data"]["id"]
+
+    folders = set(misc.get_folders_in_asreview_path())
+    # fixture project + two imports
+    assert len(folders) == 3
+
+
+# If anything fails after Project.load has copied the new project to disk,
+# the on-disk directory must be removed so we don't leak orphan projects.
+def test_import_project_cleans_up_on_failure(client, user, project, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated failure after Project.load")
+
+    monkeypatch.setattr(
+        "asreview.webapp._api.projects.ActiveLearningCycle.from_meta",
+        boom,
+    )
+
+    fp = Path(
+        "asreview",
+        "webapp",
+        "tests",
+        "asreview-project-file-archive",
+        "v1.5",
+        "asreview-project-v1-5-startreview.asreview",
+    )
+
+    folders_before = set(misc.get_folders_in_asreview_path())
+    projects_before = (
+        crud.count_projects()
+        if client.application.config.get("AUTHENTICATION")
+        else None
+    )
+
+    # The Flask test app re-raises exceptions, so the route's `raise` after
+    # cleanup surfaces here. The behaviour we care about is the side-effect:
+    # the on-disk dir + DB row created mid-import must have been removed.
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        au.import_project(client, fp)
+
+    # No new on-disk project: the dir created by Project.load was rolled back.
+    folders_after = set(misc.get_folders_in_asreview_path())
+    assert folders_after == folders_before
+
+    # And no orphan DB row either.
+    if client.application.config.get("AUTHENTICATION"):
+        assert crud.count_projects() == projects_before
+
+
 # Test known demo data
 @pytest.mark.parametrize("subset", ["plugin", "benchmark"])
 def test_demo_data_project(client, user, subset):

--- a/asreview/webapp/tests/utils/api_utils.py
+++ b/asreview/webapp/tests/utils/api_utils.py
@@ -169,10 +169,14 @@ def upgrade_projects(client: FlaskClient, project: Union[Project, asr.Project]):
     return client.put("/api/upgrade/projects")
 
 
-def import_project(client: FlaskClient, asreview_file):
+def import_project(client: FlaskClient, asreview_file, idempotency_key=None):
+    headers = {}
+    if idempotency_key is not None:
+        headers["Idempotency-Key"] = idempotency_key
     return client.post(
         "/api/projects/import",
         data={"file": (open(asreview_file, "rb"), "project.asreview")},
+        headers=headers,
     )
 
 


### PR DESCRIPTION
A grab-bag of admin/UI fixes plus a structural fix for duplicate project imports after upstream timeouts.                                                                                                                        
                                                                                                                                                                                                                                   
  ### Admin: User create form                                                                                                                                                                                                      
  - **Autofill leaking into the user search.** Typing into the create-user dialog's email field would silently mirror into the search input above (Chrome / password managers treating the page as a signup form), filtering the
  visible user list down to the one being created. Added unique `name` attributes and explicit `autoComplete` values on both the search field (`type="search"`, `autoComplete="off"`) and the dialog inputs (email/name/affiliation
   `autoComplete="off"`, password `autoComplete="new-password"`).
                                                                                                                                                                                                                                   
  ### Admin: Project details modal                                                                                                                                                                                                 
  - **"Remove member" opened the edit-user dialog instead.** The delete `IconButton` was nested inside a `ListItem` whose own `onClick` opens the edit dialog; the click bubbled. Added `e.stopPropagation()` in `UserListItem`.
                                                                                                                                                                                                                                   
  ### Invitation link section
  - Generate / Download QR / Regenerate / Revoke buttons no longer stretch to full Stack width. Generate hugs its content; the three post-QR buttons are `size="small"`, share one row with `flexWrap`, and centered below the QR  
  code.                                                                                                                                                                                                                            
   
  ### Project import: duplicate-on-retry fix                                                                                                                                                                                       
  - **Symptom:** uploading a large `.asreview` file behind nginx could result in the project appearing twice. Root cause: nginx `proxy_read_timeout` would fire while Flask was still doing `shutil.copytree` + DB commit; the
  response never reached the browser, the user retried, and `safe_import=True` happily generated a fresh uuid → second on-disk dir + second DB row.                                                                                
  - **Fix:** server-side idempotency cache keyed on `(user_id, Idempotency-Key)` with a 1h TTL. The frontend derives a stable key from the file's identity (`name|size|lastModified`) so a retry of the same file is recognised.
  The post-`Project.load` work is now wrapped in `try/except` that `rollback()`s the DB session and `rmtree`s the new project directory if anything fails, closing an unrelated orphan-dir leak.                                   
  - **Known limits (acceptable):** in-memory cache is per Flask process (fine for asreview's typical single-worker deployment); doesn't dedupe a sub-millisecond double-submit (dropzone is already disabled while loading).
                                                                                                                                                                                                                                   
  ### Tests       
  - `test_import_project_idempotency` — same file twice with same key → one project, identical responses.                                                                                                                          
  - `test_import_project_without_idempotency_key_creates_duplicate` — control case: no header, two projects.                                                                                                                       
  - `test_import_project_cleans_up_on_failure` — injected failure mid-import leaves no on-disk dir and no DB row.                                                                                                                  
  - All three run across `client_auth` / `client_implicit_auth` / `client_no_auth`.             