### PR TITLE
Toggle fulltext link visibility

### DIFF
--- a/asreview/project/schema.py
+++ b/asreview/project/schema.py
@@ -217,6 +217,13 @@ SCHEMA = {
             "title": "The tags schema",
             "description": "Optional tags for the project with no type restrictions.",
         },
+        "hide_links": {
+            "$id": "#/properties/hide_links",
+            "type": "boolean",
+            "title": "Hide DOI and URL links",
+            "description": "When true, DOI and URL buttons are hidden during screening to prevent full-text access.",
+            "default": False,
+        },
         "datasets": {
             "$id": "#/properties/datasets",
             "type": "array",

--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -393,6 +393,9 @@ def api_update_project_info(project):  # noqa: F401
         if len(update_dict["name"]) == 0:
             raise ValueError("Project title should be at least 1 character")
 
+    if "hide_links" in update_dict:
+        update_dict["hide_links"] = update_dict["hide_links"] == "true"
+
     project.update_config(**update_dict)
 
     return api_get_project_info(project.project_id)

--- a/asreview/webapp/src/ProjectComponents/DetailsComponents/DetailsPage.js
+++ b/asreview/webapp/src/ProjectComponents/DetailsComponents/DetailsPage.js
@@ -4,6 +4,7 @@ import { useLocation, useParams } from "react-router-dom";
 import {
   ModelCard,
   PriorCard,
+  ScreeningCard,
   TagCard,
 } from "ProjectComponents/SetupComponents";
 
@@ -20,6 +21,7 @@ const DetailsPage = () => {
       <Container maxWidth="md" aria-label="details page" sx={{ mb: 3 }}>
         <Stack spacing={3}>
           {mode !== projectModes.SIMULATION && <TagCard editable={false} />}
+          {mode !== projectModes.SIMULATION && <ScreeningCard />}
           <ModelCard mode={mode} editable={mode !== projectModes.SIMULATION} />
           <PriorCard mode={mode} editable={mode !== projectModes.SIMULATION} />
         </Stack>

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -23,7 +23,12 @@ import { RecordCardLabeler, RecordCardModelTraining } from ".";
 
 import { fontSizeOptions } from "globals.js";
 
-const RecordCardContent = ({ record, fontSize, collapseAbstract }) => {
+const RecordCardContent = ({
+  record,
+  fontSize,
+  collapseAbstract,
+  hideLinks = false,
+}) => {
   const [readMoreOpen, toggleReadMore] = useToggle();
 
   return (
@@ -54,33 +59,35 @@ const RecordCardContent = ({ record, fontSize, collapseAbstract }) => {
           )}
         </Typography>
         <Divider />
-        <Stack direction="row" spacing={1}>
-          {!(record.doi === undefined || record.doi === null) && (
-            <Tooltip title="Open DOI">
-              <StyledIconButton
-                className="record-card-icon"
-                href={"https://doi.org/" + record.doi}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <DOIIcon />
-              </StyledIconButton>
-            </Tooltip>
-          )}
+        {!hideLinks && (
+          <Stack direction="row" spacing={1}>
+            {!(record.doi === undefined || record.doi === null) && (
+              <Tooltip title="Open DOI">
+                <StyledIconButton
+                  className="record-card-icon"
+                  href={"https://doi.org/" + record.doi}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <DOIIcon />
+                </StyledIconButton>
+              </Tooltip>
+            )}
 
-          {!(record.url === undefined || record.url === null) && (
-            <Tooltip title="Open URL">
-              <StyledIconButton
-                className="record-card-icon"
-                href={record.url}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <LinkIcon />
-              </StyledIconButton>
-            </Tooltip>
-          )}
-        </Stack>
+            {!(record.url === undefined || record.url === null) && (
+              <Tooltip title="Open URL">
+                <StyledIconButton
+                  className="record-card-icon"
+                  href={record.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <LinkIcon />
+                </StyledIconButton>
+              </Tooltip>
+            )}
+          </Stack>
+        )}
         <Box>
           {(record.abstract === "" || record.abstract === null) && (
             <Typography
@@ -167,6 +174,7 @@ const RecordCard = ({
   modelLogLevel = "warning",
   showNotes = true,
   collapseAbstract = false,
+  hideLinks = false,
   hotkeys = false,
   transitionType = "fade",
   transitionSpeed = { enter: 500, exit: 100 },
@@ -201,6 +209,7 @@ const RecordCard = ({
               record={record}
               fontSize={fontSize}
               collapseAbstract={collapseAbstract}
+              hideLinks={hideLinks}
             />
           </Grid>
           <Grid size={landscape ? 2 : 5}>

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/ReviewPage.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/ReviewPage.js
@@ -24,6 +24,14 @@ const ReviewPage = () => {
 
   const [tagValues, setTagValues] = React.useState({});
 
+  const { data: projectInfo } = useQuery(
+    ["fetchProject", { project_id }],
+    ProjectAPI.fetchInfo,
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
   const { refetch, data, isSuccess, isError, error } = useQuery(
     ["fetchRecord", { project_id }],
     ProjectAPI.fetchRecord,
@@ -133,6 +141,7 @@ const ReviewPage = () => {
               setTagValues={setTagValues}
               collapseAbstract={false}
               hotkeys={true}
+              hideLinks={projectInfo?.hide_links === true}
               landscape={orientation === "landscape" && !landscapeDisabled}
             />
           )}

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/ScreeningCard.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/ScreeningCard.js
@@ -1,9 +1,13 @@
 import {
+  Box,
   Card,
   CardContent,
-  CardHeader,
   FormControlLabel,
+  IconButton,
+  Popover,
+  Stack,
   Switch,
+  Typography,
 } from "@mui/material";
 import * as React from "react";
 import { useContext } from "react";
@@ -11,12 +15,87 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import { ProjectAPI } from "api";
 import { ProjectContext } from "context/ProjectContext";
+import { LoadingCardHeader } from "StyledComponents/LoadingCardheader";
+import { StyledLightBulb } from "StyledComponents/StyledLightBulb";
+
+const InfoPopover = ({ anchorEl, handlePopoverClose }) => {
+  return (
+    <Popover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={handlePopoverClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "right",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "right",
+      }}
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          maxWidth: 350,
+        },
+      }}
+    >
+      <Box
+        sx={(theme) => ({
+          p: 3,
+          maxHeight: "80vh",
+          overflow: "auto",
+          "&::-webkit-scrollbar": {
+            width: "8px",
+            background: "transparent",
+          },
+          "&::-webkit-scrollbar-thumb": {
+            background: theme.palette.grey[300],
+            borderRadius: "4px",
+            "&:hover": {
+              background: theme.palette.grey[400],
+            },
+          },
+          "&::-webkit-scrollbar-track": {
+            background: "transparent",
+            borderRadius: "4px",
+          },
+          scrollbarWidth: "thin",
+          scrollbarColor: `${theme.palette.grey[300]} transparent`,
+        })}
+      >
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              Screening Options
+            </Typography>
+            <Typography variant="body2" align="justify">
+              Configure how records are presented during the screening process.
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+              Hide DOI and URL links
+            </Typography>
+            <Typography variant="body2" color="text.secondary" align="justify">
+              When enabled, the DOI and URL buttons are hidden from the
+              screening interface. This prevents reviewers from accessing the
+              full text of a record, which is useful for validation studies
+              where screening decisions should be based solely on the title and
+              abstract.
+            </Typography>
+          </Box>
+        </Stack>
+      </Box>
+    </Popover>
+  );
+};
 
 const ScreeningCard = () => {
   const project_id = useContext(ProjectContext);
   const queryClient = useQueryClient();
+  const [anchorEl, setAnchorEl] = React.useState(null);
 
-  const { data } = useQuery(
+  const { data, isLoading } = useQuery(
     ["fetchProject", { project_id: project_id }],
     ProjectAPI.fetchInfo,
     {
@@ -34,10 +113,28 @@ const ScreeningCard = () => {
 
   return (
     <Card>
-      <CardHeader
+      <LoadingCardHeader
         title="Screening"
         subheader="Configure the screening interface"
+        isLoading={isLoading}
+        action={
+          <IconButton
+            onClick={(event) => {
+              setAnchorEl(event.currentTarget);
+            }}
+          >
+            <StyledLightBulb />
+          </IconButton>
+        }
       />
+
+      <InfoPopover
+        anchorEl={anchorEl}
+        handlePopoverClose={() => {
+          setAnchorEl(null);
+        }}
+      />
+
       <CardContent>
         <FormControlLabel
           control={

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/ScreeningCard.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/ScreeningCard.js
@@ -1,0 +1,61 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  FormControlLabel,
+  Switch,
+} from "@mui/material";
+import * as React from "react";
+import { useContext } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+
+import { ProjectAPI } from "api";
+import { ProjectContext } from "context/ProjectContext";
+
+const ScreeningCard = () => {
+  const project_id = useContext(ProjectContext);
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery(
+    ["fetchProject", { project_id: project_id }],
+    ProjectAPI.fetchInfo,
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const { mutate } = useMutation(ProjectAPI.mutateInfo, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["fetchProject", { project_id }]);
+    },
+  });
+
+  const hideLinks = data?.hide_links ?? false;
+
+  return (
+    <Card>
+      <CardHeader
+        title="Screening"
+        subheader="Configure the screening interface"
+      />
+      <CardContent>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={hideLinks}
+              onChange={(e) => {
+                mutate({
+                  project_id: project_id,
+                  hide_links: e.target.checked,
+                });
+              }}
+            />
+          }
+          label="Hide DOI and URL links during screening"
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ScreeningCard;

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/SetupDialog.js
@@ -22,6 +22,7 @@ import {
   DatasetCard,
   ModelCard,
   PriorCard,
+  ScreeningCard,
   TagCard,
 } from "ProjectComponents/SetupComponents";
 import { ProjectAPI } from "api";
@@ -201,6 +202,9 @@ const SetupDialog = ({ project_id, mode, open, onClose }) => {
                         project_id={data?.id}
                         mobileScreen={fullScreen}
                       />
+                    </Box>
+                    <Box sx={{ my: 3 }}>
+                      <ScreeningCard />
                     </Box>
                     <Box sx={{ my: 3 }}>
                       <ModelCard mode={mode} />

--- a/asreview/webapp/src/ProjectComponents/SetupComponents/index.js
+++ b/asreview/webapp/src/ProjectComponents/SetupComponents/index.js
@@ -3,4 +3,5 @@ export { default as ModelCard } from "./ModelCard";
 export { default as TagCard } from "./TagCard";
 export { default as PriorCard } from "./PriorCard";
 export { default as DatasetCard } from "./DatasetCard";
+export { default as ScreeningCard } from "./ScreeningCard";
 export { default as Upload } from "./Upload";

--- a/asreview/webapp/src/api/ProjectAPI.js
+++ b/asreview/webapp/src/api/ProjectAPI.js
@@ -160,6 +160,9 @@ class ProjectAPI {
     if (variables.description !== undefined) {
       body.set("description", variables.description);
     }
+    if (variables.hide_links !== undefined) {
+      body.set("hide_links", variables.hide_links ? "true" : "false");
+    }
 
     const url = api_url + `projects/${variables.project_id}/info`;
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
I need to run some screening rounds where reviewers are not tempted to look at the fulltext. This PR implements an option on the import and a toggle on the customizations panel including help text. 