### PR TITLE
Return a consistent type from the project fixture

### DIFF
--- a/asreview/webapp/tests/conftest.py
+++ b/asreview/webapp/tests/conftest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy.orm import close_all_sessions
 
+from asreview import Project
 import asreview.webapp.tests.utils.api_utils as au
 from asreview.webapp import DB
 from asreview.webapp.app import create_app
@@ -309,7 +310,15 @@ def project(request):
         user = None
 
     au.create_project(client, benchmark="synergy:van_der_Valk_2021")
-    yield user.projects[0] if user is not None else get_projects()[0]
+    if user is not None:
+        db_project = user.projects[0]
+        project = Project(
+            db_project.project_path,
+            project_id=db_project.project_id,
+        )
+    else:
+        project = get_projects()[0]
+    yield project
 
     if client.application.config["AUTHENTICATION"]:
         crud.delete_everything(DB)

--- a/asreview/webapp/tests/test_api/test_projects.py
+++ b/asreview/webapp/tests/test_api/test_projects.py
@@ -28,6 +28,10 @@ UPLOAD_DATA = [
 ]
 
 
+def test_project_fixture_returns_core_project(client, project):
+    assert isinstance(project, asr.Project)
+
+
 def _asreview_file_archive():
     return list(
         Path("asreview", "webapp", "tests", "asreview-project-file-archive").glob(


### PR DESCRIPTION
Closes #2373.

Changes proposed in this pull request:

- Return the core `asreview.Project` type from the webapp `project` fixture in authenticated and unauthenticated modes.
- Preserve the database project ID when adapting authenticated projects.
- Add a regression test covering all three client configurations.

**Checklist**

- [x] Unit tests are added for new features and bug fixes
- [ ] Documentation is added for new features (not applicable)
- [x] Title of the pull request is self-explaining

**Test**

- `python -m pytest asreview/webapp/tests/test_api/test_projects.py::test_project_fixture_returns_core_project -q` (3 passed)
- `ruff check asreview/webapp/tests/conftest.py asreview/webapp/tests/test_api/test_projects.py`
