### PR TITLE
Make TextMerger.transform return a list instead of pd.Series

### DIFF
--- a/asreview/models/feature_extractors.py
+++ b/asreview/models/feature_extractors.py
@@ -43,7 +43,7 @@ class TextMerger(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        return X[self.columns].fillna("").apply(lambda x: self.sep.join(x), axis=1)
+        return X[self.columns].fillna("").apply(lambda x: self.sep.join(x), axis=1).tolist()
 
 
 class Tfidf(Pipeline):

--- a/asreview/models/feature_extractors.py
+++ b/asreview/models/feature_extractors.py
@@ -43,7 +43,12 @@ class TextMerger(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        return X[self.columns].fillna("").apply(lambda x: self.sep.join(x), axis=1).tolist()
+        return (
+            X[self.columns]
+            .fillna("")
+            .apply(lambda x: self.sep.join(x), axis=1)
+            .tolist()
+        )
 
 
 class Tfidf(Pipeline):


### PR DESCRIPTION
Dory's sentence-transformer feature extractors broke after the refactor because `TextMerger.transform returns a pd.Series`, and sentence-transformers versions reject it with `ValueError: Unsupported input type: Series. Expected one of: str, dict, PIL.Image.Image, np.ndarray, torch.Tensor`.

This changes `TextMerger.transform` to return a plain `list[str]`. A list is the most universally accepted "iterable of strings" across the libraries we and downstream extensions compose with — sklearn vectorizers, sentence-transformers, HuggingFace tokenizers, and gensim all accept it without conversion.