### PR TITLE
Enable SQLite WAL mode for concurrent project/queue access and prevent silent task-manager death

### DIFF
--- a/asreview/database/database.py
+++ b/asreview/database/database.py
@@ -162,7 +162,11 @@ class Database:
         sqlite3.Connection
             Connection to the SQLite database.
         """
-        return sqlite3.connect(self._conn_uri, uri=True)
+        conn = sqlite3.connect(self._conn_uri, uri=True)
+        if not self.read_only:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
 
     def close(self):
         """Close the database and release all resources.

--- a/asreview/database/store.py
+++ b/asreview/database/store.py
@@ -225,9 +225,16 @@ class DataStore:
         # connection pool, but just create and dispose of a connection every time a
         # request comes. This makes it very easy dispose of the engine, but is less
         # efficient.
+        def _creator():
+            conn = sqlite3.connect(self._conn_uri, uri=True)
+            if not self.read_only:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA synchronous=NORMAL")
+            return conn
+
         self.engine = create_engine(
             "sqlite://",
-            creator=lambda: sqlite3.connect(self._conn_uri, uri=True),
+            creator=_creator,
             poolclass=NullPool,
         )
 

--- a/asreview/webapp/_task_manager/task_manager.py
+++ b/asreview/webapp/_task_manager/task_manager.py
@@ -8,6 +8,7 @@ import errno
 from collections import deque
 
 from sqlalchemy import create_engine
+from sqlalchemy import event
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -108,6 +109,14 @@ class TaskManager:
         # set up database
         database_url = f"sqlite:///{asreview_path()}/queue.sqlite"
         engine = create_engine(database_url, pool_size=5, max_overflow=10)
+
+        @event.listens_for(engine, "connect")
+        def _set_sqlite_pragma(dbapi_connection, connection_record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.close()
+
         Base.metadata.create_all(engine)
 
         Session = sessionmaker(bind=engine)
@@ -476,6 +485,15 @@ class TaskManager:
                     break
                 logger.error(f"Socket error occurred: {e}")
                 break  # Exit the loop if the socket is closed
+
+            except Exception as e:
+                logger.exception(f"Unexpected error in task manager loop: {e}")
+                try:
+                    if self.session:
+                        self.session.rollback()
+                except Exception:
+                    pass
+                continue
 
         # After exiting main loop, clean up client thread
         if self.client_thread and self.client_conn:


### PR DESCRIPTION
This PR addresses two related failure modes seen in server deployments under concurrent database access, observed on a large project (~10,000 records with prior knowledge):

1. Frequent SQLITE_BUSY ("database is locked") errors when the task manager rewrites the last_ranking / results tables while another connection reads the same project database.
2. The task manager process silently dying and never recovering, which blocks all further screening until the app is restarted.

It makes two kinds of change: enabling WAL journal mode on all SQLite connections, and hardening the task manager's main loop so an unhandled exception no longer terminates the process.

## Code Changes

1. WAL + synchronous=NORMAL on all SQLite connections
Three connection sites, each opened differently, so each is patched with the appropriate mechanism:

* asreview/database/database.py — the raw sqlite3.connect() for the project DB (results, last_ranking, decision_changes). Pragmas set directly on the connection, guarded by not self.read_only.
* asreview/database/store.py — the SQLAlchemy engine creator for the project input records (same file). Pragmas set inside the creator function, same guard.
* asreview/webapp/_task_manager/task_manager.py — the queue.sqlite engine. Pragmas set via a connect event listener, since this engine is built from a URL with no creator hook.

The read_only guard is required because PRAGMA journal_mode=WAL writes to the database header and fails on a mode=ro connection.

2. Catch-all in the task manager main loop
start_manager's accept loop previously caught only socket.timeout and OSError; any other exception raised during the periodic queue tick (_process_buffer() / pop_waiting_queue()) propagated out of the loop and terminated the process. 

Added an except Exception clause that logs the exception, rolls back the SQLAlchemy session, and continues.
The session.rollback() is deliberate: after a failed statement SQLAlchemy puts the session into a state where every subsequent query raises PendingRollbackError until rolled back. Without it, the loop would survive but spin re-raising the same error each tick. The rollback resets the session and, on SQLite, releases any lock the connection held.

### Why WAL + synchronous=NORMAL

In the default rollback-journal mode a write needs an exclusive lock, which any concurrent reader blocks — so writes fail with SQLITE_BUSY even after the default 5s busy-timeout. WAL lets one writer and multiple readers coexist without blocking, removing that contention class. `synchronous=NORMAL` is SQLite's recommended companion to WAL. In WAL mode it is corruption-safe — the only risk on an OS crash or power loss is losing the last few committed transactions, never a corrupt database — and it avoids an fsync on every commit, which matters given the frequent full-table rewrites of last_ranking.

### Verification

Reproduced in isolation: with a concurrent reader holding a cursor on the table, the `to_sql(if_exists="replace")` / `DELETE FROM` write fails after ~5s with "database is locked" under the default journal mode and succeeds in milliseconds under WAL: 

```
10000 rows; a concurrent reader is held open during each write.

last_ranking  (to_sql if_exists='replace')
    default (rollback journal): FAIL after  5.01s  
        (DatabaseError: Execution failed on sql 'DROP TABLE "last_ranking"': database is locked)
    WAL                       : OK   in  0.04s

results       (DELETE FROM = truncate)
    default (rollback journal): FAIL after  5.01s  
        (OperationalError: database is locked)
    WAL                       : OK   in  0.01s
```

#### Verification script

```
"""Reproduce the SQLite "database is locked" failure and verify the WAL fix.

ASReview rewrites two project-database tables on every model/ranking update:

  * ``last_ranking`` via ``DataFrame.to_sql(..., if_exists="replace")``
    (pandas issues ``DROP TABLE`` + recreate + bulk insert)
  * ``results`` via ``DELETE FROM results`` (SQLite's truncate optimisation)

Both need an exclusive write lock. In SQLite's default rollback-journal mode a
concurrent reader holding a shared lock blocks that write: the writer waits the
full busy-timeout (5s by default) and then fails with SQLITE_BUSY
("database is locked"). This is what a gunicorn worker reading project state
does to the task manager rewriting the ranking.

WAL (Write-Ahead Logging) lets one writer and many readers coexist without
blocking, so the same write succeeds immediately with a reader still open.

Run:        python reproduce_wal_lock.py
Requires:   pandas  (already an ASReview dependency)
"""

import os
import sqlite3
import tempfile
import time

import pandas as pd

N_ROWS = 10_000


def _fresh_db(path):
    """Create a project-like database with last_ranking and results tables."""
    for p in (path, path + "-wal", path + "-shm", path + "-journal"):
        if os.path.exists(p):
            os.remove(p)
    conn = sqlite3.connect(path)
    pd.DataFrame({"record_id": range(N_ROWS), "score": range(N_ROWS)}).to_sql(
        "last_ranking", conn, if_exists="replace", index=False
    )
    conn.execute("CREATE TABLE results (record_id INTEGER, label INTEGER)")
    conn.executemany(
        "INSERT INTO results VALUES (?, ?)", [(i, i % 2) for i in range(N_ROWS)]
    )
    conn.commit()
    conn.close()


def _attempt_write(path, journal_mode, write_kind):
    """Open a writer plus a concurrent reader, attempt one write, report result.

    The reader leaves a cursor mid-iteration so it keeps a shared lock on the
    database file (SQLite write locks are database-wide), mimicking a web worker
    reading project state while the task manager rewrites the ranking.
    """
    _fresh_db(path)

    writer = sqlite3.connect(path, uri=True)  # inherits the default 5s busy timeout
    if journal_mode == "WAL":
        writer.execute("PRAGMA journal_mode=WAL")

    reader = sqlite3.connect(path, uri=True)
    reader_cursor = reader.execute("SELECT * FROM last_ranking")
    reader_cursor.fetchone()  # begin reading; do NOT finish -> lock stays held

    start = time.time()
    try:
        if write_kind == "to_sql_replace":  # mirrors add_last_ranking()
            pd.DataFrame(
                {"record_id": range(N_ROWS), "score": range(N_ROWS)}
            ).to_sql("last_ranking", writer, if_exists="replace", index=False)
        elif write_kind == "delete_truncate":  # mirrors _replace_results_from_df()
            writer.execute("DELETE FROM results")
            writer.commit()
        outcome = f"OK   in {time.time() - start:5.2f}s"
    except Exception as exc:
        outcome = f"FAIL after {time.time() - start:5.2f}s  ({type(exc).__name__}: {exc})"
    finally:
        reader.close()
        writer.close()
    return outcome


def main():
    with tempfile.TemporaryDirectory() as tmp:
        path = os.path.join(tmp, "project.sqlite")
        print(
            f"{N_ROWS} rows; a concurrent reader is held open during each write.\n"
        )
        cases = [
            ("to_sql_replace", "last_ranking  (to_sql if_exists='replace')"),
            ("delete_truncate", "results       (DELETE FROM = truncate)"),
        ]
        for write_kind, label in cases:
            default = _attempt_write(path, "DELETE", write_kind)
            wal = _attempt_write(path, "WAL", write_kind)
            print(label)
            print(f"    default (rollback journal): {default}")
            print(f"    WAL                       : {wal}\n")


if __name__ == "__main__":
    main()
```

## Scope / what this does NOT address

This does not protect the task manager from termination by causes outside the application's control — e.g., the OS OOM-killer under memory pressure. That is a separate, deeper concern (likely needing process/container-level supervision or a memory-usage review) and is intentionally out of scope for this minimal fix.

Fixes #2544 


## AI usage disclaimer

I used Anthropic's Claude (Opus 4.7) to help investigate the root cause and draft this fix. The bug surfaced on my own deployment with repeated user complaints; I made the design decisions, reviewed and tested all changes, independently reproduced the failure and confirmed the fix, and I take responsibility for the correctness of the code and claims in this PR and the linked issue.
