### PR TITLE
Introduce new ELAS u5, h4, and l3 model parameters

### DIFF
--- a/asreview/models/models.py
+++ b/asreview/models/models.py
@@ -16,7 +16,30 @@ from asreview.learner import ActiveLearningCycleData
 
 AI_MODEL_CONFIGURATIONS = [
     {
-        # ELAS u4 is the default model for this version ASReview LAB. The model
+        # ELAS u5 is the default model for this version ASReview LAB. The model
+        # parameters have been optimized on the SYNERGY dataset. After expert
+        # elicitation, the model and parameters have been chosen.
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        "name": "elas_u5",
+        "label": "ELAS u5",
+        "type": "ultra",
+        "value": ActiveLearningCycleData(
+            querier="max",
+            classifier="svm",
+            classifier_param={"loss": "squared_hinge", "C": 0.0240, "max_iter": 5000},
+            balancer="balanced",
+            balancer_param={"ratio": 9.242},
+            feature_extractor="tfidf",
+            feature_extractor_param={
+                "ngram_range": (1, 2),
+                "sublinear_tf": True,
+                "min_df": 1,
+                "max_df": 1.0,
+            },
+        ),
+    },
+    {
+        # ELAS u4 is the default model for version 2 of ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview2_0b4-nb-tfidf-full-1
@@ -60,7 +83,26 @@ AI_MODEL_CONFIGURATIONS = [
     # ELAS u1 refers to the model that was used in the ASReview LAB version 0. The
     # model is not available in the current version of ASReview LAB.
     {
-        # ELAS l2 is the multilingual model for this version ASReview LAB. The model
+        # ELAS l3 is the multilingual model for this version ASReview LAB. The model
+        # parameters have been optimized on the SYNERGY dataset. After expert
+        # elicitation, the model and parameters have been chosen.
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        "name": "elas_l3",
+        "label": "ELAS l3",
+        "type": "lang",
+        "extensions": ["asreview-dory"],
+        "value": ActiveLearningCycleData(
+            querier="max",
+            classifier="svm",
+            classifier_param={"loss": "squared_hinge", "C": 0.0410, "max_iter": 5000},
+            balancer="balanced",
+            balancer_param={"ratio": 9.748},
+            feature_extractor="multilingual-e5-large",
+            feature_extractor_param={"normalize": True},
+        ),
+    },
+    {
+        # ELAS l2 was the multilingual model for version 2 of ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview2_0b4-svm-e5-full-1
@@ -79,7 +121,26 @@ AI_MODEL_CONFIGURATIONS = [
         ),
     },
     {
-        # ELAS h3 is the heavy model for this version ASReview LAB. The model
+        # ELAS h4 is the heavy model for this version ASReview LAB. The model
+        # parameters have been optimized on the SYNERGY dataset. After expert
+        # elicitation, the model and parameters have been chosen.
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        "name": "elas_h4",
+        "label": "ELAS h4",
+        "type": "heavy",
+        "extensions": ["asreview-dory"],
+        "value": ActiveLearningCycleData(
+            querier="max",
+            classifier="svm",
+            classifier_param={"loss": "squared_hinge", "C": 0.0406, "max_iter": 5000},
+            balancer="balanced",
+            balancer_param={"ratio": 9.709},
+            feature_extractor="mxbai",
+            feature_extractor_param={"normalize": True},
+        ),
+    },
+    {
+        # ELAS h3 is the heavy model for version 2 of ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview2_0b4-svm-mxbai-full-1

--- a/asreview/models/models.py
+++ b/asreview/models/models.py
@@ -19,7 +19,7 @@ AI_MODEL_CONFIGURATIONS = [
         # ELAS u5 is the default model for this version ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
-        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_u5",
         "label": "ELAS u5",
         "type": "ultra",
@@ -86,7 +86,7 @@ AI_MODEL_CONFIGURATIONS = [
         # ELAS l3 is the multilingual model for this version ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
-        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_l3",
         "label": "ELAS l3",
         "type": "lang",
@@ -124,7 +124,7 @@ AI_MODEL_CONFIGURATIONS = [
         # ELAS h4 is the heavy model for this version ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
-        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/
+        # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_h4",
         "label": "ELAS h4",
         "type": "heavy",

--- a/asreview/models/models.py
+++ b/asreview/models/models.py
@@ -17,8 +17,8 @@ from asreview.learner import ActiveLearningCycleData
 AI_MODEL_CONFIGURATIONS = [
     {
         # ELAS u5 is the default model for this version ASReview LAB. The model
-        # parameters have been optimized on the SYNERGY dataset. After expert
-        # elicitation, the model and parameters have been chosen.
+        # parameters have been optimized on the SYNERGY+ dataset. After optimization,
+        # hyperparameters were rounded to the nearest values.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_u5",
         "label": "ELAS u5",
@@ -39,7 +39,7 @@ AI_MODEL_CONFIGURATIONS = [
         ),
     },
     {
-        # ELAS u4 is the default model for version 2 of ASReview LAB. The model
+        # ELAS u4 is the default model for versions 2 and 3 of ASReview LAB. The model
         # parameters have been optimized on the SYNERGY dataset. After expert
         # elicitation, the model and parameters have been chosen.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview2_0b4-nb-tfidf-full-1
@@ -84,8 +84,8 @@ AI_MODEL_CONFIGURATIONS = [
     # model is not available in the current version of ASReview LAB.
     {
         # ELAS l3 is the multilingual model for this version ASReview LAB. The model
-        # parameters have been optimized on the SYNERGY dataset. After expert
-        # elicitation, the model and parameters have been chosen.
+        # parameters have been optimized on the SYNERGY+ dataset. After optimization,
+        # hyperparameters were rounded to the nearest values.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_l3",
         "label": "ELAS l3",
@@ -122,8 +122,8 @@ AI_MODEL_CONFIGURATIONS = [
     },
     {
         # ELAS h4 is the heavy model for this version ASReview LAB. The model
-        # parameters have been optimized on the SYNERGY dataset. After expert
-        # elicitation, the model and parameters have been chosen.
+        # parameters have been optimized on the SYNERGY+ dataset. After optimization,
+        # hyperparameters were rounded to the nearest values.
         # Optimization setup: https://github.com/asreview/asreview-optuna/releases/tag/ASReview3-synergy_plus-optimization
         "name": "elas_h4",
         "label": "ELAS h4",

--- a/docs/source/lab/models.rst
+++ b/docs/source/lab/models.rst
@@ -16,7 +16,7 @@ available models and how to select the best one for your use case.
 
 .. tip::
 
-  Not sure where to start? The ELAS u4 model is a great choice for most users.
+  Not sure where to start? The ELAS u5 model is a great choice for most users.
   It's fast, efficient, and performs well across a variety of datasets. It's
   available by default in ASReview LAB.
 
@@ -90,6 +90,11 @@ various versions:
     - Classifier
     - Querier
     - Balancer
+  * - ELAS u5
+    - TF-IDF (with bigrams)
+    - SVM
+    - Maximum
+    - Balanced
   * - ELAS u4
     - TF-IDF (with bigrams)
     - SVM
@@ -105,7 +110,7 @@ various versions:
 
   While the components of ELAS Ultra models may appear similar across versions,
   differences in their underlying parameters can significantly impact their
-  performance and behavior. Use the latest version (e.g., ELAS u4) for the best
+  performance and behavior. Use the latest version (e.g., ELAS u5) for the best
   results.
 
 Use ELAS Ultra if you are looking for a reliable, fast, and easy-to-use model
@@ -150,6 +155,11 @@ its various versions:
     - Classifier
     - Querier
     - Balancer
+  * - ELAS l3
+    - multilingual-e5-large
+    - SVM
+    - Maximum
+    - Balanced
   * - ELAS l2
     - multilingual-e5-large
     - SVM
@@ -198,6 +208,11 @@ various versions:
     - Classifier
     - Querier
     - Balancer
+  * - ELAS h4
+    - mxbai-embed-large-v1
+    - SVM
+    - Maximum
+    - Balanced
   * - ELAS h3
     - mxbai-embed-large-v1
     - SVM

--- a/docs/source/lab/simulation_cli.rst
+++ b/docs/source/lab/simulation_cli.rst
@@ -77,7 +77,7 @@ Active learning
 
 .. option:: --ai AI
 
-    The AI to simulate with. Default is :code:`elas_u4`.
+    The AI to simulate with. Default is :code:`elas_u5`.
 
 .. option:: -c, --classifier CLASSIFIER
 

--- a/tests/test_simulate_cli.py
+++ b/tests/test_simulate_cli.py
@@ -163,7 +163,7 @@ def test_n_stop_min(tmp_project, demo_data_path, tmpdir):
 
     with asr.Project.load(tmp_project, tmpdir).db as db:
         assert db.get_results_table("label")["label"].sum() == 10
-        assert len(db.get_results_table("label")) == 51
+        assert len(db.get_results_table("label")) == 46
 
 
 def test_n_stop_all(tmp_project, tmpdir):


### PR DESCRIPTION
Optimized on the new [SYNERGY+ dataset](https://doi.org/10.34894/DDCVCV), we see slightly lower loss and SD compared to u4, h3, and l2. The new ELAS models were optimized on the train set of SYNERGY+ (91 systematic reviews) and validated and compared with the previous ELAS models on the test set of SYNERGY+ (23 systematic reviews).

<img width="784" height="500" alt="image" src="https://github.com/user-attachments/assets/085a8398-4027-4c9b-a7e2-1df052c12be0" />
