### PR TITLE
Fix tag selections being lost when saving a note during screening

### DIFF
--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCard.js
@@ -206,12 +206,7 @@ const RecordCard = ({
           <Grid size={landscape ? 2 : 5}>
             <RecordCardLabeler
               key={
-                "record-card-labeler-" +
-                project_id +
-                "-" +
-                record?.record_id +
-                "-" +
-                record?.state?.note
+                "record-card-labeler-" + project_id + "-" + record?.record_id
               }
               project_id={project_id}
               record_id={record.record_id}

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
@@ -71,6 +71,12 @@ const NoteDialog = ({ project_id, record_id, open, onClose, note = null }) => {
 
   const [noteState, setNoteState] = React.useState(note);
 
+  React.useEffect(() => {
+    if (open) {
+      setNoteState(note);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const { isError, isLoading, mutate } = useMutation(ProjectAPI.mutateNote, {
     onSuccess: () => {
       queryClient.invalidateQueries(["fetchLabeledRecord", { project_id }]);


### PR DESCRIPTION
The RecordCardLabeler component's React key included the record's note value. When a note was saved, the note changed from null to the note text, which changed the key and caused React to unmount/remount the component. This reinitialized the local tag checkbox state from the server data (null for unlabeled records), losing any checked tags.

Fixed by removing note from the component key, and adding a useEffect in NoteDialog to reset internal state when the dialog opens (previously handled implicitly by the key-triggered remount).

Fixes #2334 and #2294 