### PR TITLE
Import an original_id for consistent mapping with external datasets.

### DIFF
--- a/asreview/data/base.py
+++ b/asreview/data/base.py
@@ -47,6 +47,7 @@ class BaseReader(ABC):
             "include",
         ],
         "title": ["title", "primary_title"],
+        "original_id": ["original_id", "id"],
     }
 
     # Dictionary {column name : function to apply to the column} of function that clean

--- a/asreview/data/record.py
+++ b/asreview/data/record.py
@@ -143,6 +143,7 @@ class Record(Base):
     year: Mapped[Optional[int]] = mapped_column(default=None)
     doi: Mapped[Optional[str]] = mapped_column(default=None)
     url: Mapped[Optional[str]] = mapped_column(default=None)
+    original_id: Mapped[Optional[str]] = mapped_column(default=None)
     included: Mapped[Optional[int]] = mapped_column(default=None)
 
     @validates("authors", "keywords")
@@ -162,6 +163,12 @@ class Record(Base):
         if value is not None and not isinstance(value, str):
             raise ValueError(f"'{key}' should be a string or None, but is: {value}")
         return value
+
+    @validates("original_id")
+    def validate_original_id(self, key, value):
+        if value is None or value == "":
+            return None
+        return str(value)
 
     @validates("included")
     def validate_included(self, key, included):

--- a/asreview/data/ris.py
+++ b/asreview/data/ris.py
@@ -162,6 +162,10 @@ class RISReader(BaseReader):
         # Turn the entries dictionary into a Pandas dataframe
         df = pd.DataFrame(entries)
 
+        # Map the RIS ID tag (parsed as 'id' by rispy) to 'original_id'.
+        if "id" in df.columns:
+            df.rename(columns={"id": "original_id"}, inplace=True)
+
         # Check if "notes" column is present
         if "notes" in df:
             # Strip Zotero XHTML <p> tags on "notes"
@@ -257,6 +261,10 @@ class RISWriter:
                     rec_copy[key] = val
             if rec_copy["notes"] == []:
                 rec_copy.pop("notes")
+
+            # Map 'original_id' back to the RIS 'id' tag for rispy.
+            if "original_id" in rec_copy:
+                rec_copy["id"] = rec_copy.pop("original_id")
 
             # Throw away columns that can not be exported to RIS.
             rec_copy = {

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -276,6 +276,22 @@ class Database:
 
         if not self.read_only:
             self._fix_decision_changes_schema(cur)
+            self._fix_record_schema(cur)
+
+    def _fix_record_schema(self, cur):
+        """Add columns introduced after the initial schema to the record table."""
+        columns = [
+            row[1]
+            for row in cur.execute(
+                f"PRAGMA table_info({self.record_table_name})"
+            )
+        ]
+
+        if "original_id" not in columns:
+            cur.execute(
+                f"ALTER TABLE {self.record_table_name} ADD COLUMN original_id TEXT"
+            )
+            self._conn.commit()
 
     def _fix_decision_changes_schema(self, cur):
         """Fix decision_changes schema for projects migrated from old v2 format.

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -282,9 +282,7 @@ class Database:
         """Add columns introduced after the initial schema to the record table."""
         columns = [
             row[1]
-            for row in cur.execute(
-                f"PRAGMA table_info({self.record_table_name})"
-            )
+            for row in cur.execute(f"PRAGMA table_info({self.record_table_name})")
         ]
 
         if "original_id" not in columns:

--- a/asreview/project/api.py
+++ b/asreview/project/api.py
@@ -39,6 +39,7 @@ from asreview.data.loader import _from_file
 from asreview.data.loader import _get_reader
 from asreview.data.utils import identify_record_groups
 from asreview.database.database import Database
+from asreview.database.database import open_db
 from asreview.datasets import DatasetManager
 from asreview.learner import ActiveLearningCycle
 from asreview.learner import ActiveLearningCycleData
@@ -137,7 +138,7 @@ class Project:
 
     @functools.cached_property
     def db(self):
-        return Database(self.db_path)
+        return open_db(self.db_path)
 
     @property
     def input_data_fp(self):

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -80,6 +80,17 @@ const RecordCardContent = ({ record, fontSize, collapseAbstract }) => {
               </StyledIconButton>
             </Tooltip>
           )}
+
+          {!(
+            record.original_id === undefined || record.original_id === null
+          ) && (
+            <Typography
+              variant="body2"
+              sx={{ color: "text.secondary", alignSelf: "center" }}
+            >
+              ID: {record.original_id}
+            </Typography>
+          )}
         </Stack>
         <Box>
           {(record.abstract === "" || record.abstract === null) && (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,4 +103,8 @@ def asreview_test_project_path(tmpdir):
 @pytest.fixture
 def asreview_test_project(asreview_test_project_path, tmpdir):
     unzip_path = Path(tmpdir, "unzipped_project")
-    return Project.load(asreview_test_project_path, unzip_path)
+    project = Project.load(asreview_test_project_path, unzip_path)
+    # Access the database so that any pending schema fixups (e.g. new columns)
+    # are applied before tests that may reopen the DB in read-only mode.
+    project.db  # noqa: B018
+    return project


### PR DESCRIPTION
I would like to preserve my imported Zotero keys, so that it is easier to write my screening decisions back to the corresponding articles in Zotero. This pull requests adds a column with this id. 

Co-authored by: Claude Opus 4.6