### PR TITLE
Fix Mix Indices Function and Improve Docstrings

### DIFF
--- a/asreview/models/queriers.py
+++ b/asreview/models/queriers.py
@@ -57,6 +57,11 @@ class Random(QueryMixin, BaseEstimator):
     """Random query strategy.
 
     Choose the samples to be included at random.
+
+    Arguments
+    ---------
+    random_state: int, RandomState
+        Random state for shuffling the indices.
     """
 
     name = "random"
@@ -114,6 +119,16 @@ class Uncertainty(QueryMixin, BaseEstimator):
     Choose the most uncertain samples according to the model (i.e. closest to
     0.5 probability). If decision functions are used, the samples closest to
     the decision boundary are chosen (0).
+
+    Arguments
+    ---------
+    u: float
+        The uncertainty threshold for the uncertainty query strategy.
+    proba: bool
+        When u is not given, whether to default the uncertainty reference
+        point to 0.5 (proba=True, for probability-like scores) or 0
+        (proba=False, for decision-function-like scores). Has no effect
+        if u is set explicitly.
 
     """
 
@@ -174,6 +189,22 @@ class HybridMaxUncertainty(QueryMixin, BaseEstimator):
     At each query 95% of the instances would be sampled with the maximum
     query strategy after which the remaining 5% would be sampled with
     the uncertainty query strategy.
+
+    Arguments
+    ---------
+    probability: float
+        The probability of sampling with the maximum query strategy.
+    u: float
+        The uncertainty threshold for the uncertainty query strategy.
+    proba: bool
+        When u is not given, whether to default the uncertainty reference
+        point to 0.5 (proba=True, for probability-like scores) or 0
+        (proba=False, for decision-function-like scores). Has no effect
+        if u is set explicitly.
+    random_state: int, RandomState
+        Controls the random draws used to decide, at each step, whether
+        the next item comes from the Max ranking or the Uncertainty ranking.
+
     """
 
     name = "max_uncertainty"
@@ -207,7 +238,8 @@ class HybridMaxRandom(QueryMixin, BaseEstimator):
     probability: float
         The probability of sampling with the maximum query strategy.
     random_state: int, RandomState
-        Random
+        Controls the random draws used to decide, at each step, whether
+        the next item comes from the Max ranking or the Random ranking.
 
     """
 

--- a/asreview/models/queriers.py
+++ b/asreview/models/queriers.py
@@ -36,12 +36,13 @@ def _random_array(n, random_state=None):
 
 
 def _mix_indices(query_idx_1, query_idx_2, mix_probability=0.95, random_state=None):
+    rng = check_random_state(random_state)
     query_idx_mix = []
     i = 0
     j = 0
 
     while i < len(query_idx_1) and j < len(query_idx_2):
-        if check_random_state(random_state).rand() < mix_probability:
+        if rng.rand() < mix_probability:
             query_idx_mix.append(query_idx_1[i])
             i = i + 1
         else:


### PR DESCRIPTION
This PR fixes a bug where a new rng was created inside a loop with the same integer as its seed, if the querier was constructed with an integer as its random_state (allowed according to the docstring).

Closes #2601  