### PR TITLE
Prepopulated notes support

### DIFF
--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -471,9 +471,12 @@ class Database:
     def query_top_ranked(self, user_id=None):
         model_string = ", ".join(MODEL_COLUMNS)
         top_record_string = ", ".join(f"top_record.{col}" for col in MODEL_COLUMNS)
+        upsert_columns = ["user_id"] + MODEL_COLUMNS
+        upsert_string = ", ".join(f"{col} = excluded.{col}" for col in upsert_columns)
+
         con = self._conn
         cur = con.cursor()
-        cur.execute(
+        result = cur.execute(
             f"""WITH top_record AS (
                 SELECT last_ranking.*
                 FROM last_ranking
@@ -490,21 +493,22 @@ class Database:
                     WHERE record.record_id = (SELECT record_id FROM top_record)
                 )
             )
-            INSERT OR REPLACE INTO results (record_id, note, tags, user_id, {model_string})
-            SELECT group_records.record_id, results.note, results.tags, :user_id, {top_record_string}
+            INSERT INTO results (record_id, user_id, {model_string})
+            SELECT group_records.record_id, :user_id, {top_record_string}
             FROM group_records
-            CROSS JOIN top_record
-            LEFT JOIN results USING (record_id);
-            """,
+            CROSS JOIN top_record ON TRUE
+
+            ON CONFLICT(record_id) DO UPDATE
+                SET {upsert_string}
+            RETURNING record_id
+            ;""",
             {"user_id": user_id},
-        )
+        ).fetchone()
         con.commit()
         # Check if any record was updated, if not, the query did not return a top ranked record
         # and we should not return the newly pending record.
-        # cur.rowcount does not work here, because INSERT OR REPLACE always returns -1 (unknown)
-        # see https://sqlite.org/lang_corefunc.html#changes
-        # for documentation on the sqlite changes() function.
-        if cur.execute("SELECT changes()").fetchone()[0] == 0:
+        # cur.rowcount does not work here, because UPSERTS always return -1 (unknown)
+        if result is None:
             raise ValueError("Failed to query top ranked record")
         return self.get_pending(user_id=user_id)
 

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -499,10 +499,10 @@ class Database:
             {"user_id": user_id},
         )
         con.commit()
-        # Check if any record was updated, if not, the query did not return a top ranked record 
+        # Check if any record was updated, if not, the query did not return a top ranked record
         # and we should not return the newly pending record.
         # cur.rowcount does not work here, because INSERT OR REPLACE always returns -1 (unknown)
-        # see https://sqlite.org/lang_corefunc.html#changes 
+        # see https://sqlite.org/lang_corefunc.html#changes
         # for documentation on the sqlite changes() function.
         if cur.execute("SELECT changes()").fetchone()[0] == 0:
             raise ValueError("Failed to query top ranked record")

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -499,7 +499,12 @@ class Database:
             {"user_id": user_id},
         )
         con.commit()
-        if not cur.execute("SELECT changes()").fetchone()[0]:
+        # Check if any record was updated, if not, the query did not return a top ranked record 
+        # and we should not return the newly pending record.
+        # cur.rowcount does not work here, because INSERT OR REPLACE always returns -1 (unknown)
+        # see https://sqlite.org/lang_corefunc.html#changes 
+        # for documentation on the sqlite changes() function.
+        if cur.execute("SELECT changes()").fetchone()[0] == 0:
             raise ValueError("Failed to query top ranked record")
         return self.get_pending(user_id=user_id)
 

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -499,7 +499,7 @@ class Database:
             {"user_id": user_id},
         )
         con.commit()
-        if not cur.rowcount:
+        if not cur.execute("SELECT changes()").fetchone()[0]:
             raise ValueError("Failed to query top ranked record")
         return self.get_pending(user_id=user_id)
 

--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -474,12 +474,11 @@ class Database:
         con = self._conn
         cur = con.cursor()
         cur.execute(
-            f"""INSERT INTO results (record_id, user_id, {model_string})
-            WITH top_record AS (
+            f"""WITH top_record AS (
                 SELECT last_ranking.*
                 FROM last_ranking
                 LEFT JOIN results USING (record_id)
-                WHERE results.record_id IS NULL
+                WHERE results.record_id IS NULL OR (results.label IS NULL AND results.user_id IS NULL)
                 ORDER BY ranking
                 LIMIT 1
             ), group_records AS (
@@ -491,9 +490,12 @@ class Database:
                     WHERE record.record_id = (SELECT record_id FROM top_record)
                 )
             )
-            SELECT group_records.record_id, :user_id, {top_record_string}
+            INSERT OR REPLACE INTO results (record_id, note, tags, user_id, {model_string})
+            SELECT group_records.record_id, results.note, results.tags, :user_id, {top_record_string}
             FROM group_records
-            CROSS JOIN top_record;""",
+            CROSS JOIN top_record
+            LEFT JOIN results USING (record_id);
+            """,
             {"user_id": user_id},
         )
         con.commit()

--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -573,7 +573,13 @@ def api_get_labeled(project):  # noqa: F401
         state_data = state_data[~state_data["note"].isnull()]
 
     if latest_first == 1:
-        state_data = state_data.iloc[::-1]
+        state_data = state_data.sort_values(
+            by="time", ascending=False, na_position="last"
+        )
+    else:
+        state_data = state_data.sort_values(
+            by="time", ascending=True, na_position="last"
+        )
 
     # count labeled records and max pages
     if len(state_data) == 0:

--- a/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
+++ b/asreview/webapp/src/ProjectComponents/ReviewComponents/RecordCardLabeler.js
@@ -535,7 +535,9 @@ const RecordCardLabeler = ({
                 >
                   Labeled {label === 1 ? "relevant" : "not relevant"}{" "}
                   {user && formatUser(user)}{" "}
-                  {timeAgo.format(new Date(labelTime * 1000))}
+                  {labelTime != null
+                    ? timeAgo.format(new Date(labelTime * 1000))
+                    : "some time ago"}
                 </Typography>
               )}
             </>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -361,6 +361,14 @@ def test_query_top_ranked(db):
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [5]
 
+    # record_id 5 is the top ranked, now already present in results. 
+    # However, no user and no label has been assigned yet, so still pending for all users.
+    pending = db.query_top_ranked(1)
+    state[0] = [5, None, 1, "nb", "max", "balanced", "tfidf", 42]
+    assert_state(db, state, columns)
+    # Pending only returns 0 since the previous record was not for user id = 2
+    assert pending["record_id"].to_list() == [5]
+
     # record_id 0 is the top ranked not in results. It's grouped with record_id 1.
     pending = db.query_top_ranked(2)
     state.append([0, None, 2, "nb", "max", "balanced", "tfidf", 42])
@@ -369,20 +377,41 @@ def test_query_top_ranked(db):
     # Pending only returns 0 since the previous record was not for user id = 2
     assert pending["record_id"].to_list() == [0]
 
-    # record_id 2 is the top ranked not in results. It's not grouped.
+    # record_id 2 is the top ranked not in results. It's not grouped. 
+    # It's added to results without user assignment.
     pending = db.query_top_ranked()
     state.append([2, None, None, "nb", "max", "balanced", "tfidf", 42])
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [5, 0, 2]
 
+    # record_id 2 is still the top ranked. Nothing to append or update here.
+    pending = db.query_top_ranked()
+    assert_state(db, state, columns)
+    assert pending["record_id"].to_list() == [5, 0, 2]
+
+    # record_id 2 is still the top ranked as it's not assigned to anyone.
+    pending = db.query_top_ranked(3)
+    state[3] = [2, None, 3, "nb", "max", "balanced", "tfidf", 42]
+    assert_state(db, state, columns)
+    assert pending["record_id"].to_list() == [2]
+
     # record_id 4 is the top ranked not in results. It's grouped with record_id 3.
     # The grouped records end up in the results table in the same order as they are in
-    # the records table, to 3 comes before 4.
-    pending = db.query_top_ranked(3)
-    state.append([3, None, 3, "nb", "max", "balanced", "tfidf", 42])
-    state.append([4, None, 3, "nb", "max", "balanced", "tfidf", 42])
+    # the records table, so 3 comes before 4.
+    pending = db.query_top_ranked()
+    state.append([3, None, None, "nb", "max", "balanced", "tfidf", 42])
+    state.append([4, None, None, "nb", "max", "balanced", "tfidf", 42])
+    assert_state(db, state, columns)
+    assert pending["record_id"].to_list() == [5, 0, 2, 3]
+
+    # Another user without assignment queries the top ranked. The same records are returned, 
+    # but now record_id 3 is assigned to this user.
+    pending = db.query_top_ranked(4)
+    state[4] = [3, None, 4, "nb", "max", "balanced", "tfidf", 42]
+    state[5] = [4, None, 4, "nb", "max", "balanced", "tfidf", 42]
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [3]
+
 
 
 def test_update(db):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -361,7 +361,7 @@ def test_query_top_ranked(db):
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [5]
 
-    # record_id 5 is the top ranked, now already present in results. 
+    # record_id 5 is the top ranked, now already present in results.
     # However, no user and no label has been assigned yet, so still pending for all users.
     pending = db.query_top_ranked(1)
     state[0] = [5, None, 1, "nb", "max", "balanced", "tfidf", 42]
@@ -377,7 +377,7 @@ def test_query_top_ranked(db):
     # Pending only returns 0 since the previous record was not for user id = 2
     assert pending["record_id"].to_list() == [0]
 
-    # record_id 2 is the top ranked not in results. It's not grouped. 
+    # record_id 2 is the top ranked not in results. It's not grouped.
     # It's added to results without user assignment.
     pending = db.query_top_ranked()
     state.append([2, None, None, "nb", "max", "balanced", "tfidf", 42])
@@ -404,14 +404,13 @@ def test_query_top_ranked(db):
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [5, 0, 2, 3]
 
-    # Another user without assignment queries the top ranked. The same records are returned, 
+    # Another user without assignment queries the top ranked. The same records are returned,
     # but now record_id 3 is assigned to this user.
     pending = db.query_top_ranked(4)
     state[4] = [3, None, 4, "nb", "max", "balanced", "tfidf", 42]
     state[5] = [4, None, 4, "nb", "max", "balanced", "tfidf", 42]
     assert_state(db, state, columns)
     assert pending["record_id"].to_list() == [3]
-
 
 
 def test_update(db):


### PR DESCRIPTION
The logic for selecting the next article now doesn't assume anymore that the row doesn't exist yet in the results table, instead it looks for the next ranked row that either does not exist yer or doesn't have a label yet and no user assigned yet. It then does an upsert (insert if possible, or update if necessary). 

A bug that assumed the order of the collections (results) view is equal to the insertion order was also fixed by ordering now by timestamp and null timestamps are now displayed as "some time ago" instead of "56 years ago". 

Fixes #2455 for me. Replaces pull request #2483 (using a named branch in my fork instead of main)
