### PR TITLE
added white-space:pre-wrap to the user-entered note field

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
@@ -413,7 +413,9 @@ const RecordCardLabeler = ({
                     <NoteAltOutlinedIcon />
                     <Typography variant="subtitle1">Note</Typography>
                   </Stack>
-                  <Typography sx={{ mt: 1 }}>{note}</Typography>
+                  <Typography sx={{ mt: 1, whiteSpace: "pre-wrap" }}>
+                    {note}
+                  </Typography>
                 </Paper>
               )}
               {labelFromDataset === 0 && (


### PR DESCRIPTION
 so that notes are as readable after saving as while they are being edited.