### PR TITLE
Redesign collection filters with 3-state toggles and tag filtering

### DIFF
--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -595,9 +595,7 @@ def api_get_labeled(project):  # noqa: F401
     # Tag filters. Supported format:
     #   "tag_{group_export}_{value_export}" or "...=true"  → tag is set
     #   "tag_{group_export}_{value_export}=false"           → tag is not set
-    tag_filters = {
-        k: v for k, v in parsed_filters.items() if k.startswith("tag_")
-    }
+    tag_filters = {k: v for k, v in parsed_filters.items() if k.startswith("tag_")}
     if tag_filters:
         tags_config = read_tags_data(project)
         if tags_config is not None:

--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -556,9 +556,26 @@ def api_get_labeled(project):  # noqa: F401
     filters = request.args.getlist("filter", type=str)
     latest_first = request.args.get("latest_first", default=1, type=int)
 
+    # Parse boolean filters. Supported formats:
+    #   "is_prior" or "is_prior=true"  → only priors
+    #   "is_prior=false"               → exclude priors
+    #   "has_note" or "has_note=true"  → only records with notes
+    #   "has_note=false"               → only records without notes
+    parsed_filters = {}
+    for f in filters:
+        if "=" in f:
+            key, val = f.split("=", 1)
+            parsed_filters[key] = val.lower() == "true"
+        else:
+            parsed_filters[f] = True
+
     with project.db as db:
-        if "is_prior" in filters:
+        filter_is_prior = parsed_filters.get("is_prior")
+        if filter_is_prior is True:
             state_data = db.get_priors()
+        elif filter_is_prior is False:
+            # All labeled records that are NOT priors
+            state_data = db.get_results_table(priors=False)
         else:
             state_data = db.get_results_table()
 
@@ -569,8 +586,28 @@ def api_get_labeled(project):  # noqa: F401
     else:
         state_data = state_data[~state_data["label"].isnull()]
 
-    if "has_note" in filters:
+    filter_has_note = parsed_filters.get("has_note")
+    if filter_has_note is True:
         state_data = state_data[~state_data["note"].isnull()]
+    elif filter_has_note is False:
+        state_data = state_data[state_data["note"].isnull()]
+
+    # Tag filters. Supported format:
+    #   "tag_{group_export}_{value_export}" or "...=true"  → tag is set
+    #   "tag_{group_export}_{value_export}=false"           → tag is not set
+    tag_filters = {
+        k: v for k, v in parsed_filters.items() if k.startswith("tag_")
+    }
+    if tag_filters:
+        tags_config = read_tags_data(project)
+        if tags_config is not None:
+            state_data = _flatten_tags(state_data.copy(), tags_config)
+            for tag_col, want_set in tag_filters.items():
+                if tag_col in state_data.columns:
+                    if want_set:
+                        state_data = state_data[state_data[tag_col] == 1]
+                    else:
+                        state_data = state_data[state_data[tag_col] != 1]
 
     if latest_first == 1:
         state_data = state_data.iloc[::-1]

--- a/asreview/webapp/_api/projects.py
+++ b/asreview/webapp/_api/projects.py
@@ -599,13 +599,16 @@ def api_get_labeled(project):  # noqa: F401
     if tag_filters:
         tags_config = read_tags_data(project)
         if tags_config is not None:
-            state_data = _flatten_tags(state_data.copy(), tags_config)
+            # Filter on a flattened copy so the original `tags` column (needed by the
+            # frontend to render the tag checkboxes) stays intact on `state_data`.
+            flattened = _flatten_tags(state_data.copy(), tags_config)
             for tag_col, want_set in tag_filters.items():
-                if tag_col in state_data.columns:
+                if tag_col in flattened.columns:
                     if want_set:
-                        state_data = state_data[state_data[tag_col] == 1]
+                        flattened = flattened[flattened[tag_col] == 1]
                     else:
-                        state_data = state_data[state_data[tag_col] != 1]
+                        flattened = flattened[flattened[tag_col] != 1]
+            state_data = state_data.loc[flattened.index]
 
     if latest_first == 1:
         state_data = state_data.iloc[::-1]

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/Filter.js
@@ -1,76 +1,293 @@
 import { FilterList } from "@mui/icons-material";
-import { Autocomplete, Checkbox, IconButton, InputBase } from "@mui/material";
+import {
+  Badge,
+  Chip,
+  CircularProgress,
+  IconButton,
+  InputBase,
+  Popover,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { api_url } from "globals.js";
+import axios from "axios";
 import * as React from "react";
 
-const historyFilterOptions = [
-  { value: "has_note", label: "Contains note" },
-  { value: "is_prior", label: "Prior knowledge" },
+const STATIC_FILTER_DEFS = [
+  {
+    key: "has_note",
+    label: "Contains note",
+    options: [
+      { value: "has_note", label: "True", symbol: "✓" },
+      { value: "has_note=false", label: "False", symbol: "\u20E0" },
+    ],
+  },
+  {
+    key: "is_prior",
+    label: "Prior knowledge",
+    options: [
+      { value: "is_prior", label: "True", symbol: "✓" },
+      { value: "is_prior=false", label: "False", symbol: "\u20E0" },
+    ],
+  },
 ];
+
+/**
+ * Build tag filter definitions from the project's tag configuration.
+ * Each tag group becomes a filter row, and each tag value within it
+ * becomes a True/False toggle.
+ */
+function buildTagFilterDefs(tagsConfig) {
+  if (!tagsConfig || !Array.isArray(tagsConfig)) return [];
+  return tagsConfig.flatMap((group) =>
+    (group.values || []).map((tag) => ({
+      key: `tag_${group.export}_${tag.export}`,
+      label: `tag: ${tag.label}`,
+      options: [
+        {
+          value: `tag_${group.export}_${tag.export}`,
+          label: "True",
+          symbol: "✓",
+        },
+        {
+          value: `tag_${group.export}_${tag.export}=false`,
+          label: "False",
+          symbol: "\u20E0",
+        },
+      ],
+    })),
+  );
+}
 
 const PREFIX = "Filter";
 
 const classes = {
   icon: `${PREFIX}-icon`,
+  popover: `${PREFIX}-popover`,
+  filterRow: `${PREFIX}-filterRow`,
+  searchInput: `${PREFIX}-searchInput`,
 };
 
 const Root = styled("div")(({ theme }) => ({
   display: "flex",
   alignItems: "center",
-  padding: 0,
+  padding: theme.spacing(3),
+  flexWrap: "wrap",
+  gap: theme.spacing(0.5),
   [`& .${classes.icon}`]: {
     color: theme.palette.text.secondary,
     [`:hover`]: {
       bgcolor: "transparent",
     },
   },
+  [`& .${classes.popover}`]: {
+    minWidth: 260,
+    maxHeight: 400,
+    overflow: "auto",
+  },
+  [`& .${classes.filterRow}`]: {
+    padding: theme.spacing(1, 0),
+    "& + &": {
+      borderTop: `1px solid ${theme.palette.divider}`,
+    },
+  },
+  [`& .${classes.searchInput}`]: {
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    paddingBottom: theme.spacing(1),
+    marginBottom: theme.spacing(0.5),
+  },
 }));
 
 export default function Filter(props) {
-  const filterInput = React.useRef(null);
+  const anchorRef = React.useRef(null);
+  const searchRef = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState("");
+  const [tagDefs, setTagDefs] = React.useState([]);
+  const [tagsLoading, setTagsLoading] = React.useState(false);
 
-  const onClickFilter = () => {
-    filterInput.current.focus();
+  const activeFilters = props.filterQuery || [];
+
+  // Fetch tag configuration when the popover opens
+  const fetchTags = React.useCallback(() => {
+    if (!props.project_id) return;
+    setTagsLoading(true);
+    axios
+      .get(api_url + `projects/${props.project_id}/tags`, {
+        withCredentials: true,
+      })
+      .then((res) => {
+        setTagDefs(buildTagFilterDefs(res.data));
+      })
+      .catch(() => {
+        setTagDefs([]);
+      })
+      .finally(() => {
+        setTagsLoading(false);
+      });
+  }, [props.project_id]);
+
+  const allFilterDefs = [...STATIC_FILTER_DEFS, ...tagDefs];
+
+  const activeKeys = new Set(
+    activeFilters.map((f) => (f.value || "").split("=")[0]).filter(Boolean),
+  );
+
+  const getFilterState = (key) => {
+    const entry = activeFilters.find((f) => f.value && f.value.startsWith(key));
+    if (!entry) return null;
+    return entry.value;
   };
+
+  const setFilterState = (key, value) => {
+    const others = activeFilters.filter(
+      (f) => !f.value || !f.value.startsWith(key),
+    );
+    const def = allFilterDefs.find((d) => d.key === key);
+    const opt = def?.options.find((o) => o.value === value);
+    props.setFilterQuery([
+      ...others,
+      { value, label: `${def.label} ${opt.symbol}` },
+    ]);
+  };
+
+  const removeFilter = (value) => {
+    props.setFilterQuery(activeFilters.filter((f) => f.value !== value));
+  };
+
+  const searchLower = search.toLowerCase();
+  const availableFilters = allFilterDefs.filter(
+    (def) =>
+      !activeKeys.has(def.key) && def.label.toLowerCase().includes(searchLower),
+  );
+
+  // Truncate label text to maxLen characters
+  const truncateLabel = (label, maxLen = 50) => {
+    if (label.length <= maxLen) return label;
+    return label.slice(0, maxLen) + "...";
+  };
+
+  // Render a chip label with the trailing symbol bolded and text truncated
+  const renderChipLabel = (label, maxLen = 30) => {
+    const match = label.match(/^(.+)\s+([\u2713\u20E0]+)$/);
+    if (match) {
+      let text = match[1];
+      if (text.length > maxLen) {
+        text = text.slice(0, maxLen) + "...";
+      }
+      return (
+        <span>
+          {text} <span style={{ fontWeight: 700 }}>{match[2]}</span>
+        </span>
+      );
+    }
+    return label;
+  };
+
+  const handleOpen = () => {
+    setSearch("");
+    if (tagDefs.length === 0 && !tagsLoading) {
+      fetchTags();
+    }
+    setOpen(true);
+  };
+
+  const hasVisibleFilters =
+    allFilterDefs.some((d) => !activeKeys.has(d.key)) ||
+    activeFilters.length > 0;
+
+  if (!hasVisibleFilters) {
+    return null;
+  }
 
   return (
     <Root>
-      <IconButton className={classes.icon} onClick={onClickFilter}>
-        <FilterList />
+      <IconButton ref={anchorRef} className={classes.icon} onClick={handleOpen}>
+        <Badge
+          badgeContent={activeFilters.length}
+          color="primary"
+          invisible={activeFilters.length === 0}
+          sx={{
+            "& .MuiBadge-badge": {
+              fontSize: 9,
+              height: 16,
+              minWidth: 16,
+            },
+          }}
+        >
+          <FilterList />
+        </Badge>
       </IconButton>
-      <Autocomplete
-        id="filter labeled record"
-        sx={{ ml: 1, display: "flex", flexGrow: 1 }}
-        blurOnSelect
-        disableClearable
-        filterSelectedOptions
-        multiple
-        openOnFocus
-        options={historyFilterOptions}
-        getOptionLabel={(option) => option.label}
-        renderOption={(props, option, { selected }) => (
-          <li {...props} key={option.value}>
-            <Checkbox style={{ marginRight: 8 }} checked={selected} />
-            {option.label}
-          </li>
-        )}
-        renderInput={(params) => {
-          const { InputLabelProps, InputProps, ...rest } = params;
-          return (
-            <InputBase
-              {...params.InputProps}
-              {...rest}
-              sx={{ width: "100%" }}
-              inputRef={filterInput}
-              placeholder={!props.filterQuery.length ? "Filter" : ""}
-            />
-          );
-        }}
-        onChange={(event, value) => {
-          props.setFilterQuery(value);
-        }}
-        value={props.filterQuery}
-      />
+
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={() => setOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+      >
+        <Stack className={classes.popover} spacing={1} sx={{ p: "10px" }}>
+          <InputBase
+            className={classes.searchInput}
+            inputRef={searchRef}
+            placeholder="Search filters..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+          {tagsLoading ? (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                Loading tag filters...
+              </Typography>
+            </Stack>
+          ) : availableFilters.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              {search ? "No matching filters" : "All filters active"}
+            </Typography>
+          ) : (
+            availableFilters.map((def) => {
+              const currentValue = getFilterState(def.key);
+              return (
+                <div key={def.key} className={classes.filterRow}>
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    {def.options.map((opt) => {
+                      const isSelected = opt.value === currentValue;
+                      return (
+                        <Chip
+                          key={opt.label}
+                          label={opt.label}
+                          size="small"
+                          variant={isSelected ? "filled" : "outlined"}
+                          color="primary"
+                          onClick={() => setFilterState(def.key, opt.value)}
+                        />
+                      );
+                    })}
+                    <Typography variant="body2" noWrap title={def.label}>
+                      {truncateLabel(def.label)}
+                    </Typography>
+                  </Stack>
+                </div>
+              );
+            })
+          )}
+        </Stack>
+      </Popover>
+
+      {activeFilters.map((f) => (
+        <Chip
+          key={f.value}
+          label={renderChipLabel(f.label)}
+          title={f.label}
+          size="small"
+          variant="filled"
+          color={f.value.endsWith("=false") ? "error" : "primary"}
+          onDelete={() => removeFilter(f.value)}
+        />
+      ))}
     </Root>
   );
 }

--- a/asreview/webapp/src/ProjectComponents/HistoryComponents/LabelHistory.js
+++ b/asreview/webapp/src/ProjectComponents/HistoryComponents/LabelHistory.js
@@ -105,7 +105,11 @@ const LabelHistory = ({
             </Stack>
             {!mobileScreen && showFilter && (
               <Box sx={{ flexGrow: 1, minWidth: "200px" }}>
-                <Filter filterQuery={state} setFilterQuery={setState} />
+                <Filter
+                  project_id={project_id}
+                  filterQuery={state}
+                  setFilterQuery={setState}
+                />
               </Box>
             )}
           </Stack>
@@ -151,7 +155,11 @@ const LabelHistory = ({
               justifyContent="space-between"
             >
               <Box sx={{ flexGrow: 1, mr: 1 }}>
-                <Filter filterQuery={state} setFilterQuery={setState} />
+                <Filter
+                  project_id={project_id}
+                  filterQuery={state}
+                  setFilterQuery={setState}
+                />
               </Box>
               {showExport && (
                 <IconButton


### PR DESCRIPTION
Replace checkbox-based filters with True/False chip toggles. 
Support filtering not only for presence or absence of notes, prior knowledge status but also absence of these and dynamically loaded project tags. False-state chips get a red tint; labels truncate with native tooltips on hover.

Currently: 
<img width="837" height="144" alt="image" src="https://github.com/user-attachments/assets/02ff70ff-1aea-4cb7-9404-e29e7d7392e8" />
<img width="850" height="137" alt="image" src="https://github.com/user-attachments/assets/80320953-6844-4461-b9f4-ea7c4a2f926e" />


What this pull request proposes:
<img width="837" height="416" alt="image" src="https://github.com/user-attachments/assets/72bfe1af-3c31-4b3d-b3d4-1c80f5ff8100" />
<img width="831" height="416" alt="image" src="https://github.com/user-attachments/assets/02c0506d-9f4a-4550-9bd3-25b07fbf0c46" />


Looking forward to feedback, are pull requests like this welcome?
All the best, 
Michael